### PR TITLE
feat: isolate terraform state for shared module sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ See [docs/](docs/README.md) for the blueprint model, groups, vendoring, the exec
 Self-contained and cloud-credential-free (`random`/`local` providers only). Clone and run directly, each with its own README:
 
 - [`examples/basic`](examples/basic): one node feeding two independent downstream nodes (wiring, parallel execution, skipping unchanged nodes).
-- [`examples/reuse`](examples/reuse): the same module instantiated twice via distinct `backend_config`, proving state isolation.
-- [`examples/group`](examples/group): a group instantiated via `use`, proving expansion and export wiring.
+- [`examples/reuse`](examples/reuse): the same module instantiated twice, proving the local state default isolates each node.
+- [`examples/group`](examples/group): a group instantiated twice via `use`, proving expansion, export wiring, and per-instance state isolation.
 - [`examples/vendored`](examples/vendored): a node sourced from a remote git address, showing the vendor workflow.
 
 ## Development

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -56,18 +56,19 @@ Either endpoint may be a group instance (`use.<name>`), and each expanded edge t
 
 ## Reusing the same module across instances
 
-A node can optionally set `backend_config` to reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding:
+A node can reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding. If the module declares `backend "local"` (an empty block is enough) and the node does not set `path`, terragraph fills `path` to `<blueprint dir>/.terragraph/state/<node>.tfstate` (absolute) and passes it as `terraform init -backend-config=path=...`. An explicit `path` wins.
 
 ```hcl
 node "vpc_prod" {
   source = "./stacks/vpc"
-  backend_config = {
-    path = ".terragraph/state/vpc_prod.tfstate"   # local backend example
-  }
+}
+
+node "vpc_dev" {
+  source = "./stacks/vpc"
 }
 ```
 
-This is passed straight through to `terraform init -backend-config=key=value` (Terraform's own partial backend configuration mechanism, not code generation). It requires the module to declare at least an empty backend block (`terraform { backend "local" {} }`); with no backend block at all there's nothing for `-backend-config` to apply to and it's silently ignored. Every node also gets its own isolated `.terraform/` metadata directory (`TF_DATA_DIR`, managed automatically) regardless of whether its `source` is shared with another node. Otherwise two instances of the same module would also fight over which backend they were last configured with.
+`backend_config` is still available for remote backends (`bucket`, `profile`, `region`, `key`, ...) or an explicit local `path`. It requires a `backend` block in the module; a missing block or a `cloud` block plus a non-empty `backend_config` is a validate **Error**. Two nodes that share a module directory and resolve to the same `backend_config` map (including both empty) are also a validate **Error**. Every node also gets its own isolated `.terraform/` metadata directory (`TF_DATA_DIR`, managed automatically) regardless of whether its `source` is shared with another node. Otherwise two instances of the same module would also fight over which backend they were last configured with.
 
 Sharing a `source` directory does *not* isolate `.terraform.lock.hcl`, though: unlike `.terraform/`, that file lives in the module directory itself. If those instances also resolve to different runtimes (see below), Terraform and OpenTofu will each keep rewriting it to their own provider registry host on every `init`, and `terragraph validate` warns about exactly this. Give each instance its own `source` copy (or wait until they're all on the same runtime) rather than ignoring that warning.
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -3,7 +3,7 @@
 ## Validation
 
 `terragraph validate` (and `graph`/`plan`/`apply`/`destroy`, which run it first) reports two severities:
-- **Error**: blocks the command (a `from`/`to` referencing a port that doesn't exist, two data edges targeting the same input after group expansion even when they are exact duplicates, a data edge and `vars` both setting the same input, a cycle, a value that doesn't fit the target variable's declared type).
+- **Error**: blocks the command (a `from`/`to` referencing a port that doesn't exist, two data edges targeting the same input after group expansion even when they are exact duplicates, a data edge and `vars` both setting the same input, a cycle, a value that doesn't fit the target variable's declared type, `backend_config` set on a module with no `backend` block, two nodes sharing a module directory with identical `backend_config` maps).
 - **Warning**: printed but never blocks. A required variable with no edge feeding it may legitimately come from that module's own `terraform.tfvars` or the environment, outside the blueprint entirely.
 
 Cycle detection reports every independent cyclic cluster in one pass (Tarjan's SCC algorithm), not just the first one found.
@@ -22,7 +22,7 @@ tfvars {
 }
 ```
 
-- **`workdir`** (default): `<blueprint dir>/.terragraph/vars/<node>.tfvars.json`, next to the node's other engine-managed state (`tfdata/`, `plans/`). Never touches a module's own directory, so nothing needs adding to any module's `.gitignore`, and two nodes sharing a `source` never collide on a filename. This is the right choice for a vendored module (not yours to add a `.gitignore` entry to) or one reused across many near-identical instances.
+- **`workdir`** (default): `<blueprint dir>/.terragraph/vars/<node>.tfvars.json`, next to the node's other engine-managed state (`tfdata/`, `plans/`, and for `backend "local"` modules that do not set `path`, `state/<node>.tfstate`). Never touches a module's own directory, so nothing needs adding to any module's `.gitignore`, and two nodes sharing a `source` never collide on a filename. This is the right choice for a vendored module (not yours to add a `.gitignore` entry to) or one reused across many near-identical instances. If a module already declared `backend "local"` and kept `terraform.tfstate` in the module directory, the next `plan`/`apply` points state at `.terragraph/state/<node>.tfstate` instead; migrate with `terraform init -migrate-state` per node if you need the old state. `destroy` still uses the backend last cached in `TF_DATA_DIR` (it does not re-run `init`).
 - **`module`**: `<node source>/.terragraph.<node>.tfvars.json`, alongside the module's own `.tf` files, for a resolved input value visible next to its source while debugging. Add the pattern below to each module's `.gitignore`:
 
   ```

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -91,4 +91,22 @@ That fills `export { input "cluster_name" { to = node.cluster.input.cluster_name
 
 Unlike `env`, this does not cascade onto every expanded node. Unlike `runtime`, it is not a single replace-on-override choice. It fills the public inputs the group author exported.
 
+## Isolating state for an instance
+
+A `use` block can likewise set `backend_config` (see [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), which is merged onto every node this instance expands to. A node's own keys win.
+
+```hcl
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  backend_config = {
+    bucket  = "tfstate"
+    profile = "prod"
+    region  = "ap-northeast-2"
+  }
+}
+```
+
+Use this for instance-wide remote fields (`bucket`, `profile`, `region`). Do not invent a per-leaf remote `key` here (`checkout.cluster` vs `checkout.nodegroup` needs string interpolation; that is a follow-up). For local state, put `backend "local" {}` in the group's modules; the engine fills a unique `path` per qualified leaf (`checkout.cluster` vs `payments.cluster`).
+
 See it end to end in [`examples/group`](../examples/group).

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -9,7 +9,7 @@ The extension bundles a compatible language server, so nothing here requires ins
 Open the completion list with `Ctrl+Space` (`Control+Space` on macOS).
 
 - Top-level blueprint blocks: `node`, `edge`, `runtime`, `group`, `use`, `vendor`, `tfvars`
-- The attributes each block accepts: a node's `source`, `vars`, `env`, `runtime`, `backend_config`; a `use` block's `as`, `source`, `vars`, `env`, `runtime`, `approve`; and so on
+- The attributes each block accepts: a node's `source`, `vars`, `env`, `runtime`, `backend_config`; a `use` block's `as`, `source`, `vars`, `env`, `runtime`, `backend_config`, `approve`; and so on
 - A Terraform/OpenTofu module's own input variables and outputs
 - Declared runtime names
 

--- a/examples/group/README.md
+++ b/examples/group/README.md
@@ -1,13 +1,13 @@
 # group
 
-A `vpc` node feeding a reusable `eks-service` group (`cluster` + `nodegroup`) instantiated as `checkout`, proving group expansion, export wiring, and the group's own internal edge all work end to end. `cluster_name` is instance data via `use.vars`; `vpc_id` still comes from an edge. See [docs/groups.md](../../docs/groups.md) for the concept. Cloud-credential-free (`random`/`local` providers only).
+A `vpc` node feeding a reusable `eks-service` group (`cluster` + `nodegroup`) instantiated twice (`checkout` and `payments`), proving group expansion, export wiring, the group's own internal edge, per-instance `use.vars` (`cluster_name`), and per-instance Terraform state isolation. `vpc_id` still comes from an edge. See [docs/groups.md](../../docs/groups.md) for the concept. Cloud-credential-free (`random`/`local` providers only).
 
 ```
 cd examples/group
 go run ../../cmd/terragraph graph
 # level 1: vpc
-# level 2: checkout.cluster
-# level 3: checkout.nodegroup
+# level 2: checkout.cluster, payments.cluster
+# level 3: checkout.nodegroup, payments.nodegroup
 go run ../../cmd/terragraph apply --auto-approve
-cat modules/nodegroup/cluster_id.txt   # matches checkout.cluster's cluster_id output
+ls modules/nodegroup/*.txt   # one file per instance, named after that instance's cluster_id
 ```

--- a/examples/group/blueprint.hcl
+++ b/examples/group/blueprint.hcl
@@ -10,7 +10,20 @@ use "eks-service" {
   }
 }
 
+use "eks-service" {
+  as     = "payments"
+  source = "./groups/eks-service"
+  vars = {
+    cluster_name = "payments"
+  }
+}
+
 edge {
   from = node.vpc.output.vpc_id
   to   = use.checkout.input.vpc_id
+}
+
+edge {
+  from = node.vpc.output.vpc_id
+  to   = use.payments.input.vpc_id
 }

--- a/examples/group/modules/cluster/main.tf
+++ b/examples/group/modules/cluster/main.tf
@@ -5,6 +5,8 @@ terraform {
       version = "~> 3.6"
     }
   }
+
+  backend "local" {}
 }
 
 resource "random_id" "cluster" {

--- a/examples/group/modules/nodegroup/main.tf
+++ b/examples/group/modules/nodegroup/main.tf
@@ -5,9 +5,11 @@ terraform {
       version = "~> 2.5"
     }
   }
+
+  backend "local" {}
 }
 
 resource "local_file" "wired_value" {
-  filename = "${path.module}/cluster_id.txt"
+  filename = "${path.module}/${var.cluster_id}.txt"
   content  = var.cluster_id
 }

--- a/examples/reuse/README.md
+++ b/examples/reuse/README.md
@@ -1,9 +1,9 @@
 # reuse
 
-The same module (`stacks/vpc`, with an empty `backend "local" {}`) instantiated twice (`vpc_a`, `vpc_b`) via distinct `backend_config.path` values, proving state stays isolated per instance. Cloud-credential-free (`random`/`local` providers only).
+The same module (`stacks/vpc`, with an empty `backend "local" {}`) instantiated twice (`vpc_a`, `vpc_b`). Terragraph fills a unique local `path` per node, proving state stays isolated per instance. Cloud-credential-free (`random`/`local` providers only).
 
 ```
 cd examples/reuse
 go run ../../cmd/terragraph apply --auto-approve
-# stacks/vpc/.terragraph/state/vpc_a.tfstate and vpc_b.tfstate hold different vpc_id values
+# .terragraph/state/vpc_a.tfstate and vpc_b.tfstate hold different vpc_id values
 ```

--- a/examples/reuse/blueprint.hcl
+++ b/examples/reuse/blueprint.hcl
@@ -1,13 +1,7 @@
 node "vpc_a" {
   source = "./stacks/vpc"
-  backend_config = {
-    path = ".terragraph/state/vpc_a.tfstate"
-  }
 }
 
 node "vpc_b" {
   source = "./stacks/vpc"
-  backend_config = {
-    path = ".terragraph/state/vpc_b.tfstate"
-  }
 }

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -90,6 +90,7 @@ var useSchema = &hcl.BodySchema{
 		{Name: "env", Required: false},
 		{Name: "vars", Required: false},
 		{Name: "approve", Required: false},
+		{Name: "backend_config", Required: false},
 	},
 }
 
@@ -941,14 +942,24 @@ func parseUseBlock(block *hcl.Block) (Use, error) {
 		return Use{}, err
 	}
 
+	var backendConfig map[string]string
+	if attr, ok := content.Attributes["backend_config"]; ok {
+		var err error
+		backendConfig, err = parseBackendConfig(attr)
+		if err != nil {
+			return Use{}, err
+		}
+	}
+
 	return Use{
-		GroupName: block.Labels[0],
-		As:        asVal.AsString(),
-		Source:    sourceVal.AsString(),
-		Runtime:   runtime,
-		Env:       env,
-		Vars:      vars,
-		Approve:   approve,
+		GroupName:     block.Labels[0],
+		As:            asVal.AsString(),
+		Source:        sourceVal.AsString(),
+		Runtime:       runtime,
+		Env:           env,
+		Vars:          vars,
+		Approve:       approve,
+		BackendConfig: backendConfig,
 	}, nil
 }
 

--- a/internal/blueprint/parse_test.go
+++ b/internal/blueprint/parse_test.go
@@ -174,6 +174,41 @@ node "a" { source = "./a" }
 	}
 }
 
+func TestParseFile_UseBackendConfig(t *testing.T) {
+	path := writeTemp(t, `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  backend_config = {
+    bucket = "b"
+  }
+}
+`)
+	bp, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if bp.Uses[0].BackendConfig["bucket"] != "b" {
+		t.Fatalf("unexpected use backend_config: %+v", bp.Uses[0].BackendConfig)
+	}
+}
+
+func TestParseFile_UseNoBackendConfigIsNil(t *testing.T) {
+	path := writeTemp(t, `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+}
+`)
+	bp, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(bp.Uses[0].BackendConfig) != 0 {
+		t.Fatalf("expected no use backend_config, got %+v", bp.Uses[0].BackendConfig)
+	}
+}
+
 func TestParseFile_Vars(t *testing.T) {
 	path := writeTemp(t, `
 node "data-apne2-dev-vpc" {

--- a/internal/blueprint/types.go
+++ b/internal/blueprint/types.go
@@ -53,7 +53,7 @@ func (p PortRef) String() string {
 
 // Node is one independent Terraform/OpenTofu root module participating in the graph. Source is a path relative to the blueprint file.
 //
-// BackendConfig is optional and lets the same Source be reused by multiple nodes (e.g. the same module for both "dev" and "prod") without state collisions: its entries are passed to `terraform init -backend-config=k=v`, Terraform's own partial backend configuration mechanism. This requires the module to declare at least an empty backend block (e.g. `backend "local" {}`); with no backend block at all, there's nothing for -backend-config to apply to and it's silently ignored.
+// BackendConfig is optional and lets the same Source be reused by multiple nodes (e.g. the same module for both "dev" and "prod") without state collisions: its entries are passed to `terraform init -backend-config=k=v`, Terraform's own partial backend configuration mechanism. The module must declare a backend block; a non-empty BackendConfig with no backend block (or only a cloud block) is a validation Error. If the module declares backend "local" and this map has no path, graph.Build fills path with an absolute file under <blueprint>/.terragraph/state/<node>.tfstate. An explicit path wins. Two leaves that share a module directory and resolve to identical maps (including both empty) are a validation Error.
 //
 // Vars is optional and supplies literal input values directly, keyed by variable name: for a value that's genuinely this node's own data (e.g. "this tenant's CIDR is 10.16.0.0/20"), not something that comes from another node's real output. It's merged into the same <node source>/.terragraph.auto.tfvars.json a data edge's resolved value would populate (see engine.Engine.resolveInputs), type-checked against the target variable's declared type the same way, and it's an error for a variable to be set by more than one source at once (two data edges, or a data edge and Vars together). Unlike BackendConfig (always strings), a value here can be any JSON-compatible shape a Terraform variable can hold (string, number, bool, list, or a nested object), so a module needing many inputs can still be wired with one Vars entry per node instead of one edge per variable.
 type Node struct {
@@ -100,6 +100,8 @@ type Use struct {
 	Vars map[string]any
 	// Approve, if set, becomes the approve level for every node this instantiation expands to, unless that node sets its own. Like Runtime, only the instantiation site can set this and a group definition has no equivalent: how much of a reusable group may be changed unattended is a fact about where it is deployed, not about the group.
 	Approve Approve
+	// BackendConfig, if set, is merged into every node this instantiation expands to, the same way Env merges: leaf keys win. Instantiation-site fact (bucket, profile, region). Do not invent a remote key from the instance name.
+	BackendConfig map[string]string
 }
 
 // ExportInput is one input port a group exposes to the outside. To may list more than one internal target: a single exposed value sometimes needs to fan out to several internal nodes that each independently need it, and, unlike execution ordering (which is inferable from the internal graph's shape), there is no way to infer that fan-out from structure alone, so the group author must declare it explicitly.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -73,7 +73,7 @@ func TestGraph_DefaultText_MatchesExampleOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("graph: %v", err)
 	}
-	want := "level 1: vpc\nlevel 2: checkout.cluster\nlevel 3: checkout.nodegroup\n"
+	want := "level 1: vpc\nlevel 2: checkout.cluster, payments.cluster\nlevel 3: checkout.nodegroup, payments.nodegroup\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
@@ -88,13 +88,18 @@ func TestGraph_OutputJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
 		t.Fatalf("unmarshal %q: %v", stdout, err)
 	}
-	want := [][]string{{"vpc"}, {"checkout.cluster"}, {"checkout.nodegroup"}}
+	want := [][]string{{"vpc"}, {"checkout.cluster", "payments.cluster"}, {"checkout.nodegroup", "payments.nodegroup"}}
 	if len(got.Levels) != len(want) {
 		t.Fatalf("levels = %v, want %v", got.Levels, want)
 	}
 	for i := range want {
-		if len(got.Levels[i]) != 1 || got.Levels[i][0] != want[i][0] {
+		if len(got.Levels[i]) != len(want[i]) {
 			t.Fatalf("levels[%d] = %v, want %v", i, got.Levels[i], want[i])
+		}
+		for j := range want[i] {
+			if got.Levels[i][j] != want[i][j] {
+				t.Fatalf("levels[%d] = %v, want %v", i, got.Levels[i], want[i])
+			}
 		}
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -148,7 +148,7 @@ func load(blueprintPath string, binary exec.Binary, stdout, stderr io.Writer, ta
 	}, lock, nil
 }
 
-// Validate returns every structural problem found in the graph (missing ports, two data edges targeting the same input, a data edge and vars both setting the same input, cycles, unresolved required variables) plus any tfvars orphan warnings (see tfVarsOrphans) and shared-source runtime conflict warnings (see runtimeConflicts). Check each Problem's IsError(): only errors should block graph/plan/apply/destroy, warnings are advisory.
+// Validate returns every structural problem found in the graph (missing ports, two data edges targeting the same input, a data edge and vars both setting the same input, cycles, unresolved required variables, backend_config without a backend block, identical backend_config maps on a shared module directory) plus any tfvars orphan warnings (see tfVarsOrphans) and shared-source runtime conflict warnings (see runtimeConflicts). Check each Problem's IsError(): only errors should block graph/plan/apply/destroy, warnings are advisory.
 func (e *Engine) Validate() []graph.Problem {
 	problems := graph.Validate(e.Graph)
 	problems = append(problems, e.tfVarsOrphans()...)

--- a/internal/engine/tfvars_test.go
+++ b/internal/engine/tfvars_test.go
@@ -16,7 +16,7 @@ func writeModule(t *testing.T, dir string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
 	}
-	src := "output \"id\" {\n  value = \"x\"\n}\n"
+	src := "terraform {\n  backend \"local\" {}\n}\noutput \"id\" {\n  value = \"x\"\n}\n"
 	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(src), 0o644); err != nil {
 		t.Fatalf("writing fixture module: %v", err)
 	}

--- a/internal/graph/backend_test.go
+++ b/internal/graph/backend_test.go
@@ -1,0 +1,556 @@
+package graph
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+func writeBackendModule(t *testing.T, dir, terraformBody string) {
+	t.Helper()
+	src := terraformBody
+	if src != "" {
+		src += "\n"
+	}
+	src += "output \"id\" { value = \"x\" }\n"
+	writeFixtureFile(t, filepath.Join(dir, "main.tf"), src)
+}
+
+const localBackend = `
+terraform {
+  backend "local" {}
+}
+`
+
+const s3Backend = `
+terraform {
+  backend "s3" {}
+}
+`
+
+const cloudBackend = `
+terraform {
+  cloud {}
+}
+`
+
+func TestBuild_FillsLocalBackendPath(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	want := filepath.Join(dir, ".terragraph", "state", "vpc.tfstate")
+	got := g.Nodes["vpc"].BackendConfig["path"]
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected an absolute path, got %q", got)
+	}
+}
+
+func TestBuild_ExplicitPathWins(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "custom.tfstate" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := g.Nodes["vpc"].BackendConfig["path"]; got != "custom.tfstate" {
+		t.Fatalf("path = %q, want %q", got, "custom.tfstate")
+	}
+}
+
+func TestBuild_FillSkipsNonLocal(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, ok := g.Nodes["vpc"].BackendConfig["path"]; ok {
+		t.Fatalf("did not expect a filled path on s3, got %+v", g.Nodes["vpc"].BackendConfig)
+	}
+}
+
+func TestBuild_FillSkipsNoBackendBlock(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), "")
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(g.Nodes["vpc"].BackendConfig) != 0 {
+		t.Fatalf("expected empty backend_config, got %+v", g.Nodes["vpc"].BackendConfig)
+	}
+}
+
+func TestBuild_FillGroupLeafUsesOuterRoot(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "modules/cluster"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "cluster" { source = "../../modules/cluster" }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "checkout"
+  source = "./groups/g"
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	got := g.Nodes["checkout.cluster"].BackendConfig["path"]
+	want := filepath.Join(dir, ".terragraph", "state", "checkout.cluster.tfstate")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+	if strings.Contains(got, filepath.Join("groups", "g")) {
+		t.Fatalf("fill used the group directory, got %q", got)
+	}
+}
+
+func TestBuild_UseBackendConfigMerges(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "modules/a"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "inherited" { source = "../../modules/a" }
+  node "explicit" {
+    source         = "../../modules/a"
+    backend_config = { path = "from-node" }
+  }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "inst"
+  source = "./groups/g"
+  backend_config = {
+    bucket = "acct"
+    path   = "from-use"
+  }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	inherited := g.Nodes["inst.inherited"].BackendConfig
+	if inherited["bucket"] != "acct" || inherited["path"] != "from-use" {
+		t.Fatalf("expected use backend_config to cascade, got %+v", inherited)
+	}
+	explicit := g.Nodes["inst.explicit"].BackendConfig
+	if explicit["path"] != "from-node" {
+		t.Fatalf("expected leaf path to win, got %+v", explicit)
+	}
+	if explicit["bucket"] != "acct" {
+		t.Fatalf("expected use bucket to remain when the leaf only set path, got %+v", explicit)
+	}
+}
+
+func TestValidate_BackendConfigWithoutBackendBlock(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), "")
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "x" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	problems := Validate(g)
+	if !hasErrorContaining(problems, "backend_config is set") || !hasErrorContaining(problems, "no backend block") {
+		t.Fatalf("expected Error A, got %v", problems)
+	}
+}
+
+func TestValidate_BackendConfigOnLocalAfterFillIsOk(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected no problems after fill, got %v", problems)
+	}
+}
+
+func TestValidate_BackendConfigOnS3IsOk(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+  source         = "./stacks/vpc"
+  backend_config = { bucket = "b" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected no problems for s3 backend_config, got %v", problems)
+	}
+}
+
+func TestValidate_BackendConfigOnCloudIsError(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), cloudBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "x" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g.Nodes["vpc"].Schema.Backend != "cloud" {
+		t.Fatalf("Backend = %q, want cloud", g.Nodes["vpc"].Schema.Backend)
+	}
+	if _, ok := g.Nodes["vpc"].BackendConfig["path"]; !ok {
+		t.Fatalf("fill must not drop the explicit path, got %+v", g.Nodes["vpc"].BackendConfig)
+	}
+	if g.Nodes["vpc"].BackendConfig["path"] != "x" {
+		t.Fatalf("fill must not rewrite cloud path, got %+v", g.Nodes["vpc"].BackendConfig)
+	}
+	problems := Validate(g)
+	if !hasErrorContaining(problems, "backend_config is set") || !hasErrorContaining(problems, "no backend block") {
+		t.Fatalf("expected Error A for cloud, got %v", problems)
+	}
+}
+
+func TestValidate_IdenticalBackendConfigOnSharedDir(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "same.tfstate" }
+}
+node "b" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "same.tfstate" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	problems := Validate(g)
+	if !hasErrorContaining(problems, "identical backend_config") {
+		t.Fatalf("expected Error B, got %v", problems)
+	}
+	if !hasErrorContaining(problems, "a") || !hasErrorContaining(problems, "b") {
+		t.Fatalf("expected both node names, got %v", problems)
+	}
+}
+
+func TestValidate_MixedBackendConfigOnSharedDir(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "shared.tfstate" }
+}
+node "b" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "shared.tfstate" }
+}
+node "c" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "other.tfstate" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	problems := Validate(g)
+	if len(problems) != 1 {
+		t.Fatalf("expected exactly one Error B for the colliding pair, got %v", problems)
+	}
+	msg := problems[0].Message
+	if !strings.Contains(msg, "identical backend_config") {
+		t.Fatalf("expected Error B, got %q", msg)
+	}
+	if !strings.Contains(msg, "nodes a, b share") {
+		t.Fatalf("expected colliding pair a, b in %q", msg)
+	}
+	if strings.Contains(msg, "nodes a, b, c") {
+		t.Fatalf("c must not be named in the collision, got %q", msg)
+	}
+}
+
+func TestValidate_EmptyBackendConfigOnSharedDirNoBackend(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), "")
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" { source = "./stacks/vpc" }
+node "b" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasErrorContaining(Validate(g), "identical backend_config") {
+		t.Fatalf("expected Error B for empty+empty with no backend")
+	}
+}
+
+func TestValidate_EmptyBackendConfigOnSharedDirLocalIsOk(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" { source = "./stacks/vpc" }
+node "b" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g.Nodes["a"].BackendConfig["path"] == g.Nodes["b"].BackendConfig["path"] {
+		t.Fatalf("expected fill to isolate a and b, got %+v / %+v", g.Nodes["a"].BackendConfig, g.Nodes["b"].BackendConfig)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected no Error B after fill, got %v", problems)
+	}
+}
+
+func TestValidate_CopyPasteKeyOnSharedDir(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" {
+  source         = "./stacks/vpc"
+  backend_config = { key = "prod/vpc" }
+}
+node "b" {
+  source         = "./stacks/vpc"
+  backend_config = { key = "prod/vpc" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasErrorContaining(Validate(g), "identical backend_config") {
+		t.Fatalf("expected Error B for copy-paste key")
+	}
+}
+
+func TestValidate_DistinctBackendConfigOnSharedDir(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "a" }
+}
+node "b" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "b" }
+}
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected distinct maps to be valid, got %v", problems)
+	}
+}
+
+func TestValidate_UniqueDirEmptyConfigIsOk(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "stacks/vpc"), "")
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" { source = "./stacks/vpc" }
+`)
+
+	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected unique Dir with no backend to be valid, got %v", problems)
+	}
+}
+
+func TestValidate_GroupUsedTwiceWithLocal(t *testing.T) {
+	root, bpPath := setupSameGroupTwiceFixture(t)
+	bp, err := blueprint.ParseFile(bpPath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g.Nodes["first.a"].BackendConfig["path"] == g.Nodes["second.a"].BackendConfig["path"] {
+		t.Fatalf("expected distinct paths for two instances, got %+v", g.Nodes["first.a"].BackendConfig)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected clean Validate, got %v", problems)
+	}
+}
+
+func TestValidate_GroupUsedTwiceWithoutBackend(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "modules/a/main.tf"), `output "id" { value = "x" }`)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+}
+`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "g" {
+  as     = "first"
+  source = "./groups/g"
+}
+use "g" {
+  as     = "second"
+  source = "./groups/g"
+}
+`)
+
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !hasErrorContaining(Validate(g), "identical backend_config") {
+		t.Fatalf("expected Error B when the same group is used twice with no backend")
+	}
+}
+
+func hasErrorContaining(problems []Problem, substr string) bool {
+	for _, p := range problems {
+		if p.IsError() && strings.Contains(p.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/build.go
+++ b/internal/graph/build.go
@@ -76,12 +76,27 @@ func mergeEnv(base, override map[string]string) map[string]string {
 
 // Build resolves a blueprint into a Graph, recursively expanding any group instantiations (`use` blocks). baseDir is the directory the blueprint file lives in and must be absolute: it becomes the root every relative node/group source resolves against, directly or (for a node inside a group) transitively. Build fails fast if a node's source directory cannot be inspected (e.g. it doesn't exist); that is a structural problem, not something validate can usefully report alongside others.
 func Build(bp *blueprint.Blueprint, baseDir string) (*Graph, error) {
-	g, _, err := build(bp, baseDir, "", nil, nil, "", &resolveContext{})
+	g, _, err := build(bp, baseDir, "", nil, nil, nil, "", &resolveContext{rootDir: baseDir})
 	return g, err
 }
 
-// build resolves bp into a Graph, also returning this scope's own use instances (keyed by their unqualified `as` name), needed by a caller that is itself resolving a group's Export, since an export mapping may reference either a plain internal node or one of this same group's own use instances (see resolveExportEndpoint). ambient is the runtime, if any, this whole scope inherits from the `use` block that instantiated it (nil at the top level, or when that use set none): it becomes a node's Runtime when the node names no blueprint.Node.Runtime of its own, and it cascades unchanged into a nested use's own recursive build unless that nested use sets its own override (see the loop below). ambientEnv is the analogous inherited environment, except it merges rather than replaces at every layer (see mergeEnv).
-func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprint.Runtime, ambientEnv map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (*Graph, map[string]useInfo, error) {
+// fillLocalBackendPath sets path to <rootDir>/.terragraph/state/<name>.tfstate when the module declares backend "local" and cfg has no path. Explicit path wins. Returns cfg, allocating a map if needed.
+func fillLocalBackendPath(cfg map[string]string, schema *module.Schema, rootDir, name string) map[string]string {
+	if schema == nil || schema.Backend != "local" {
+		return cfg
+	}
+	if cfg["path"] != "" {
+		return cfg
+	}
+	if cfg == nil {
+		cfg = make(map[string]string, 1)
+	}
+	cfg["path"] = filepath.Join(rootDir, ".terragraph", "state", name+".tfstate")
+	return cfg
+}
+
+// build resolves bp into a Graph, also returning this scope's own use instances (keyed by their unqualified `as` name), needed by a caller that is itself resolving a group's Export, since an export mapping may reference either a plain internal node or one of this same group's own use instances (see resolveExportEndpoint). ambient is the runtime, if any, this whole scope inherits from the `use` block that instantiated it (nil at the top level, or when that use set none): it becomes a node's Runtime when the node names no blueprint.Node.Runtime of its own, and it cascades unchanged into a nested use's own recursive build unless that nested use sets its own override (see the loop below). ambientEnv is the analogous inherited environment, except it merges rather than replaces at every layer (see mergeEnv). ambientBackendConfig is the analogous inherited backend_config, merged the same way.
+func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (*Graph, map[string]useInfo, error) {
 	g := &Graph{
 		Nodes: make(map[string]*Node),
 		Out:   make(map[string][]string),
@@ -122,6 +137,7 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 		}
 		qn := cloneNode(n)
 		qn.Name = qualify(n.Name)
+		qn.BackendConfig = fillLocalBackendPath(mergeEnv(ambientBackendConfig, qn.BackendConfig), schema, rc.rootDir, qn.Name)
 
 		resolved := ambient
 		if n.Runtime != "" {
@@ -147,12 +163,13 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 			nextAmbient = &rt
 		}
 		nextAmbientEnv := mergeEnv(ambientEnv, u.Env)
+		nextAmbientBackend := mergeEnv(ambientBackendConfig, u.BackendConfig)
 		nextAmbientApprove := ambientApprove
 		if u.Approve != "" {
 			nextAmbientApprove = u.Approve
 		}
 
-		info, internal, err := resolveUse(u, baseDir, qualify(u.As), nextAmbient, nextAmbientEnv, nextAmbientApprove, rc)
+		info, internal, err := resolveUse(u, baseDir, qualify(u.As), nextAmbient, nextAmbientEnv, nextAmbientBackend, nextAmbientApprove, rc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("use %q as %q: %w", u.GroupName, u.As, err)
 		}
@@ -183,8 +200,8 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 	return g, uses, nil
 }
 
-// resolveUse loads and builds the group instantiated by u (recursing through the group's own nested `use` blocks, if any), validates it, and returns both its expanded internal graph (nodes already namespaced under instancePrefix, ready to splice into the caller's graph) and a useInfo describing how the caller's edges should resolve references to this instance. ambient is u's own resolved runtime override, if any (already merged with whatever u itself inherited from further out), the new default every node inside this instance inherits unless it names its own; ambientEnv is the analogous already-merged environment.
-func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient *blueprint.Runtime, ambientEnv map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (useInfo, *Graph, error) {
+// resolveUse loads and builds the group instantiated by u (recursing through the group's own nested `use` blocks, if any), validates it, and returns both its expanded internal graph (nodes already namespaced under instancePrefix, ready to splice into the caller's graph) and a useInfo describing how the caller's edges should resolve references to this instance. ambient is u's own resolved runtime override, if any (already merged with whatever u itself inherited from further out), the new default every node inside this instance inherits unless it names its own; ambientEnv is the analogous already-merged environment; ambientBackendConfig is the analogous already-merged backend_config.
+func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (useInfo, *Graph, error) {
 	groupDir := filepath.Join(referencingDir, u.Source)
 
 	pop, err := rc.push(groupDir, u.GroupName)
@@ -200,7 +217,7 @@ func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient 
 
 	// def.Nodes/Uses may reference a runtime by name (blueprint.Node.Runtime / blueprint.Use.Runtime); those names resolve against groupRuntimes, the `runtime` blocks declared in this same group source directory, never against whatever the outer scope that wrote u happens to have declared (see blueprint.validateRuntimes, which already enforced this scoping at parse time).
 	innerBP := &blueprint.Blueprint{Nodes: def.Nodes, Edges: def.Edges, Uses: def.Uses, Runtimes: groupRuntimes}
-	internal, innerUses, err := build(innerBP, groupDir, instancePrefix, ambient, ambientEnv, ambientApprove, rc)
+	internal, innerUses, err := build(innerBP, groupDir, instancePrefix, ambient, ambientEnv, ambientBackendConfig, ambientApprove, rc)
 	if err != nil {
 		return useInfo{}, nil, err
 	}

--- a/internal/graph/env_test.go
+++ b/internal/graph/env_test.go
@@ -19,7 +19,12 @@ func setupEnvFixture(t *testing.T) (root, blueprintPath string) {
 	t.Helper()
 	root = t.TempDir()
 
-	writeFixtureFile(t, filepath.Join(root, "modules/a/main.tf"), `output "id" { value = "x" }`)
+	writeFixtureFile(t, filepath.Join(root, "modules/a/main.tf"), `
+terraform {
+  backend "local" {}
+}
+output "id" { value = "x" }
+`)
 
 	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
 group "g" {

--- a/internal/graph/group.go
+++ b/internal/graph/group.go
@@ -14,6 +14,8 @@ type resolveContext struct {
 	stack     []string
 	groupDirs map[string]*blueprint.Blueprint
 	schemas   map[string]*module.Schema
+	// rootDir is the outer blueprint directory passed to Build, used for the local state default path. It is not the recursive baseDir used to resolve group-relative sources.
+	rootDir string
 }
 
 func (rc *resolveContext) push(dir, name string) (func(), error) {

--- a/internal/graph/group_build_test.go
+++ b/internal/graph/group_build_test.go
@@ -89,6 +89,9 @@ func setupSameGroupTwiceFixture(t *testing.T) (root, blueprintPath string) {
 	root = t.TempDir()
 
 	writeFixtureFile(t, filepath.Join(root, "modules/a/variables.tf"), `
+terraform {
+  backend "local" {}
+}
 variable "greeting" {
   type    = string
   default = ""
@@ -149,5 +152,18 @@ func TestBuild_SameGroupDirectoryUsedTwice_InstancesDontShareState(t *testing.T)
 	first.Vars["greeting"] = "mutated"
 	if second.Vars["greeting"] != "hi" {
 		t.Fatalf("mutating the first instance's Vars affected the second instance's Vars: %+v", second.Vars)
+	}
+
+	if first.BackendConfig["path"] == "" || first.BackendConfig["path"] == second.BackendConfig["path"] {
+		t.Fatalf("expected distinct filled backend paths, got %+v / %+v", first.BackendConfig, second.BackendConfig)
+	}
+	if first.BackendConfig != nil {
+		first.BackendConfig["path"] = "mutated"
+		if second.BackendConfig["path"] == "mutated" {
+			t.Fatalf("mutating the first instance's BackendConfig affected the second: %+v", second.BackendConfig)
+		}
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("expected a valid graph after fill, got problems: %v", problems)
 	}
 }

--- a/internal/graph/runtime_test.go
+++ b/internal/graph/runtime_test.go
@@ -24,6 +24,9 @@ func setupRuntimeFixture(t *testing.T) (root, blueprintPath string) {
 	root = t.TempDir()
 
 	writeFixtureFile(t, filepath.Join(root, "modules/a/main.tf"), `
+terraform {
+  backend "local" {}
+}
 output "id" { value = "x" }
 `)
 

--- a/internal/graph/validate.go
+++ b/internal/graph/validate.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 )
@@ -23,7 +24,7 @@ type Problem struct {
 // IsError reports whether this problem should block graph/plan/apply, as opposed to a Warning, which is only surfaced.
 func (p Problem) IsError() bool { return p.Severity == SeverityError }
 
-// Validate checks a built Graph for issues that Build itself does not catch: edges referencing ports that don't actually exist on the target module (Error), two data edges targeting the same input, whether their from sides differ or match (Error; checked here rather than at parse so group expansion can rewrite a use export onto leaf ports first), a node's own vars targeting a variable the module doesn't declare or one a data edge already targets (Error), cycles in the dependency graph (Error), and required variables that neither an edge nor vars ever supplies a value for (Warning: a module may legitimately get such a value from its own terraform.tfvars or the environment, outside the blueprint entirely).
+// Validate checks a built Graph for issues that Build itself does not catch: edges referencing ports that don't actually exist on the target module (Error), two data edges targeting the same input, whether their from sides differ or match (Error; checked here rather than at parse so group expansion can rewrite a use export onto leaf ports first), a node's own vars targeting a variable the module doesn't declare or one a data edge already targets (Error), cycles in the dependency graph (Error), required variables that neither an edge nor vars ever supplies a value for (Warning: a module may legitimately get such a value from its own terraform.tfvars or the environment, outside the blueprint entirely), a non-empty backend_config on a module with no backend block (Error), and two or more leaves that share a module directory and resolve to identical backend_config maps (Error).
 func Validate(g *Graph) []Problem {
 	var problems []Problem
 
@@ -119,6 +120,82 @@ func Validate(g *Graph) []Problem {
 		})
 	}
 
+	problems = append(problems, backendProblems(g)...)
+
+	return problems
+}
+
+func backendProblems(g *Graph) []Problem {
+	names := make([]string, 0, len(g.Nodes))
+	for name := range g.Nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var problems []Problem
+	byDir := map[string][]string{}
+	for _, name := range names {
+		node := g.Nodes[name]
+		if len(node.BackendConfig) > 0 {
+			backend := ""
+			if node.Schema != nil {
+				backend = node.Schema.Backend
+			}
+			if backend == "" || backend == "cloud" {
+				problems = append(problems, Problem{
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("node.%s: backend_config is set but the module declares no backend block", name),
+				})
+			}
+		}
+		if node.Dir != "" {
+			byDir[node.Dir] = append(byDir[node.Dir], name)
+		}
+	}
+
+	dirs := make([]string, 0, len(byDir))
+	for dir := range byDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		nodesInDir := byDir[dir]
+		if len(nodesInDir) < 2 {
+			continue
+		}
+		type partition struct {
+			cfg   map[string]string
+			names []string
+		}
+		var parts []partition
+		for _, name := range nodesInDir {
+			cfg := g.Nodes[name].BackendConfig
+			found := false
+			for i := range parts {
+				if maps.Equal(parts[i].cfg, cfg) {
+					parts[i].names = append(parts[i].names, name)
+					found = true
+					break
+				}
+			}
+			if !found {
+				parts = append(parts, partition{cfg: cfg, names: []string{name}})
+			}
+		}
+		for _, p := range parts {
+			if len(p.names) < 2 {
+				continue
+			}
+			problems = append(problems, Problem{
+				Severity: SeverityError,
+				Message: fmt.Sprintf(
+					"%s: nodes %s share this module directory but resolve to identical backend_config",
+					dir, strings.Join(p.names, ", "),
+				),
+			})
+		}
+	}
 	return problems
 }
 

--- a/internal/language/workspace.go
+++ b/internal/language/workspace.go
@@ -347,6 +347,7 @@ var completionSchemas = map[string][]attributeSpec{
 	"use": {
 		{name: "as", insert: "as = \"\"", detail: "required string", documentation: "Namespace used to refer to this group instance."},
 		{name: "source", insert: "source = \"\"", detail: "required string", documentation: "Local path or remote source containing the group."},
+		{name: "backend_config", insert: "backend_config = {\n}", detail: "map(string)", documentation: "Backend configuration merged onto every node this instance expands to. Leaf keys win."},
 		{name: "runtime", insert: "runtime = runtime.", detail: "runtime reference", documentation: "Default runtime for nodes expanded from this group."},
 		{name: "env", insert: "env = {\n}", detail: "map(string)", documentation: "Environment variables inherited by nodes expanded from this group."},
 		{name: "vars", insert: "vars = {\n}", detail: "object", documentation: "Literal values for this instance's export inputs. Use an edge for another node's output."},

--- a/internal/module/inspect.go
+++ b/internal/module/inspect.go
@@ -3,7 +3,12 @@ package module
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
@@ -27,11 +32,13 @@ type Output struct {
 	Deprecated  string
 }
 
-// Schema is the subset of a root module's shape that terragraph cares about: its declared input variables (with type/required metadata) and the names of its output values. Standard root module outputs don't declare a type (that's an HCP Terraform Stacks-only feature), so Outputs only tracks presence.
+// Schema is the subset of a root module's shape that terragraph cares about: its declared input variables (with type/required metadata), the names of its output values, and the backend type if any. Standard root module outputs don't declare a type (that's an HCP Terraform Stacks-only feature), so Outputs only tracks presence.
 type Schema struct {
 	Variables     map[string]Variable
 	Outputs       map[string]bool
 	OutputDetails map[string]Output
+	// Backend is the type label of terraform { backend "TYPE" {} }, or "cloud" if the module declared a cloud block and no backend block. Empty means neither was declared (Terraform's implicit local backend). Attributes inside the block are not captured.
+	Backend string
 }
 
 // Inspect statically parses the root module at dir and returns its variable/output schema.
@@ -60,7 +67,78 @@ func Inspect(dir string) (*Schema, error) {
 		schema.Outputs[name] = true
 		schema.OutputDetails[name] = Output{Name: name, Type: output.Type, Description: output.Description, Sensitive: output.Sensitive, Deprecated: output.Deprecated}
 	}
+	schema.Backend = inspectBackend(dir)
 	return schema, nil
+}
+
+var terraformFileSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{{Type: "terraform"}},
+}
+
+var terraformBackendSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "backend", LabelNames: []string{"type"}},
+		{Type: "cloud"},
+	},
+}
+
+// inspectBackend returns the module's backend type label, "cloud" if only a cloud block is present, or "" if neither was declared. terraform-config-inspect does not expose this; we scan .tf / .tf.json ourselves and ignore backend attributes.
+func inspectBackend(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	parser := hclparse.NewParser()
+	backend := ""
+	cloud := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || strings.HasSuffix(name, "~") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var file *hcl.File
+		var diags hcl.Diagnostics
+		switch {
+		case strings.HasSuffix(name, ".tf.json"):
+			file, diags = parser.ParseJSON(src, path)
+		case strings.HasSuffix(name, ".tf"):
+			file, diags = parser.ParseHCL(src, path)
+		default:
+			continue
+		}
+		if diags.HasErrors() || file == nil {
+			continue
+		}
+		content, _, _ := file.Body.PartialContent(terraformFileSchema)
+		for _, block := range content.Blocks {
+			inner, _, _ := block.Body.PartialContent(terraformBackendSchema)
+			for _, b := range inner.Blocks {
+				switch b.Type {
+				case "backend":
+					if len(b.Labels) > 0 && b.Labels[0] != "" {
+						backend = b.Labels[0]
+					}
+				case "cloud":
+					cloud = true
+				}
+			}
+		}
+	}
+	if backend != "" {
+		return backend
+	}
+	if cloud {
+		return "cloud"
+	}
+	return ""
 }
 
 // HasOutput reports whether the module declares an output with this name.

--- a/internal/module/inspect_test.go
+++ b/internal/module/inspect_test.go
@@ -55,4 +55,101 @@ output "id" {
 	if schema.HasOutput("does_not_exist") {
 		t.Fatalf("expected no output named does_not_exist")
 	}
+	if schema.Backend != "" {
+		t.Fatalf("expected no backend, got %q", schema.Backend)
+	}
+}
+
+func TestInspect_BackendTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		content string
+		want    string
+	}{
+		{
+			name:    "no backend block",
+			file:    "main.tf",
+			content: `output "id" { value = "x" }`,
+			want:    "",
+		},
+		{
+			name: "empty local",
+			file: "main.tf",
+			content: `
+terraform {
+  backend "local" {}
+}
+output "id" { value = "x" }
+`,
+			want: "local",
+		},
+		{
+			name: "s3",
+			file: "main.tf",
+			content: `
+terraform {
+  backend "s3" {}
+}
+output "id" { value = "x" }
+`,
+			want: "s3",
+		},
+		{
+			name: "cloud",
+			file: "main.tf",
+			content: `
+terraform {
+  cloud {}
+}
+output "id" { value = "x" }
+`,
+			want: "cloud",
+		},
+		{
+			name: "tf.json local",
+			file: "terraform.tf.json",
+			content: `{
+  "terraform": {
+    "backend": {
+      "local": {}
+    }
+  },
+  "output": {
+    "id": { "value": "x" }
+  }
+}
+`,
+			want: "local",
+		},
+		{
+			name: "tf.json s3",
+			file: "terraform.tf.json",
+			content: `{
+  "terraform": {
+    "backend": {
+      "s3": {}
+    }
+  }
+}
+`,
+			want: "s3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tt.file), []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("writing fixture: %v", err)
+			}
+			schema, err := Inspect(dir)
+			if err != nil {
+				t.Fatalf("Inspect: %v", err)
+			}
+			if schema.Backend != tt.want {
+				t.Fatalf("Backend = %q, want %q", schema.Backend, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Nodes that share a module directory no longer share Terraform state.

- Inspect the module's `backend` type (or `cloud` / absence) without generating `.tf`.
- `use.backend_config` merges onto expanded leaves the same way `use.env` does (leaf keys win).
- If the module declares `backend "local"` and the leaf has no `path`, fill an absolute `<blueprint>/.terragraph/state/<qualified-node>.tfstate`.
- Validate Errors (not Warnings):
  - non-empty `backend_config` when the module has no `backend` block (including `cloud`)
  - two or more leaves on the same `Dir` with identical resolved maps, including both empty (mixed maps still error only the colliding subset)

Docs drop "silently ignored". `examples/reuse` uses the local default. `examples/group` instantiates the group twice so isolation is visible.

## How to verify

```
make check
go run ./cmd/terragraph validate --blueprint examples/reuse
go run ./cmd/terragraph validate --blueprint examples/group
go run ./cmd/terragraph graph --blueprint examples/group
```

Expected graph:

```
level 1: vpc
level 2: checkout.cluster, payments.cluster
level 3: checkout.nodegroup, payments.nodegroup
```

## Breaking change

Modules that already declare `backend "local"` and keep `terraform.tfstate` in the module directory will, on the next `plan`/`apply`, point at `.terragraph/state/<node>.tfstate`. Migrate with `terraform init -migrate-state` per node if you need the old state.

Closes #35