### PR TITLE
feat: let --blueprint merge a directory of .hcl files

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -1,6 +1,6 @@
 # Blueprint
 
-A blueprint (`blueprint.hcl` by default) is a flat list of `node` and `edge` facts, not nested configuration:
+A blueprint (`blueprint.hcl` by default) is a flat list of `node` and `edge` facts, not nested configuration. `--blueprint` can also point at a directory instead of a single file: every `.hcl` file directly inside it (not recursively) is merged into one blueprint, exactly the way a [group](groups.md)'s source directory already merges its own `.hcl` files. This is useful for splitting a large blueprint across several files (e.g. `nodes.hcl`, `edges.hcl`) without any of them needing a specific name.
 
 ```hcl
 node "vpc" {

--- a/docs/cli/terragraph.md
+++ b/docs/cli/terragraph.md
@@ -5,7 +5,7 @@ Graph-based orchestration for independent Terraform/OpenTofu root modules
 ### Options
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
   -h, --help               help for terragraph
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform

--- a/docs/cli/terragraph_apply.md
+++ b/docs/cli/terragraph_apply.md
@@ -19,7 +19,7 @@ terragraph apply [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -18,7 +18,7 @@ terragraph destroy [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_graph.md
+++ b/docs/cli/terragraph_graph.md
@@ -17,7 +17,7 @@ terragraph graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_plan.md
+++ b/docs/cli/terragraph_plan.md
@@ -17,7 +17,7 @@ terragraph plan [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_validate.md
+++ b/docs/cli/terragraph_validate.md
@@ -16,7 +16,7 @@ terragraph validate [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_vendor.md
+++ b/docs/cli/terragraph_vendor.md
@@ -18,7 +18,7 @@ terragraph vendor [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file (default "blueprint.hcl")
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -77,87 +79,143 @@ var exportOutputSchema = &hcl.BodySchema{
 
 // ParseFile reads and parses a blueprint HCL file at path into a Blueprint. It does not touch any Terraform module, it only extracts graph topology.
 func ParseFile(path string) (*Blueprint, error) {
+	bp := &Blueprint{}
+	seenNodes := map[string]bool{}
+	seenGroups := map[string]bool{}
+	seenUses := map[string]bool{}
+
+	if err := parseOneFile(path, bp, seenNodes, seenGroups, seenUses); err != nil {
+		return nil, err
+	}
+	if err := validateEdges(bp, seenNodes, seenUses); err != nil {
+		return nil, err
+	}
+	return bp, nil
+}
+
+// ParseDir reads and parses every .hcl file directly inside dir (not recursively) and merges them into a single Blueprint, the same way loadGroupDef already treats a group source directory: node/group/use names and the vendor block must be unique across the whole directory, not just within one file, and an edge in one file may reference a node or use instance declared in another. Files are visited in the order os.ReadDir returns them (lexical by name), so a duplicate-name error always names the second file, deterministically.
+func ParseDir(dir string) (*Blueprint, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading blueprint directory: %w", err)
+	}
+
+	bp := &Blueprint{}
+	seenNodes := map[string]bool{}
+	seenGroups := map[string]bool{}
+	seenUses := map[string]bool{}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".hcl") {
+			continue
+		}
+		if err := parseOneFile(filepath.Join(dir, e.Name()), bp, seenNodes, seenGroups, seenUses); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := validateEdges(bp, seenNodes, seenUses); err != nil {
+		return nil, err
+	}
+	return bp, nil
+}
+
+// LoadPath resolves path to a Blueprint and the base directory its node/group sources resolve against. If path names a directory, every .hcl file directly inside it is parsed and merged (see ParseDir) and baseDir is path itself. If path names a file, only that file is parsed (see ParseFile) and baseDir is its parent directory.
+func LoadPath(path string) (*Blueprint, string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving blueprint path: %w", err)
+	}
+	if info.IsDir() {
+		bp, err := ParseDir(path)
+		return bp, path, err
+	}
+	bp, err := ParseFile(path)
+	return bp, filepath.Dir(path), err
+}
+
+// parseOneFile parses one HCL file and merges its node/edge/group/use/vendor blocks into bp, checking name and vendor-block uniqueness against the caller-supplied seen-sets (shared across every file being merged into the same bp). Edge endpoint validation deliberately does not happen here: it happens once, in validateEdges, after every file that will ever contribute to bp has been merged, so an edge in one file may reference a node or use instance declared in another.
+func parseOneFile(path string, bp *Blueprint, seenNodes, seenGroups, seenUses map[string]bool) error {
 	src, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading blueprint file: %w", err)
+		return fmt.Errorf("reading blueprint file: %w", err)
 	}
 
 	parser := hclparse.NewParser()
 	file, diags := parser.ParseHCL(src, path)
 	if diags.HasErrors() {
-		return nil, fmt.Errorf("parsing blueprint file: %s", diags.Error())
+		return fmt.Errorf("parsing blueprint file: %s", diags.Error())
 	}
 
 	content, diags := file.Body.Content(topSchema)
 	if diags.HasErrors() {
-		return nil, fmt.Errorf("reading blueprint file: %s", diags.Error())
+		return fmt.Errorf("reading blueprint file: %s", diags.Error())
 	}
-
-	bp := &Blueprint{}
-	seenNodes := map[string]bool{}
-	seenUses := map[string]bool{}
-	seenGroups := map[string]bool{}
 
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "node":
 			node, err := parseNodeBlock(block)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if seenNodes[node.Name] {
-				return nil, fmt.Errorf("%s: duplicate node %q", block.DefRange, node.Name)
+				return fmt.Errorf("%s: duplicate node %q", block.DefRange, node.Name)
 			}
 			seenNodes[node.Name] = true
 			bp.Nodes = append(bp.Nodes, node)
 		case "edge":
 			edge, err := parseEdgeBlock(block)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			bp.Edges = append(bp.Edges, edge)
 		case "group":
 			group, err := parseGroupBlock(block)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if seenGroups[group.Name] {
-				return nil, fmt.Errorf("%s: duplicate group %q", block.DefRange, group.Name)
+				return fmt.Errorf("%s: duplicate group %q", block.DefRange, group.Name)
 			}
 			seenGroups[group.Name] = true
 			bp.Groups = append(bp.Groups, group)
 		case "use":
 			use, err := parseUseBlock(block)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if seenUses[use.As] {
-				return nil, fmt.Errorf("%s: duplicate use instance name %q", block.DefRange, use.As)
+				return fmt.Errorf("%s: duplicate use instance name %q", block.DefRange, use.As)
 			}
 			seenUses[use.As] = true
 			bp.Uses = append(bp.Uses, use)
 		case "vendor":
 			if bp.Vendor != nil {
-				return nil, fmt.Errorf("%s: duplicate vendor block", block.DefRange)
+				return fmt.Errorf("%s: duplicate vendor block", block.DefRange)
 			}
 			vc, err := parseVendorBlock(block)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			bp.Vendor = vc
 		}
 	}
 
+	return nil
+}
+
+// validateEdges checks every edge's endpoints against the full set of nodes/use instances merged into bp so far. Run once, after all contributing files have been merged, so cross-file references resolve correctly.
+func validateEdges(bp *Blueprint, seenNodes, seenUses map[string]bool) error {
 	for _, edge := range bp.Edges {
 		if err := validateEndpointKnown(edge.From, seenNodes, seenUses); err != nil {
-			return nil, err
+			return err
 		}
 		if err := validateEndpointKnown(edge.To, seenNodes, seenUses); err != nil {
-			return nil, err
+			return err
 		}
 	}
-
-	return bp, nil
+	return nil
 }
 
 // validateEndpointKnown checks that a PortRef's referenced entity was actually declared in the same scope: a node reference against declared nodes, a use reference against declared use instances.

--- a/internal/blueprint/parse_dir_test.go
+++ b/internal/blueprint/parse_dir_test.go
@@ -1,0 +1,147 @@
+package blueprint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeDirTemp writes files (keyed by filename relative to a fresh temp dir) and returns the temp dir's root.
+func writeDirTemp(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, contents := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	return dir
+}
+
+func TestParseDir_MergesMultipleFilesAndCrossFileEdge(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"nodes.hcl": `
+node "vpc" { source = "./stacks/vpc" }
+node "eks" { source = "./stacks/eks" }
+`,
+		"edges.hcl": `
+edge {
+  from = node.vpc.output.vpc_id
+  to   = node.eks.input.vpc_id
+}
+`,
+	})
+
+	bp, err := ParseDir(dir)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(bp.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(bp.Nodes))
+	}
+	if len(bp.Edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(bp.Edges))
+	}
+	e := bp.Edges[0]
+	if e.From.Node != "vpc" || e.To.Node != "eks" {
+		t.Fatalf("unexpected edge: %+v", e)
+	}
+}
+
+func TestParseDir_DuplicateNodeAcrossFiles(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"a.hcl": `node "x" { source = "./a" }`,
+		"b.hcl": `node "x" { source = "./b" }`,
+	})
+
+	if _, err := ParseDir(dir); err == nil {
+		t.Fatalf("expected an error for a node name duplicated across files")
+	}
+}
+
+func TestParseDir_DuplicateGroupAcrossFiles(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"a.hcl": `group "g" { node "a" { source = "./a" } }`,
+		"b.hcl": `group "g" { node "b" { source = "./b" } }`,
+	})
+
+	if _, err := ParseDir(dir); err == nil {
+		t.Fatalf("expected an error for a group name duplicated across files")
+	}
+}
+
+func TestParseDir_DuplicateVendorBlockAcrossFiles(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"a.hcl": `vendor { directory = "vendor_a" }`,
+		"b.hcl": `vendor { directory = "vendor_b" }`,
+	})
+
+	if _, err := ParseDir(dir); err == nil {
+		t.Fatalf("expected an error for a vendor block duplicated across files")
+	}
+}
+
+func TestParseDir_IgnoresNonHCLFilesAndSubdirectories(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"nodes.hcl":        `node "a" { source = "./a" }`,
+		"README.md":        "not hcl",
+		"nested/other.hcl": `node "b" { source = "./b" }`,
+		"terragraph.notes": "also not hcl",
+	})
+
+	bp, err := ParseDir(dir)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(bp.Nodes) != 1 || bp.Nodes[0].Name != "a" {
+		t.Fatalf("expected only the top-level node from nodes.hcl, got %+v", bp.Nodes)
+	}
+}
+
+func TestParseDir_EmptyDirectoryIsEmptyBlueprint(t *testing.T) {
+	dir := t.TempDir()
+
+	bp, err := ParseDir(dir)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(bp.Nodes) != 0 || len(bp.Edges) != 0 || len(bp.Groups) != 0 || len(bp.Uses) != 0 {
+		t.Fatalf("expected an empty Blueprint, got %+v", bp)
+	}
+}
+
+func TestLoadPath_File(t *testing.T) {
+	path := writeTemp(t, `node "a" { source = "./a" }`)
+
+	bp, baseDir, err := LoadPath(path)
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if len(bp.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(bp.Nodes))
+	}
+	if want := filepath.Dir(path); baseDir != want {
+		t.Fatalf("baseDir = %q, want %q", baseDir, want)
+	}
+}
+
+func TestLoadPath_Directory(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		"nodes.hcl": `node "a" { source = "./a" }`,
+	})
+
+	bp, baseDir, err := LoadPath(dir)
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if len(bp.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(bp.Nodes))
+	}
+	if baseDir != dir {
+		t.Fatalf("baseDir = %q, want %q", baseDir, dir)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,7 +48,7 @@ func NewRootCmd(version string) *cobra.Command {
 			return nil
 		},
 	}
-	root.PersistentFlags().StringVar(&blueprintPath, "blueprint", "blueprint.hcl", "path to the blueprint file")
+	root.PersistentFlags().StringVar(&blueprintPath, "blueprint", "blueprint.hcl", "path to the blueprint file, or a directory whose .hcl files are merged into one blueprint")
 	root.PersistentFlags().BoolVar(&useTofu, "tofu", false, "use the tofu binary instead of terraform")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "log verbosity for internal diagnostics on stderr: debug, info, warn, or error")
 
@@ -279,11 +279,11 @@ func newVendorCmd(blueprintPath *string, loggerOf func() *slog.Logger) *cobra.Co
 			logger := loggerOf()
 
 			// Parsed directly, not via engine.Load: building the full graph would fail for any not-yet-vendored remote node, but vendoring has to work *before* the graph is buildable.
-			bp, err := blueprint.ParseFile(*blueprintPath)
+			bp, dir, err := blueprint.LoadPath(*blueprintPath)
 			if err != nil {
 				return err
 			}
-			baseDir, err := filepath.Abs(filepath.Dir(*blueprintPath))
+			baseDir, err := filepath.Abs(dir)
 			if err != nil {
 				return fmt.Errorf("resolving blueprint directory: %w", err)
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -17,6 +19,52 @@ func runCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	root.SetArgs(append([]string{"--blueprint", "../../examples/group/blueprint.hcl"}, args...))
 	err = root.Execute()
 	return outBuf.String(), errBuf.String(), err
+}
+
+// writeFixtureFile writes contents to path, creating any parent directories needed.
+func writeFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// TestGraph_BlueprintFlagAcceptsDirectory proves --blueprint may name a directory: every .hcl file directly inside it (nodes.hcl, edges.hcl below) is merged into one blueprint, the same way a group source directory already merges its own .hcl files.
+func TestGraph_BlueprintFlagAcceptsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "nodes.hcl"), `
+node "a" { source = "./stacks/a" }
+node "b" { source = "./stacks/b" }
+`)
+	writeFixtureFile(t, filepath.Join(dir, "edges.hcl"), `
+edge {
+  from = node.a.output.x
+  to   = node.b.input.x
+}
+`)
+	writeFixtureFile(t, filepath.Join(dir, "stacks/a/outputs.tf"), `
+output "x" { value = "hi" }
+`)
+	writeFixtureFile(t, filepath.Join(dir, "stacks/b/variables.tf"), `
+variable "x" { type = string }
+`)
+
+	root := NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"--blueprint", dir, "graph"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("graph: %v (stderr: %s)", err, errBuf.String())
+	}
+
+	want := "level 1: a\nlevel 2: b\n"
+	if outBuf.String() != want {
+		t.Fatalf("stdout = %q, want %q", outBuf.String(), want)
+	}
 }
 
 func TestGraph_DefaultText_MatchesExampleOutput(t *testing.T) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -31,15 +31,15 @@ func (e *Engine) logger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
-// Load parses the blueprint at blueprintPath and builds its graph. Node sources are resolved relative to the blueprint file's directory.
+// Load parses the blueprint at blueprintPath and builds its graph. blueprintPath may name a single file or a directory (every .hcl file directly inside it is merged, see blueprint.LoadPath); node sources are resolved relative to the resulting base directory.
 func Load(blueprintPath string, binary exec.Binary, stdout, stderr io.Writer) (*Engine, error) {
-	bp, err := blueprint.ParseFile(blueprintPath)
+	bp, dir, err := blueprint.LoadPath(blueprintPath)
 	if err != nil {
 		return nil, err
 	}
 
 	// Absolute, so paths derived from it (DataDir in particular) are unambiguous no matter what working directory a terraform/tofu subprocess runs with. A relative TF_DATA_DIR would otherwise be resolved relative to the subprocess's own cwd (the node's source dir), not this process's, producing a nested, wrong path.
-	baseDir, err := filepath.Abs(filepath.Dir(blueprintPath))
+	baseDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving blueprint directory: %w", err)
 	}

--- a/internal/graph/build.go
+++ b/internal/graph/build.go
@@ -27,6 +27,25 @@ type Graph struct {
 	In    map[string][]string
 }
 
+// cloneNode returns a value copy of n with its BackendConfig/Vars maps deep-copied. n.Nodes for a group instantiation come from a group definition that resolveContext.parseGroupDir may hand back to more than one `use` site (see loadGroupDef); without this, every instance of the same group would share the exact same underlying BackendConfig/Vars map objects, since a plain struct copy only copies the map header, not its contents.
+func cloneNode(n blueprint.Node) blueprint.Node {
+	if n.BackendConfig != nil {
+		clone := make(map[string]string, len(n.BackendConfig))
+		for k, v := range n.BackendConfig {
+			clone[k] = v
+		}
+		n.BackendConfig = clone
+	}
+	if n.Vars != nil {
+		clone := make(map[string]any, len(n.Vars))
+		for k, v := range n.Vars {
+			clone[k] = v
+		}
+		n.Vars = clone
+	}
+	return n
+}
+
 // Build resolves a blueprint into a Graph, recursively expanding any group instantiations (`use` blocks). baseDir is the directory the blueprint file lives in and must be absolute: it becomes the root every relative node/group source resolves against, directly or (for a node inside a group) transitively. Build fails fast if a node's source directory cannot be inspected (e.g. it doesn't exist); that is a structural problem, not something validate can usefully report alongside others.
 func Build(bp *blueprint.Blueprint, baseDir string) (*Graph, error) {
 	g, _, err := build(bp, baseDir, "", &resolveContext{})
@@ -59,11 +78,11 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, rc *resolveContex
 				)
 			}
 		}
-		schema, err := module.Inspect(dir)
+		schema, err := rc.inspect(dir)
 		if err != nil {
 			return nil, nil, fmt.Errorf("node %q: %w", n.Name, err)
 		}
-		qn := n
+		qn := cloneNode(n)
 		qn.Name = qualify(n.Name)
 		g.Nodes[qn.Name] = &Node{Node: qn, Schema: schema, Dir: dir}
 	}
@@ -111,7 +130,7 @@ func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, rc *reso
 	}
 	defer pop()
 
-	def, err := loadGroupDef(groupDir, u.GroupName)
+	def, err := loadGroupDef(rc, groupDir, u.GroupName)
 	if err != nil {
 		return useInfo{}, nil, err
 	}

--- a/internal/graph/group.go
+++ b/internal/graph/group.go
@@ -2,17 +2,17 @@ package graph
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
 	"github.com/cloudfluent/terragraph/internal/module"
 )
 
-// resolveContext tracks in-progress group resolutions (by absolute source directory + group name) to catch group self-reference cycles: a group that, directly or transitively, uses itself.
+// resolveContext tracks state for one Build() call: in-progress group resolutions (by absolute source directory + group name), to catch group self-reference cycles, plus per-directory caches so a group source directory or a node's module directory is only ever read and parsed once no matter how many times it's referenced (multiple `use` instances of the same group, or multiple nodes sharing one `source` via backend_config). Both caches are safe uncontended: Build runs entirely single-threaded, and every goroutine terragraph ever spawns (see engine.runLevels) starts only after the graph it walks has already been fully built.
 type resolveContext struct {
-	stack []string
+	stack     []string
+	groupDirs map[string]*blueprint.Blueprint
+	schemas   map[string]*module.Schema
 }
 
 func (rc *resolveContext) push(dir, name string) (func(), error) {
@@ -26,26 +26,47 @@ func (rc *resolveContext) push(dir, name string) (func(), error) {
 	return func() { rc.stack = rc.stack[:len(rc.stack)-1] }, nil
 }
 
-// loadGroupDef parses the .hcl files directly inside dir (not recursively; group source directories aren't tree-scanned) and returns the group definition named groupName.
-func loadGroupDef(dir, groupName string) (*blueprint.Group, error) {
-	entries, err := os.ReadDir(dir)
+// parseGroupDir returns dir merged as a Blueprint (every .hcl file directly inside it, see blueprint.ParseDir), parsing it at most once per Build() call regardless of how many `use` blocks reference dir.
+func (rc *resolveContext) parseGroupDir(dir string) (*blueprint.Blueprint, error) {
+	if bp, ok := rc.groupDirs[dir]; ok {
+		return bp, nil
+	}
+	bp, err := blueprint.ParseDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	if rc.groupDirs == nil {
+		rc.groupDirs = map[string]*blueprint.Blueprint{}
+	}
+	rc.groupDirs[dir] = bp
+	return bp, nil
+}
+
+// inspect returns dir's module schema (see module.Inspect), inspecting it at most once per Build() call regardless of how many nodes share dir as their source (the backend_config pattern docs/blueprint.md documents for reusing one module across instances).
+func (rc *resolveContext) inspect(dir string) (*module.Schema, error) {
+	if s, ok := rc.schemas[dir]; ok {
+		return s, nil
+	}
+	s, err := module.Inspect(dir)
+	if err != nil {
+		return nil, err
+	}
+	if rc.schemas == nil {
+		rc.schemas = map[string]*module.Schema{}
+	}
+	rc.schemas[dir] = s
+	return s, nil
+}
+
+// loadGroupDef returns the group definition named groupName from dir, a group source directory (see resolveContext.parseGroupDir for how dir's .hcl files are merged and cached).
+func loadGroupDef(rc *resolveContext, dir, groupName string) (*blueprint.Group, error) {
+	bp, err := rc.parseGroupDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("reading group source directory %s: %w", dir, err)
 	}
-
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".hcl") {
-			continue
-		}
-		path := filepath.Join(dir, e.Name())
-		bp, err := blueprint.ParseFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("parsing %s: %w", path, err)
-		}
-		for i := range bp.Groups {
-			if bp.Groups[i].Name == groupName {
-				return &bp.Groups[i], nil
-			}
+	for i := range bp.Groups {
+		if bp.Groups[i].Name == groupName {
+			return &bp.Groups[i], nil
 		}
 	}
 	return nil, fmt.Errorf("no group named %q found in %s", groupName, dir)

--- a/internal/graph/group_build_test.go
+++ b/internal/graph/group_build_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
 )
 
 func writeFixtureFile(t *testing.T, path, content string) {
@@ -73,4 +75,79 @@ edge {
 `)
 
 	return root, filepath.Join(root, "blueprint.hcl")
+}
+
+// setupSameGroupTwiceFixture builds, under a temp dir, a group instantiated twice from the same source directory:
+//
+//	modules/a:           variable "greeting" (default ""), output "echo"
+//	groups/g/group.hcl:  group "g": node a { vars = { greeting = "hi" } }
+//	blueprint.hcl:       use "g" as "first"; use "g" as "second" (same source)
+//
+// returning the root dir and the path to blueprint.hcl. Exercises resolveContext.parseGroupDir's cache: both `use` blocks resolve the same group source directory.
+func setupSameGroupTwiceFixture(t *testing.T) (root, blueprintPath string) {
+	t.Helper()
+	root = t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "greeting" {
+  type    = string
+  default = ""
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/outputs.tf"), `
+output "echo" { value = var.greeting }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" {
+    source = "../../modules/a"
+    vars   = { greeting = "hi" }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "first"
+  source = "./groups/g"
+}
+
+use "g" {
+  as     = "second"
+  source = "./groups/g"
+}
+`)
+
+	return root, filepath.Join(root, "blueprint.hcl")
+}
+
+// TestBuild_SameGroupDirectoryUsedTwice_InstancesDontShareState proves the resolveContext.parseGroupDir cache (both `use` blocks below resolve the exact same group source directory) doesn't let two instances of the same group alias each other's Vars/BackendConfig maps: see cloneNode in build.go.
+func TestBuild_SameGroupDirectoryUsedTwice_InstancesDontShareState(t *testing.T) {
+	root, bpPath := setupSameGroupTwiceFixture(t)
+
+	bp, err := blueprint.ParseFile(bpPath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	first, ok := g.Nodes["first.a"]
+	if !ok {
+		t.Fatalf("expected node %q, got nodes: %v", "first.a", nodeNames(g))
+	}
+	second, ok := g.Nodes["second.a"]
+	if !ok {
+		t.Fatalf("expected node %q, got nodes: %v", "second.a", nodeNames(g))
+	}
+
+	if first.Vars["greeting"] != "hi" || second.Vars["greeting"] != "hi" {
+		t.Fatalf("expected both instances to resolve vars.greeting = %q, got %+v / %+v", "hi", first.Vars, second.Vars)
+	}
+
+	first.Vars["greeting"] = "mutated"
+	if second.Vars["greeting"] != "hi" {
+		t.Fatalf("mutating the first instance's Vars affected the second instance's Vars: %+v", second.Vars)
+	}
 }


### PR DESCRIPTION
## Summary
- `--blueprint` (default `blueprint.hcl`) now also accepts a directory: every `.hcl` file directly inside it is merged into one blueprint, the same way a group source directory already merges its own `.hcl` files (`blueprint.ParseDir`/`LoadPath`).
- Fixes two existing perf issues found along the way: `loadGroupDef` re-read and re-parsed a group's whole source directory on every `use` of that group, and `module.Inspect` re-parsed a module's `.tf` files for every node sharing a `source` via `backend_config`. Both are now cached per absolute directory on `resolveContext`, scoped to one `Build()` call.
- Closes a resulting aliasing gap: multiple `use` instances of the same group would otherwise share the same underlying `BackendConfig`/`Vars` map objects; `cloneNode` deep-copies them per instance.
- Also fixes a latent gap merging surfaced: two files in one group/blueprint directory declaring the same group name used to silently keep only the first; now it's a duplicate-name error.

## Test plan
- [x] `make check` (fmt-check, lint, docs-check, build, `go test ./... -race`) passes locally
- [x] New tests: `ParseDir`/`LoadPath` cases (blueprint package), same-group-used-twice cache/aliasing test in graph package (verified it actually fails without the `cloneNode` fix), `--blueprint <dir>` CLI case
- [x] Manual smoke test: built binary, ran `graph`/`validate` against a directory blueprint split across `nodes.hcl`/`edges.hcl`
- [x] Manual smoke test: same group directory `use`d twice under different instance names, both resolve correctly