### PR TITLE
fix: let destroy be approved too, instead of failing at its own prompt

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -128,6 +128,8 @@ It asks about the plan you were just shown, and applies exactly that plan — a 
 - Input may be piped (`echo yes | terragraph apply`). If a node needs approving and there is nothing to read — a CI runner, `</dev/null` — the run stops and says to pass `--auto-approve`, rather than reporting a refusal nobody made.
 - `--parallelism N` (N > 1) requires `--auto-approve`: output from concurrent nodes is buffered and flushed a node at a time, so there is nowhere to put a prompt.
 
+`terragraph destroy` is confirmed the same way, except the question comes from Terraform itself: there is no saved plan for terragraph to ask about on its behalf.
+
 ### There is no local cache
 
 Earlier versions kept a content-addressed cache at `<blueprint dir>/.terragraph/cache.json`, hashing each node's source files, resolved inputs, runtime and `env` to decide whether it could skip apply. Hashing local files is a proxy for a remote fact, and the gap between the two produced a series of bugs: a backend or inherited `env` change that the key never modelled, remote drift that no local hash could see, and files consumed through `file()`/`templatefile()` that never invalidated anything.

--- a/internal/engine/apply.go
+++ b/internal/engine/apply.go
@@ -15,6 +15,11 @@ import (
 //
 // When the plan does report changes, that plan is what gets applied (see Runner.PlanChanges/ApplyPlan), so a node refreshes once and the change made is the change that was planned.
 func (e *Engine) Apply(opts Options) error {
+	// Concurrent nodes have their output buffered and flushed a node at a time (see runLevels), so a prompt written mid-level would be invisible until long after the answer was needed. Rather than deadlock on that, say so — before taking the run lock, so a combination that cannot run fails immediately instead of first waiting on whatever else holds it.
+	if !opts.AutoApprove && opts.parallelism() > 1 {
+		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
+	}
+
 	unlock, err := e.lockRun()
 	if err != nil {
 		return err
@@ -22,11 +27,6 @@ func (e *Engine) Apply(opts Options) error {
 	defer unlock()
 
 	e.logger().Info("apply starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
-
-	// Concurrent nodes have their output buffered and flushed a node at a time (see runLevels), so a prompt written mid-level would be invisible until long after the answer was needed. Rather than deadlock on that, say so.
-	if !opts.AutoApprove && opts.parallelism() > 1 {
-		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
-	}
 
 	return e.runLevels(opts, false, func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, error) {
 		vars, err := e.resolveInputs(name, applied)

--- a/internal/engine/apply_unix_test.go
+++ b/internal/engine/apply_unix_test.go
@@ -80,6 +80,10 @@ case "$1" in
     ;;
   destroy)
     printf 'destroy\n' >> "$TG_COMMAND_LOG"
+    # Nothing to tear down: terraform reports no changes and never asks.
+    if [ -n "${TG_DESTROY_NOOP:-}" ]; then
+      exit 0
+    fi
     # Mirrors the real CLI: -input=false does not suppress the confirmation, so without -auto-approve an answer has to arrive on stdin.
     case "$*" in
       *-auto-approve*) rm -f managed.out; exit 0 ;;

--- a/internal/engine/apply_unix_test.go
+++ b/internal/engine/apply_unix_test.go
@@ -78,6 +78,18 @@ case "$1" in
     esac
     exit 0
     ;;
+  destroy)
+    printf 'destroy\n' >> "$TG_COMMAND_LOG"
+    # Mirrors the real CLI: -input=false does not suppress the confirmation, so without -auto-approve an answer has to arrive on stdin.
+    case "$*" in
+      *-auto-approve*) rm -f managed.out; exit 0 ;;
+    esac
+    read -r answer || exit 1
+    case "$answer" in
+      yes|y) rm -f managed.out; exit 0 ;;
+      *) exit 1 ;;
+    esac
+    ;;
   show)
     # show -json <plan file>: report what that plan does. TG_PLAN_ACTIONS names the actions, so a test can plan a destroy or a replace without a real provider.
     printf '{"resource_changes":[{"address":"fake.managed","change":{"actions":[%s]}}]}' "${TG_PLAN_ACTIONS:-\"create\"}"

--- a/internal/engine/approve_unix_test.go
+++ b/internal/engine/approve_unix_test.go
@@ -151,3 +151,27 @@ func TestApply_PrintsAPerNodeChangeSummary(t *testing.T) {
 		t.Fatalf("expected %q in output, got:\n%s", want, out.String())
 	}
 }
+
+// destroy has no saved plan for terragraph to ask about, so terraform's own confirmation is the approval — which needs a stdin to read from, the same defect apply had.
+func TestDestroy_WithoutAutoApproveReadsApprovalFromStdin(t *testing.T) {
+	e, _, _ := loadApplyTestEngine(t)
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	e.Stdin = strings.NewReader("yes\n")
+	if err := e.Destroy(Options{}); err != nil {
+		t.Fatalf("Destroy without auto-approve: %v", err)
+	}
+}
+
+func TestDestroy_ParallelismRequiresAutoApprove(t *testing.T) {
+	e, _, _ := loadApplyTestEngine(t)
+	err := e.Destroy(Options{Parallelism: 2})
+	if err == nil {
+		t.Fatal("expected --parallelism without --auto-approve to be refused")
+	}
+	if !strings.Contains(err.Error(), "--auto-approve") {
+		t.Fatalf("expected the error to name --auto-approve, got: %v", err)
+	}
+}

--- a/internal/engine/approve_unix_test.go
+++ b/internal/engine/approve_unix_test.go
@@ -175,3 +175,57 @@ func TestDestroy_ParallelismRequiresAutoApprove(t *testing.T) {
 		t.Fatalf("expected the error to name --auto-approve, got: %v", err)
 	}
 }
+
+// Destroy cannot tell in advance whether it is about to ask a question, so a node that fails with no input available says why, rather than leaving terraform's bare "error asking for approval: EOF" as the whole explanation.
+func TestDestroy_WithoutAutoApproveAndNoInputExplainsItself(t *testing.T) {
+	e, _, _ := loadApplyTestEngine(t)
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// A reader that yields nothing, not a nil one: this is what a CLI run redirected from /dev/null actually looks like, and testing for nil would miss it.
+	e.Stdin = strings.NewReader("")
+	err := e.Destroy(Options{})
+	if err == nil {
+		t.Fatal("expected destroy to fail when it cannot read approval")
+	}
+	if !strings.Contains(err.Error(), "--auto-approve") {
+		t.Fatalf("expected the error to name --auto-approve, got: %v", err)
+	}
+}
+
+// A refusal is a decision someone made, so it must not be dressed up as missing input.
+func TestDestroy_DeclinedApprovalIsNotReportedAsMissingInput(t *testing.T) {
+	e, _, _ := loadApplyTestEngine(t)
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	e.Stdin = strings.NewReader("no\n")
+	err := e.Destroy(Options{})
+	if err == nil {
+		t.Fatal("expected a declined destroy to fail")
+	}
+	if strings.Contains(err.Error(), "nothing was available") {
+		t.Fatalf("a declined destroy should not be reported as missing input, got: %v", err)
+	}
+}
+
+// An unattended destroy with nothing left to tear down still succeeds: terraform never asks, so there is no approval to be missing.
+func TestDestroy_NoOpNeedsNoApproval(t *testing.T) {
+	e, _, _ := loadApplyTestEngine(t)
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	e.Stdin = strings.NewReader("yes\n")
+	if err := e.Destroy(Options{}); err != nil {
+		t.Fatalf("first Destroy: %v", err)
+	}
+
+	// Nothing left; the fake reports no-op without prompting, exactly as terraform does.
+	t.Setenv("TG_DESTROY_NOOP", "1")
+	e.Stdin = nil
+	if err := e.Destroy(Options{}); err != nil {
+		t.Fatalf("expected a no-op destroy to need no approval: %v", err)
+	}
+}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -11,13 +11,18 @@ import (
 //
 // Nothing has to be invalidated afterwards. Destroy once had to drop the incremental-apply cache entry for everything it tore down, because a stale "unchanged" hit against infrastructure that no longer exists would have been a correctness bug rather than a missed optimization; a later apply now asks Terraform, which plans against real state and sees the resources are gone.
 func (e *Engine) Destroy(opts Options) error {
+	// Same reason Apply refuses it: concurrent nodes have their output buffered and flushed a node at a time, so terraform's confirmation prompt would be invisible until long after the answer was needed. Checked before taking the run lock, so an unrunnable combination fails immediately instead of after waiting for whatever else holds it.
+	if !opts.AutoApprove && opts.parallelism() > 1 {
+		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
+	}
+
 	unlock, err := e.lockRun()
 	if err != nil {
 		return err
 	}
 	defer unlock()
 
-	e.logger().Info("destroy starting", "node", opts.Node, "parallelism", opts.parallelism())
+	e.logger().Info("destroy starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
 
 	return e.runLevels(opts, true, func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, error) {
 		// A destroy plan needs the same resolved input values an apply would have used (e.g. a variable feeding a resource's count or for_each), so it's evaluated identically here: every upstream dependency is still standing at this point, since destroy walks the graph in reverse topological order (downstream first).
@@ -31,6 +36,10 @@ func (e *Engine) Destroy(opts Options) error {
 		}
 
 		r := &exec.Runner{Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
+		// Unlike apply, there is no saved plan here for terragraph to ask about itself, so terraform's own confirmation is the approval — and it needs somewhere to read the answer from. Left nil when auto-approving, so an unattended run can never block on a question.
+		if !opts.AutoApprove {
+			r.Stdin = e.Stdin
+		}
 		if err := r.Destroy(opts.AutoApprove, exec.VarFileArgs(varsPath, vars)...); err != nil {
 			return nil, fmt.Errorf("destroy: %w", err)
 		}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -37,12 +37,32 @@ func (e *Engine) Destroy(opts Options) error {
 
 		r := &exec.Runner{Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		// Unlike apply, there is no saved plan here for terragraph to ask about itself, so terraform's own confirmation is the approval — and it needs somewhere to read the answer from. Left nil when auto-approving, so an unattended run can never block on a question.
-		if !opts.AutoApprove {
-			r.Stdin = e.Stdin
+		var answered *countingReader
+		if !opts.AutoApprove && e.Stdin != nil {
+			answered = &countingReader{r: e.Stdin}
+			r.Stdin = answered
 		}
 		if err := r.Destroy(opts.AutoApprove, exec.VarFileArgs(varsPath, vars)...); err != nil {
+			// Apply knows in advance whether a node has changes, because it plans first, so it can refuse with noApprovalError before running anything. Destroy has no such plan and cannot tell an unattended no-op (which succeeds, and should) from one about to ask a question nobody can answer. So the hint is attached to the failure rather than predicted.
+			//
+			// "Was there an answer to be had?" is not the same question as "is Stdin nil?": a CLI run always has one (cmd.InOrStdin()), and redirecting from /dev/null still produces a perfectly good reader that yields nothing. What separates the two is whether terraform got any bytes out of it, which is why this counts them rather than testing for nil.
+			if !opts.AutoApprove && (answered == nil || answered.n == 0) {
+				return nil, fmt.Errorf("destroy: %w (nothing was available to read approval from; pass --auto-approve to destroy without asking)", err)
+			}
 			return nil, fmt.Errorf("destroy: %w", err)
 		}
 		return nil, nil
 	}, nil)
+}
+
+// countingReader records whether anything was ever read from it, so a failed destroy can tell "nobody answered" from "the answer was rejected". Only ever handed to one subprocess at a time (destroy prompts require --parallelism 1), so it needs no locking.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
 }

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -199,15 +199,6 @@ func (r *Runner) SupportsSavedPlan() bool {
 	}
 }
 
-func (r *Runner) Apply(autoApprove bool, extraArgs ...string) error {
-	args := []string{"apply", "-input=false"}
-	if autoApprove {
-		args = append(args, "-auto-approve")
-	}
-	args = append(args, extraArgs...)
-	return r.run(args...)
-}
-
 func (r *Runner) Destroy(autoApprove bool, extraArgs ...string) error {
 	args := []string{"destroy", "-input=false"}
 	if autoApprove {


### PR DESCRIPTION
Follow-up to #30, which fixed approval for `apply` and left the same bug in `destroy`.

The defect was in the shared `Runner`, not in `apply`: `Runner.run` never set `cmd.Stdin`, so `os/exec` handed every subprocess the null device. #30 fixed the apply path by having terragraph ask about its saved plan directly, but `destroy` still went straight to terraform's own confirmation with nothing to read an answer from.

On `main` today:

```
$ echo yes | terragraph destroy
  Enter a value:
  Error: error asking for approval: EOF
error: node "one": destroy: exit status 1
```

The answer is right there on stdin and cannot be reached. `--auto-approve` works, which is why this survived #30 — the same reason nobody had hit the apply version.

## Fix

`destroy` has no saved plan for terragraph to ask about on terraform's behalf — there is no `terraform destroy -out` — so this wires the runner's stdin through and lets terraform's own prompt do the asking. That is route (a) from #29, which #30 rejected for `apply` because a saved plan gave it something better; here it is the appropriate answer rather than a fallback.

Stdin is left nil when `--auto-approve` is set, so an unattended run still cannot block on a question.

`--parallelism > 1` now requires `--auto-approve` here too, for the reason it already does in `apply`: concurrent node output is buffered and flushed a node at a time, so the prompt would be invisible until long after the answer was needed.

Also drops `Runner.Apply`, which lost its last caller in #30 when apply started refusing backends that cannot produce a local plan.

## Verified

Against Terraform 1.16.0, end to end:

```
echo yes | terragraph destroy   ->  Destroy complete! Resources: 1 destroyed.
echo no  | terragraph destroy   ->  Destroy cancelled.  (exit 1, nothing destroyed)
terragraph destroy --parallelism 2
  ->  error: --parallelism 2 needs --auto-approve: output from concurrent nodes
      is buffered, so there is nowhere to ask for approval
```

Plus two engine tests, with the fake CLI's `destroy` taught to model the real one: `-input=false` does not suppress the confirmation, so without `-auto-approve` an answer has to arrive on stdin.

## Two follow-up commits since review

**Explaining a missing answer (`b2cf478`).** Review flagged that a run with nothing on stdin gets terraform's bare `error asking for approval: EOF` rather than terragraph's guidance. Exact parity with `Apply` is not reachable — apply plans first and so knows a node has changes, while destroy cannot tell an unattended no-op (which should succeed) from one about to ask an unanswerable question — so the explanation is attached to the failure instead of predicted.

Worth flagging: the first attempt guarded on `e.Stdin == nil` and never fired. A CLI run always has a stdin (`cmd.InOrStdin()`), and `</dev/null` hands over a perfectly good reader that yields nothing, so the nil test missed precisely the case it was for. It now counts bytes the subprocess actually read, which also keeps a declined destroy reported as the refusal it was:

```
</dev/null   ->  error: ... (nothing was available to read approval from;
                 pass --auto-approve to destroy without asking)
echo no  |   ->  Destroy cancelled.          # no hint: someone decided this
echo yes |   ->  Destroy complete! Resources: 1 destroyed.
```

**Guard before lock (`94531d4`).** Rebasing onto #31's run lock put it ahead of this branch's parallelism guard, so an unrunnable flag combination would wait on whatever else held the lock before being told it was never going to run. The guard now comes first in both `Apply` and `Destroy`, which also restores the symmetry the rebase had quietly broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

