### PR TITLE
ci: make VS Code extension publishing idempotent and re-runnable

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -11,6 +11,13 @@ on:
       VSCE_PAT:
         description: Visual Studio Marketplace publishing token.
         required: true
+  # Lets a maintainer re-run publishing for a tag whose release already exists, without cutting another one: the Marketplace goes down often enough that a release can end up with only some of its six platform packages published. Everything below is idempotent, so a re-run finishes whatever the first attempt left behind.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to publish, including the v prefix (e.g. v0.1.5).
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -118,16 +125,47 @@ jobs:
           path: dist/vsix
           merge-multiple: true
 
+      # Every package is attempted, and a package the Marketplace already has is treated as done, so one target failing never strands the rest and a re-run of this workflow only publishes what is actually missing. A 5xx from the Marketplace is retried with a growing delay: it is routinely unavailable for a minute or two at a time, which is not a reason to leave a release half-published.
       - name: Publish platform-specific packages to Marketplace
         working-directory: editors/vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          for vsix in $(find ../../dist/vsix -name '*.vsix' -print | sort); do
-            npx --no-install vsce publish --packagePath "$vsix"
-          done
+          publish() {
+            local vsix="$1" name attempt output delay
+            name=$(basename "$vsix")
+            for attempt in 1 2 3 4 5; do
+              if output=$(npx --no-install vsce publish --packagePath "$vsix" 2>&1); then
+                printf '%s\n' "$output"
+                return 0
+              fi
+              printf '%s\n' "$output"
+              if grep -qiE 'already exists' <<<"$output"; then
+                echo "::notice::$name is already published at this version; nothing to do."
+                return 0
+              fi
+              if ! grep -qiE 'Service Unavailable|HTTP Error 5[0-9][0-9]|Internal Server Error|Bad Gateway|ETIMEDOUT|ECONNRESET|EAI_AGAIN|socket hang up' <<<"$output"; then
+                return 1
+              fi
+              delay=$((attempt * 30))
+              echo "::warning::Marketplace was unavailable while publishing $name (attempt $attempt of 5); retrying in ${delay}s."
+              sleep "$delay"
+            done
+            return 1
+          }
 
+          failed=()
+          for vsix in $(find ../../dist/vsix -name '*.vsix' -print | sort); do
+            publish "$vsix" || failed+=("$(basename "$vsix")")
+          done
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::Could not publish: ${failed[*]}. Re-run this workflow for the same tag once the Marketplace is back; packages already published are skipped."
+            exit 1
+          fi
+
+      # Runs even when publishing failed: the release assets are the fallback way to install the extension, so they are exactly what a Marketplace outage should not take with it.
       - name: Attach VSIX packages to GitHub Release
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.tag_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ A PR needs: the PR-title check, all CI checks (`fmt, lint, docs, build, test` pl
 
 You never pick a version number. [release-please](https://github.com/googleapis/release-please) watches `main`, and every `feat`/`fix`/breaking-change PR title merged there updates a standing "chore: release vX.Y.Z" pull request with the next [SemVer](https://semver.org) bump and changelog entry. A maintainer merges that PR when it's time to cut a release; that merge tags the release, and GoReleaser builds and attaches the Linux/macOS/Windows binaries automatically (`.github/workflows/release-please.yml`, `.goreleaser.yaml`). Nothing else to do on your end.
 
+The same tag also publishes the VS Code extension's six platform packages to the Marketplace (`.github/workflows/publish-vscode.yml`). The Marketplace is unreliable enough that this sometimes gets partway through; when it does, run that workflow manually from the Actions tab with the same tag. It skips whatever is already published and only retries what's missing, so a re-run is always safe. The VSIX files are attached to the GitHub Release either way.
+
 ## Code of Conduct
 
 This project follows the [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Why

Publishing v0.1.5 to the Marketplace ([run](https://github.com/cloudfluent/terragraph/actions/runs/33621219912)) got two of the six platform packages up and then hit `HTTP Error 503. The service is unavailable.` on the third. Three things went wrong at once:

- The loop runs under `bash -e`, so the first failure abandoned the remaining packages.
- "Attach VSIX packages to GitHub Release" never ran, so the release had no VSIX assets even though all six had been built.
- Re-running was not an option: the loop starts at the first package, which the Marketplace now already has, so it would fail immediately with `already exists`.

The token was fine — the Marketplace was simply down for a minute. That should not be able to strand a release.

## What

- **Per-package publishing.** A package the Marketplace already has at this version counts as done (`already exists` → skip). A 5xx / connection error is retried 5 times with a growing delay (30s, 60s, …). Anything else fails that package immediately without burning retries — an expired PAT should not take four minutes to report.
- **Every package is attempted**, and the step fails at the end listing what is missing, so one bad target no longer hides the others.
- **The release upload no longer depends on the Marketplace** (`if: !cancelled()`): those assets are the fallback way to install the extension, so an outage is exactly when they matter.
- **`workflow_dispatch` with a tag input**, so a maintainer can finish a partly-published release from the Actions tab without cutting another one. Safe by construction now that each package is idempotent.

Together: a re-run publishes exactly what is missing and nothing else.

## Test plan

- YAML parses; both triggers present.
- The publish script was run locally against a stubbed `vsce` covering all four paths — success, `already exists`, a 503 that clears on the third attempt, and a hard 401:

```
Published cloudfluent.terragraph-vscode (darwin-arm64) v0.1.5.
::notice::b-exists.vsix is already published at this version; nothing to do.
::warning::Marketplace was unavailable while publishing c-flaky.vsix (attempt 1 of 5); retrying in 30s.
::warning::Marketplace was unavailable while publishing c-flaky.vsix (attempt 2 of 5); retrying in 60s.
Published (win32-x64) v0.1.5.
ERROR  Failed Request: Unauthorized(401)
::error::Could not publish: d-auth.vsix. Re-run this workflow for the same tag once the Marketplace is back; packages already published are skipped.
EXIT=1
```

The real check is the first dispatch run against `v0.1.5`, which still needs its four remaining targets (`linux-arm64`, `linux-x64`, `win32-arm64`, `win32-x64`) once the Marketplace is back.