### PR TITLE
feat: allow literal vars on use to fill group export inputs

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -23,7 +23,7 @@ An edge can be:
 
 Mixing the two on the same edge (a port on one side, a bare node on the other) is rejected at parse time.
 
-An input is a single slot: two data edges targeting the same input are a validation Error, whether their `from` sides differ or match (exact duplicates). The same rule covers a data edge colliding with `vars` (see [Literal input values (`vars`)](#literal-input-values-vars)). It is checked after group expansion, so two outer edges, or an outer edge plus an internal one, that only meet on the same leaf once a `use` export has rewritten them are caught too. Ordering-only edges are not this rule; they carry no value.
+An input is a single slot: two data edges targeting the same input are a validation Error, whether their `from` sides differ or match (exact duplicates). The same rule covers a data edge colliding with `vars` (see [Literal input values (`vars`)](#literal-input-values-vars)). It is checked after group expansion, so two outer edges, or an outer edge plus an internal one, that only meet on the same leaf once a `use` export has rewritten them are caught too. A `use.vars` key is rewritten onto those same leaves and collides the same way as `node.vars`; see [groups.md](groups.md#setting-literal-inputs-for-an-instance). Ordering-only edges are not this rule; they carry no value.
 
 Node canvas layout (for the future visual editor) lives in a separate `blueprint.layout.json`, so moving a box never shows up in a `blueprint.hcl` diff.
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -12,7 +12,7 @@ Type checking is a runtime check, not static inference: a standard root module's
 
 ## How values are passed
 
-terragraph never writes or modifies `.tf` files. Before running a node, it writes the values resolved from its incoming data edges (and its own `vars`, see [blueprint.md](blueprint.md#literal-input-values-vars)) to an ephemeral, engine-managed tfvars file, then passes it to Terraform explicitly via `-var-file`. Terraform's own `*.auto.tfvars.json` auto-loading is never relied on: two nodes can share a module directory (see `backend_config` in [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), and auto-loading by a fixed filename would let them clobber each other's values.
+terragraph never writes or modifies `.tf` files. Before running a node, it writes the values resolved from its incoming data edges (and its own `vars`, including literals a `use.vars` rewrote onto that node; see [blueprint.md](blueprint.md#literal-input-values-vars)) to an ephemeral, engine-managed tfvars file, then passes it to Terraform explicitly via `-var-file`. Terraform's own `*.auto.tfvars.json` auto-loading is never relied on: two nodes can share a module directory (see `backend_config` in [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), and auto-loading by a fixed filename would let them clobber each other's values.
 
 Where that file is written is controlled by an optional `tfvars` block:
 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -38,7 +38,7 @@ This expands purely in memory when the graph is built (no files are generated) i
 A few rules fall out of that expansion:
 - **Only `export`-declared ports are visible from outside the instance.** `use.checkout.output.cluster_id` works; `use.checkout.cluster.output.cluster_id` doesn't even parse. This is deliberate: a group is only safely reusable if its author can change internals without an unbounded set of external edges depending on them, the same reason Terraform modules, Go's unexported identifiers, and private class members all work this way. If a consumer needs something not currently exported, the fix is adding it to the group's `export` block, not reaching around it. Plain nodes (not inside a group) have no such restriction.
 - **A data edge into a group's exposed input can fan out** (`to = [node.a.input.x, node.b.input.x]`) because "which internal nodes need this value" is a fact about the group's own design that its author must state; it isn't inferable from graph structure. An exposed output is always a 1:1 passthrough, so it never needs this.
-- **A leaf input still takes at most one data edge after expansion.** Fan-out to distinct internal ports is not a collision. Two outer edges (or an outer edge plus an internal one) that rewrite onto the same leaf are a validation Error, including exact duplicates. This is the same one-source-per-input rule as a plain blueprint; see [blueprint.md](blueprint.md#literal-input-values-vars).
+- **A leaf input still takes at most one source after expansion** (a data edge or `vars`). Fan-out to distinct internal ports is not a collision. Two outer edges, an outer edge plus an internal one, or a `use.vars` key plus a data edge, that rewrite onto the same leaf are a validation Error, including exact duplicates. This is the same one-source-per-input rule as a plain blueprint; see [blueprint.md](blueprint.md#literal-input-values-vars).
 - **A bare, ordering-only edge into or out of a group needs no such declaration**: `edge { from = node.x, to = use.checkout }` (no port) expands automatically to every node inside the group with no internal predecessor (its "roots"); the symmetric case on the `from` side expands to every node with no internal successor (its "sinks"). Unlike fan-out, this is inferable directly from the group's internal graph shape.
 - **An edge into or out of an instance can carry nested `input` blocks** (see [blueprint.md](blueprint.md#several-values-between-the-same-two-nodes-input)), wiring several of the instance's exposed inputs in one block: `edge { from = node.vpc, to = use.checkout, input "vpc_id" { from = output.vpc_id } ... }`. Each block expands into an ordinary data edge before any of the above applies, so an expanded edge fans out through `export` and collides on a leaf exactly as a separately written one would.
 - **`node`↔`group` and `group`↔`group` edges use identical syntax** to `node`↔`node`. A group instance is indistinguishable from a node both in edge references and in schema: internal nodes are inspected exactly as today (`module.Inspect` against their real `.tf` files), the `export` block is validated against those real schemas, and once valid it's synthesized into the same schema shape a real module has. Groups can nest (a group's own `use` blocks resolve recursively), and a group that directly or transitively uses itself is a validation error.
@@ -72,5 +72,23 @@ use "eks-service" {
 ```
 
 Unlike `runtime`, this merges rather than replaces: an internal node that sets its own `env` only overrides the specific keys it names, still inheriting anything else the instance's `env` contributed. Nesting works the same way `runtime` does, layer by layer: an inner `use` block's own `env` merges over whatever it inherited from an outer one before passing the result down further.
+
+## Setting literal inputs for an instance
+
+A `use` block can set `vars` (see [blueprint.md](blueprint.md#literal-input-values-vars)) to fill this instance's public inputs with literal values. Keys are **export input names**, not internal `node.input` paths: the group author still decides what is public.
+
+```hcl
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  vars = {
+    cluster_name = "checkout"
+  }
+}
+```
+
+That fills `export { input "cluster_name" { to = node.cluster.input.cluster_name } }`. The same no-references, no-functions rule as `node.vars` applies: another node's output still needs an `edge`. After expansion the literal is rewritten onto every leaf the export names, including fan-out, and then the one-source-per-input rule applies: a key that is not an export input is an Error; `use.vars` plus a data edge on the same leaf is an Error; two vars sources on the same leaf (group-body `node.vars` and `use.vars`, or two export inputs targeting the same leaf) is an Error.
+
+Unlike `env`, this does not cascade onto every expanded node. Unlike `runtime`, it is not a single replace-on-override choice. It fills the public inputs the group author exported.
 
 See it end to end in [`examples/group`](../examples/group).

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -9,11 +9,11 @@ The extension bundles a compatible language server, so nothing here requires ins
 Open the completion list with `Ctrl+Space` (`Control+Space` on macOS).
 
 - Top-level blueprint blocks: `node`, `edge`, `runtime`, `group`, `use`, `vendor`, `tfvars`
-- The attributes each block accepts: a node's `source`, `vars`, `env`, `runtime`, `backend_config`, and so on
+- The attributes each block accepts: a node's `source`, `vars`, `env`, `runtime`, `backend_config`; a `use` block's `as`, `source`, `vars`, `env`, `runtime`, `approve`; and so on
 - A Terraform/OpenTofu module's own input variables and outputs
 - Declared runtime names
 
-Inside `vars = {}` only the input variables the node's own module declares are suggested. To pass another node's result, use an `edge` rather than `vars`.
+Inside a node's `vars = {}` only the input variables that module declares are suggested. Inside a `use` block's `vars = {}` only that instance's export input names are suggested. To pass another node's result, use an `edge` rather than `vars`.
 
 ```hcl
 edge {
@@ -48,7 +48,7 @@ Mistakes that can be found without evaluating anything are underlined as you typ
 - A node name that isn't declared
 - A module input or output name that doesn't exist
 - A `from` referencing an input, or a `to` referencing an output
-- A `vars` entry the module has no such input variable for
+- A `vars` entry the module has no such input variable for, or a `use.vars` key that is not an export input
 - An edge `input` block whose label isn't an input of the `to` node, or whose `from = output.<attr>` isn't an output of the `from` node
 
 Hovering an error lists the input or output names that are available.

--- a/examples/group/README.md
+++ b/examples/group/README.md
@@ -1,6 +1,6 @@
 # group
 
-A `vpc` node feeding a reusable `eks-service` group (`cluster` + `nodegroup`) instantiated as `checkout`, proving group expansion, export wiring, and the group's own internal edge all work end to end. See [docs/groups.md](../../docs/groups.md) for the concept. Cloud-credential-free (`random`/`local` providers only).
+A `vpc` node feeding a reusable `eks-service` group (`cluster` + `nodegroup`) instantiated as `checkout`, proving group expansion, export wiring, and the group's own internal edge all work end to end. `cluster_name` is instance data via `use.vars`; `vpc_id` still comes from an edge. See [docs/groups.md](../../docs/groups.md) for the concept. Cloud-credential-free (`random`/`local` providers only).
 
 ```
 cd examples/group

--- a/examples/group/blueprint.hcl
+++ b/examples/group/blueprint.hcl
@@ -5,6 +5,9 @@ node "vpc" {
 use "eks-service" {
   as     = "checkout"
   source = "./groups/eks-service"
+  vars = {
+    cluster_name = "checkout"
+  }
 }
 
 edge {

--- a/examples/group/groups/eks-service/group.hcl
+++ b/examples/group/groups/eks-service/group.hcl
@@ -15,6 +15,9 @@ group "eks-service" {
     input "vpc_id" {
       to = node.cluster.input.vpc_id
     }
+    input "cluster_name" {
+      to = node.cluster.input.cluster_name
+    }
     output "cluster_id" {
       from = node.cluster.output.cluster_id
     }

--- a/examples/group/modules/cluster/main.tf
+++ b/examples/group/modules/cluster/main.tf
@@ -10,6 +10,7 @@ terraform {
 resource "random_id" "cluster" {
   byte_length = 4
   keepers = {
-    vpc_id = var.vpc_id
+    vpc_id       = var.vpc_id
+    cluster_name = var.cluster_name
   }
 }

--- a/examples/group/modules/cluster/variables.tf
+++ b/examples/group/modules/cluster/variables.tf
@@ -2,3 +2,8 @@ variable "vpc_id" {
   type        = string
   description = "Wired in by terragraph from the group's export input"
 }
+
+variable "cluster_name" {
+  type        = string
+  description = "Instance-specific name supplied via use.vars"
+}

--- a/internal/blueprint/group_test.go
+++ b/internal/blueprint/group_test.go
@@ -149,6 +149,9 @@ edge {
 	if u.GroupName != "eks-service" || u.As != "checkout" || u.Source != "../groups/eks-service" {
 		t.Fatalf("unexpected use block: %+v", u)
 	}
+	if len(u.Vars) != 0 {
+		t.Fatalf("expected no vars, got %+v", u.Vars)
+	}
 
 	if len(bp.Edges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(bp.Edges))
@@ -156,6 +159,63 @@ edge {
 	to := bp.Edges[0].To
 	if to.Entity != EntityUse || to.Node != "checkout" || to.Kind != PortInput || to.Name != "vpc_id" {
 		t.Fatalf("unexpected edge target: %+v", to)
+	}
+}
+
+func TestParseFile_UseVars(t *testing.T) {
+	path := writeTemp(t, `
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  vars = {
+    cluster_name = "checkout"
+    az_count     = 3
+  }
+}
+`)
+
+	bp, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(bp.Uses) != 1 {
+		t.Fatalf("expected 1 use instantiation, got %d", len(bp.Uses))
+	}
+	u := bp.Uses[0]
+	if u.Vars["cluster_name"] != "checkout" {
+		t.Fatalf("unexpected cluster_name: %+v", u.Vars["cluster_name"])
+	}
+	if u.Vars["az_count"] != float64(3) {
+		t.Fatalf("unexpected az_count: %+v", u.Vars["az_count"])
+	}
+}
+
+func TestParseFile_UseVarsRejectsOutputReference(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+use "g" {
+  as     = "inst"
+  source = "./g"
+  vars = {
+    x = node.a.output.id
+  }
+}
+`)
+	if _, err := ParseFile(path); err == nil {
+		t.Fatalf("expected an error: use vars must not reference another node's output; use an edge for that")
+	}
+}
+
+func TestParseFile_UseVarsRejectsNonObject(t *testing.T) {
+	path := writeTemp(t, `
+use "g" {
+  as     = "inst"
+  source = "./g"
+  vars = ["not", "an", "object"]
+}
+`)
+	if _, err := ParseFile(path); err == nil {
+		t.Fatalf("expected an error: use vars must be an object/map, not a list")
 	}
 }
 
@@ -178,6 +238,9 @@ group "outer" {
   use "inner-group" {
     as     = "inner"
     source = "../inner"
+    vars = {
+      name = "from-outer"
+    }
   }
   node "a" { source = "./a" }
 
@@ -194,6 +257,9 @@ group "outer" {
 	g := bp.Groups[0]
 	if len(g.Uses) != 1 || g.Uses[0].As != "inner" {
 		t.Fatalf("unexpected nested use: %+v", g.Uses)
+	}
+	if g.Uses[0].Vars["name"] != "from-outer" {
+		t.Fatalf("unexpected nested use vars: %+v", g.Uses[0].Vars)
 	}
 	if g.Export.Outputs[0].From.Entity != EntityUse {
 		t.Fatalf("expected export output to reference the nested use instance, got %+v", g.Export.Outputs[0].From)

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -88,6 +88,7 @@ var useSchema = &hcl.BodySchema{
 		{Name: "source", Required: true},
 		{Name: "runtime", Required: false},
 		{Name: "env", Required: false},
+		{Name: "vars", Required: false},
 		{Name: "approve", Required: false},
 	},
 }
@@ -544,7 +545,7 @@ func parseApproveAttr(attr *hcl.Attribute) (Approve, error) {
 	return a, nil
 }
 
-// parseVarsAttr evaluates the optional vars attribute: literal input values declared directly on a node, keyed by the target variable's name (see Node.Vars). The expression is evaluated with no variables or functions in scope, so a reference to another node's or use instance's output (e.g. node.vpc.output.vpc_id) fails to parse here exactly as intended: that kind of value must come from a real edge, not vars, since only an edge records the dependency the engine needs to sequence execution and wait for the value to actually exist.
+// parseVarsAttr evaluates the optional vars attribute: literal input values declared on a node or a use. On a node the keys are module variable names (see Node.Vars); on a use they are the group's export input names (see Use.Vars). The HCL shape is the same either way. The expression is evaluated with no variables or functions in scope, so a reference to another node's or use instance's output (e.g. node.vpc.output.vpc_id) fails to parse here exactly as intended: that kind of value must come from a real edge, not vars, since only an edge records the dependency the engine needs to sequence execution and wait for the value to actually exist.
 func parseVarsAttr(attr *hcl.Attribute) (map[string]any, error) {
 	val, diags := attr.Expr.Value(nil)
 	if diags.HasErrors() {
@@ -926,6 +927,15 @@ func parseUseBlock(block *hcl.Block) (Use, error) {
 		}
 	}
 
+	var vars map[string]any
+	if attr, ok := content.Attributes["vars"]; ok {
+		var err error
+		vars, err = parseVarsAttr(attr)
+		if err != nil {
+			return Use{}, err
+		}
+	}
+
 	approve, err := parseApproveAttr(content.Attributes["approve"])
 	if err != nil {
 		return Use{}, err
@@ -937,6 +947,7 @@ func parseUseBlock(block *hcl.Block) (Use, error) {
 		Source:    sourceVal.AsString(),
 		Runtime:   runtime,
 		Env:       env,
+		Vars:      vars,
 		Approve:   approve,
 	}, nil
 }

--- a/internal/blueprint/types.go
+++ b/internal/blueprint/types.go
@@ -96,6 +96,8 @@ type Use struct {
 	Runtime string
 	// Env, if set, contributes extra environment variables to every node this instantiation expands to (e.g. which AWS account/region/role the whole group deploys into), merged under whatever ambient Env an enclosing Use.Env already contributed and merged under, key-by-key, by each internal node's own Env in turn. Like Runtime, a group definition has no equivalent of its own: which account a reusable group deploys into is a fact about where it's instantiated.
 	Env map[string]string
+	// Vars is optional and supplies literal input values for this instance, keyed by the group's export input names (not internal node.input paths). Same literal object as Node.Vars: JSON-compatible values, no references to other nodes' outputs, no functions. Graph expansion rewrites each key through the resolved export onto the leaf nodes' Vars maps (see graph.applyUseVars); a group definition has no equivalent, because instance data belongs at the use site.
+	Vars map[string]any
 	// Approve, if set, becomes the approve level for every node this instantiation expands to, unless that node sets its own. Like Runtime, only the instantiation site can set this and a group definition has no equivalent: how much of a reusable group may be changed unattended is a fact about where it is deployed, not about the group.
 	Approve Approve
 }

--- a/internal/graph/build.go
+++ b/internal/graph/build.go
@@ -222,6 +222,10 @@ func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient 
 		return useInfo{}, nil, err
 	}
 
+	if err := applyUseVars(u.Vars, resolvedExport, internal.Nodes, u.As); err != nil {
+		return useInfo{}, nil, err
+	}
+
 	var roots, sinks []string
 	for name := range internal.Nodes {
 		if len(internal.In[name]) == 0 {

--- a/internal/graph/group.go
+++ b/internal/graph/group.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
@@ -241,4 +242,44 @@ func rewriteEndpoint(ref blueprint.PortRef, uses map[string]useInfo, qualify fun
 		}
 	}
 	return nil, fmt.Errorf("use.%s.input.%s is not exported by this group", ref.Node, ref.Name)
+}
+
+// applyUseVars rewrites a use block's literal vars through the instance's already-resolved export onto the leaf nodes' Vars maps. Keys are export input names; each value is written onto every leaf the export names (fan-out included). Unknown export names are an Error rather than skipped, because Validate only sees leaf variable names and would otherwise accept a key that never landed. A leaf that already has that Vars key (group-body node.vars, a nested use.vars, or two export inputs targeting the same leaf) is also an Error: an input is a single slot. Does not mutate vars itself.
+func applyUseVars(vars map[string]any, export blueprint.Export, nodes map[string]*Node, instanceAs string) error {
+	if len(vars) == 0 {
+		return nil
+	}
+
+	byName := make(map[string][]blueprint.PortRef, len(export.Inputs))
+	for _, in := range export.Inputs {
+		byName[in.Name] = in.To
+	}
+
+	keys := make([]string, 0, len(vars))
+	for key := range vars {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		targets, ok := byName[key]
+		if !ok {
+			return fmt.Errorf("use.%s.vars.%s is not an export input of this group", instanceAs, key)
+		}
+		val := vars[key]
+		for _, ref := range targets {
+			node, ok := nodes[ref.Node]
+			if !ok {
+				return fmt.Errorf("use.%s.vars.%s: export input maps to unknown node %q", instanceAs, key, ref.Node)
+			}
+			if node.Vars == nil {
+				node.Vars = map[string]any{}
+			}
+			if _, exists := node.Vars[ref.Name]; exists {
+				return fmt.Errorf("node.%s.input.%s: set by more than one vars source; remove extras", ref.Node, ref.Name)
+			}
+			node.Vars[ref.Name] = val
+		}
+	}
+	return nil
 }

--- a/internal/graph/use_vars_test.go
+++ b/internal/graph/use_vars_test.go
@@ -1,0 +1,599 @@
+package graph
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+func parseAndBuild(t *testing.T, root string) *Graph {
+	t.Helper()
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return g
+}
+
+func parseAndBuildErr(t *testing.T, root string) error {
+	t.Helper()
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	_, err = Build(bp, root)
+	return err
+}
+
+func TestBuild_UseVarsRewritesOntoLeaf(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/b/main.tf"), ``)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  node "b" { source = "../../modules/b" }
+
+  export {
+    input "name" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    name = "checkout"
+  }
+}
+`)
+
+	g := parseAndBuild(t, root)
+
+	if got := g.Nodes["inst.a"].Vars["x"]; got != "checkout" {
+		t.Fatalf("inst.a.Vars[x] = %+v, want %q", got, "checkout")
+	}
+	if _, ok := g.Nodes["inst.b"].Vars["x"]; ok {
+		t.Fatalf("sibling leaf inst.b must not receive use.vars: %+v", g.Nodes["inst.b"].Vars)
+	}
+
+	problems := Validate(g)
+	if len(problems) != 0 {
+		t.Fatalf("expected no problems when use.vars fills the required export input, got %v", problems)
+	}
+}
+
+func TestBuild_UseVarsFanOut(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/b/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  node "b" { source = "../../modules/b" }
+
+  export {
+    input "x" { to = [node.a.input.x, node.b.input.x] }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    x = "shared"
+  }
+}
+`)
+
+	g := parseAndBuild(t, root)
+
+	if g.Nodes["inst.a"].Vars["x"] != "shared" || g.Nodes["inst.b"].Vars["x"] != "shared" {
+		t.Fatalf("expected fan-out onto both leaves, got %+v / %+v", g.Nodes["inst.a"].Vars, g.Nodes["inst.b"].Vars)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("fan-out of use.vars to distinct leaves is not a collision, got %v", problems)
+	}
+}
+
+func TestBuild_UseVarsNestedExportForward(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/leaf/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/inner/group.hcl"), `
+group "inner" {
+  node "leaf" { source = "../../modules/leaf" }
+  export {
+    input "x" { to = node.leaf.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/outer/group.hcl"), `
+group "outer" {
+  use "inner" {
+    as     = "inner"
+    source = "../inner"
+  }
+  export {
+    input "x" { to = use.inner.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "outer" {
+  as     = "top"
+  source = "./groups/outer"
+  vars = {
+    x = "v"
+  }
+}
+`)
+
+	g := parseAndBuild(t, root)
+
+	if got := g.Nodes["top.inner.leaf"].Vars["x"]; got != "v" {
+		t.Fatalf("expected outer use.vars to land on flattened leaf, got %+v", g.Nodes["top.inner.leaf"].Vars)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected a valid graph, got %v", problems)
+	}
+}
+
+func TestBuild_UseVarsTwoInstancesDoNotShareMaps(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "first"
+  source = "./groups/g"
+  vars = {
+    x = "one"
+  }
+}
+
+use "g" {
+  as     = "second"
+  source = "./groups/g"
+  vars = {
+    x = "two"
+  }
+}
+`)
+
+	g := parseAndBuild(t, root)
+
+	if g.Nodes["first.a"].Vars["x"] != "one" || g.Nodes["second.a"].Vars["x"] != "two" {
+		t.Fatalf("expected distinct instance vars, got %+v / %+v", g.Nodes["first.a"].Vars, g.Nodes["second.a"].Vars)
+	}
+	g.Nodes["first.a"].Vars["x"] = "mutated"
+	if g.Nodes["second.a"].Vars["x"] != "two" {
+		t.Fatalf("mutating the first instance's Vars affected the second: %+v", g.Nodes["second.a"].Vars)
+	}
+}
+
+func TestBuild_UseVarsUnknownExportName(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    not_exported = "x"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error for a use.vars key that is not an export input")
+	}
+	if !strings.Contains(err.Error(), "use.inst.vars.not_exported is not an export input of this group") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsInternalVariableNameIsNotExported(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+variable "secret" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    secret = "nope"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error: an internal variable name that is not exported is not a use.vars key")
+	}
+	if !strings.Contains(err.Error(), "use.inst.vars.secret is not an export input of this group") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsDottedInternalPathIsUnknownExport(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    "a.x" = "nope"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error: a dotted internal path is just an unknown export name")
+	}
+	if !strings.Contains(err.Error(), "use.inst.vars.a.x is not an export input of this group") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsAndOuterDataEdgeIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/vpc/outputs.tf"), `
+output "vid" { value = "vpc-123" }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./modules/vpc" }
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    x = "literal"
+  }
+}
+edge {
+  from = node.vpc.output.vid
+  to   = use.inst.input.x
+}
+`)
+
+	g := parseAndBuild(t, root)
+	problems := Validate(g)
+	if len(problems) != 1 || !problems[0].IsError() {
+		t.Fatalf("expected 1 Error for use.vars plus a data edge, got %v", problems)
+	}
+	if !strings.Contains(problems[0].Message, "set by both a data edge and vars") {
+		t.Fatalf("unexpected message: %v", problems[0])
+	}
+}
+
+func TestBuild_UseVarsAndInternalDataEdgeIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/src/outputs.tf"), `
+output "id" { value = "from-internal" }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "src" { source = "../../modules/src" }
+  node "a"   { source = "../../modules/a" }
+
+  edge {
+    from = node.src.output.id
+    to   = node.a.input.x
+  }
+
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    x = "literal"
+  }
+}
+`)
+
+	g := parseAndBuild(t, root)
+	problems := Validate(g)
+	if len(problems) != 1 || !problems[0].IsError() {
+		t.Fatalf("expected 1 Error for use.vars plus an internal data edge, got %v", problems)
+	}
+	if !strings.Contains(problems[0].Message, "set by both a data edge and vars") {
+		t.Fatalf("unexpected message: %v", problems[0])
+	}
+}
+
+func TestBuild_UseVarsAndGroupBodyVarsIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" {
+    source = "../../modules/a"
+    vars = {
+      x = "from-group"
+    }
+  }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    x = "from-use"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error for group-body node.vars plus use.vars on the same leaf")
+	}
+	if !strings.Contains(err.Error(), "set by more than one vars source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsNestedThenOuterOnSameLeafIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/leaf/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/inner/group.hcl"), `
+group "inner" {
+  node "leaf" { source = "../../modules/leaf" }
+  export {
+    input "x" { to = node.leaf.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/outer/group.hcl"), `
+group "outer" {
+  use "inner" {
+    as     = "inner"
+    source = "../inner"
+    vars = {
+      x = "inner"
+    }
+  }
+  export {
+    input "x" { to = use.inner.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "outer" {
+  as     = "top"
+  source = "./groups/outer"
+  vars = {
+    x = "outer"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error for nested use.vars plus outer use.vars on the same leaf")
+	}
+	if !strings.Contains(err.Error(), "set by more than one vars source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsTwoExportInputsSameLeafIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "a" { to = node.a.input.x }
+    input "b" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    a = "1"
+    b = "2"
+  }
+}
+`)
+
+	err := parseAndBuildErr(t, root)
+	if err == nil {
+		t.Fatal("expected an error when two use.vars keys rewrite onto the same leaf")
+	}
+	if !strings.Contains(err.Error(), "set by more than one vars source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_UseVarsFanOutPlusEdgeOnOneLeafIsError(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/vpc/outputs.tf"), `
+output "vid" { value = "vpc-123" }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/b/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  node "b" { source = "../../modules/b" }
+
+  export {
+    input "shared" { to = [node.a.input.x, node.b.input.x] }
+    input "only_a" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./modules/vpc" }
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    shared = "from-vars"
+  }
+}
+edge {
+  from = node.vpc.output.vid
+  to   = use.inst.input.only_a
+}
+`)
+
+	g := parseAndBuild(t, root)
+	problems := Validate(g)
+	if len(problems) != 1 || !problems[0].IsError() {
+		t.Fatalf("expected 1 Error on the leaf that received both sources, got %v", problems)
+	}
+	if !strings.Contains(problems[0].Message, "node.inst.a.input.x") || !strings.Contains(problems[0].Message, "set by both a data edge and vars") {
+		t.Fatalf("unexpected message: %v", problems[0])
+	}
+	if g.Nodes["inst.b"].Vars["x"] != "from-vars" {
+		t.Fatalf("the uncollided leaf should still hold the fan-out literal, got %+v", g.Nodes["inst.b"].Vars)
+	}
+}
+
+func TestBuild_UseVarsAndOrderingOnlyEdgeIsNotCollision(t *testing.T) {
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "modules/vpc/outputs.tf"), `
+output "vid" { value = "x" }
+`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+variable "x" { type = string }
+`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  export {
+    input "x" { to = node.a.input.x }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./modules/vpc" }
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  vars = {
+    x = "literal"
+  }
+}
+edge {
+  from = node.vpc
+  to   = use.inst
+}
+`)
+
+	g := parseAndBuild(t, root)
+	if g.Nodes["inst.a"].Vars["x"] != "literal" {
+		t.Fatalf("expected use.vars to still apply, got %+v", g.Nodes["inst.a"].Vars)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("an ordering-only edge carries no value and must not collide with use.vars, got %v", problems)
+	}
+}

--- a/internal/language/workspace.go
+++ b/internal/language/workspace.go
@@ -85,7 +85,8 @@ func (w *Workspace) Complete(_ context.Context, path string, offset int) []Compl
 	fragment := string(text[start:offset])
 	objectAttribute := objectAttributeAt(text, offset)
 	if objectAttribute == "vars" && !strings.Contains(fragment, ".") {
-		return propertyCompletions(model.nodes[nodeAt(text, offset)], fragment, start, offset)
+		p, _ := varsPortsAt(model, text, offset)
+		return propertyCompletions(p, fragment, start, offset)
 	}
 	if objectAttribute != "" {
 		return nil
@@ -348,6 +349,7 @@ var completionSchemas = map[string][]attributeSpec{
 		{name: "source", insert: "source = \"\"", detail: "required string", documentation: "Local path or remote source containing the group."},
 		{name: "runtime", insert: "runtime = runtime.", detail: "runtime reference", documentation: "Default runtime for nodes expanded from this group."},
 		{name: "env", insert: "env = {\n}", detail: "map(string)", documentation: "Environment variables inherited by nodes expanded from this group."},
+		{name: "vars", insert: "vars = {\n}", detail: "object", documentation: "Literal values for this instance's export inputs. Use an edge for another node's output."},
 		{name: "approve", insert: "approve = \"\"", detail: "optional string", documentation: "Default approve level for nodes expanded from this group, unless a node sets its own."},
 	},
 	"vendor": {
@@ -503,6 +505,65 @@ func nodeAt(text []byte, offset int) string {
 		return ""
 	}
 	return matches[len(matches)-1][1]
+}
+
+var useAsLiteral = regexp.MustCompile(`as\s*=\s*"([^"]+)"`)
+
+// varsPortsAt returns the ports whose names are valid keys inside the vars object containing offset: a node's module inputs, or a use instance's export inputs.
+func varsPortsAt(m workspaceModel, text []byte, offset int) (ports, bool) {
+	path := blockPathAt(text, offset)
+	if len(path) == 0 {
+		return ports{}, false
+	}
+	switch path[len(path)-1] {
+	case "use":
+		p, ok := m.uses[useAsAt(text, offset)]
+		return p, ok
+	case "node":
+		p, ok := m.nodes[nodeAt(text, offset)]
+		return p, ok
+	default:
+		return ports{}, false
+	}
+}
+
+func useAsAt(text []byte, offset int) string {
+	start, end, ok := enclosingNamedBlock(text, offset, "use")
+	if !ok {
+		return ""
+	}
+	match := useAsLiteral.FindSubmatch(text[start:end])
+	if len(match) != 2 {
+		return ""
+	}
+	return string(match[1])
+}
+
+func enclosingNamedBlock(text []byte, offset int, name string) (start, end int, ok bool) {
+	var brace int
+	found := false
+	for _, b := range openBlocksAt(text, offset) {
+		if b.name == name {
+			brace = b.at
+			found = true
+		}
+	}
+	if !found {
+		return 0, 0, false
+	}
+	depth := 0
+	for i := brace; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return brace, i, true
+			}
+		}
+	}
+	return brace, len(text), true
 }
 
 var blockHeader = regexp.MustCompile(`(?s)(node|edge|runtime|group|use|vendor|tfvars|export|input|output)\s*(?:"[^\"]*")?\s*$`)
@@ -734,7 +795,7 @@ func (w *Workspace) Diagnose(_ context.Context, path string) []Diagnostic {
 		if objectAttributeAt(text, start) != "vars" {
 			continue
 		}
-		ports, ok := model.nodes[nodeAt(text, start)]
+		ports, ok := varsPortsAt(model, text, start)
 		if !ok || containsString(ports.inputs, string(text[start:end])) {
 			continue
 		}

--- a/internal/language/workspace_test.go
+++ b/internal/language/workspace_test.go
@@ -97,6 +97,7 @@ func TestWorkspaceCompletesBlueprintSyntaxByContext(t *testing.T) {
 		{"edge attribute", "edge {\n  __CURSOR__\n}", "from", "required output reference"},
 		{"runtime attribute", "runtime \"tofu\" {\n  __CURSOR__\n}", "binary", "required string"},
 		{"use attribute", "use \"network\" {\n  __CURSOR__\n}", "env", "map(string)"},
+		{"use vars attribute", "use \"network\" {\n  __CURSOR__\n}", "vars", "object"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			text, offset := cursor(tc.text, "__CURSOR__")
@@ -152,6 +153,69 @@ func TestWorkspaceDoesNotOfferNodeAttributesInsideBackendConfigObject(t *testing
 	ws.SetDocument(path, []byte(text))
 	if items := ws.Complete(context.Background(), path, offset); len(items) != 0 {
 		t.Fatalf("backend_config completion = %#v, want no node attribute suggestions", items)
+	}
+}
+
+func TestWorkspaceCompletesUseVarsAgainstExportInputs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "groups", "network", "group.hcl"), `group "network" {
+  export {
+    input "cidr" { to = node.vpc.input.cidr }
+    input "vpc_id" { to = node.vpc.input.vpc_id }
+  }
+}`)
+	writeFile(t, filepath.Join(dir, "stacks", "app", "main.tf"), `variable "cluster_name" { type = string }`)
+	path := filepath.Join(dir, "blueprint.hcl")
+	text, offset := cursor(`node "app" { source = "./stacks/app" }
+use "network" {
+  as     = "network"
+  source = "./groups/network"
+  vars = {
+    __CURSOR__
+  }
+}`, "__CURSOR__")
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items := NewWorkspace(dir).Complete(context.Background(), path, offset)
+	if !contains(items, "cidr") || !contains(items, "vpc_id") {
+		t.Fatalf("expected export input completions, got %#v", items)
+	}
+	if contains(items, "cluster_name") {
+		t.Fatalf("use.vars must not suggest a sibling node's module variables, got %#v", items)
+	}
+}
+
+func TestWorkspaceDiagnosesInvalidUseVars(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "groups", "network", "group.hcl"), `group "network" {
+  export {
+    input "cidr" { to = node.vpc.input.cidr }
+  }
+}`)
+	path := filepath.Join(dir, "blueprint.hcl")
+	text := `use "network" {
+  as     = "network"
+  source = "./groups/network"
+  vars = {
+    typo = "x"
+  }
+}`
+	ws := NewWorkspace(dir)
+	ws.SetDocument(path, []byte(text))
+	got := ws.Diagnose(context.Background(), path)
+	found := false
+	for _, diagnostic := range got {
+		if strings.Contains(diagnostic.Message, "Unknown input typo") {
+			found = true
+			if !strings.Contains(diagnostic.Message, "cidr") {
+				t.Fatalf("expected available export inputs in diagnostic, got %#v", diagnostic)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostic %q missing from %#v", "Unknown input typo", got)
 	}
 }
 


### PR DESCRIPTION
`use` can now pass instance-specific literal inputs through `vars`, keyed by the group's export input names. This is the same literal object as `node.vars` (JSON-compatible values, no output references, no functions). After group expansion the keys are rewritten onto the leaf nodes' `Vars` maps, then the existing one-source-per-input rule and `resolveInputs` type check apply.

A group's public inputs were only fillable from outside by a data edge. Literal per-instance data (cluster name, tenant CIDR, …) had nowhere to go except baking the value into the group body, standing up a dummy node, or copying the nodes. Encapsulation stays: `use.vars` cannot reach around `export` into internal node names.

```hcl
use "eks-service" {
  as     = "checkout"
  source = "./groups/eks-service"
  vars = {
    cluster_name = "checkout"
  }
}
```

Unknown export names are an Error. An export input set by both `use.vars` and a data edge is an Error. Fan-out export inputs receive the literal on every leaf.

## How to verify

```
make check
go run ./cmd/terragraph validate --blueprint examples/group/blueprint.hcl
go run ./cmd/terragraph graph --blueprint examples/group/blueprint.hcl
# level 1: vpc
# level 2: checkout.cluster
# level 3: checkout.nodegroup
```

`examples/group` now passes `cluster_name` through `use.vars` while `vpc_id` still comes from an edge.

Closes #36