### PR TITLE
docs: contrast terragraph with terraform_remote_state in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Release](https://img.shields.io/github/v/release/cloudfluent/terragraph)](https://github.com/cloudfluent/terragraph/releases) [![CI](https://github.com/cloudfluent/terragraph/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfluent/terragraph/actions/workflows/ci.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/cloudfluent/terragraph.svg)](https://pkg.go.dev/github.com/cloudfluent/terragraph) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-Split infrastructure into independent Terraform modules and you lose the one thing a single workspace gives you for free: one module's outputs feeding straight into another's inputs. In practice that gap gets closed by hand: `apply`, copy a value, paste it into the next module's tfvars, repeat. Or it gets closed by giving up the isolation and merging everything back into one giant workspace.
+Split infrastructure into independent Terraform modules and you lose the one thing a single workspace gives you for free: one module's outputs feeding straight into another's inputs. That gap gets closed one of three ways. By hand — `apply`, copy a value, paste it into the next module's tfvars, repeat. With `terraform_remote_state`, which trades the copying for a dependency written into the consumer's code: it names the producer's backend and needs read access to its entire state file, so the module no longer stands on its own. Or by giving up the isolation and merging everything back into one giant workspace.
 
-terragraph closes that gap without either tradeoff. Every root module stays completely standalone (its own backend, its own providers, its own resources), and a separate file declares the **wiring**: which output feeds which input. terragraph reads that file, works out the dependency order, and passes the real values through automatically as it applies each module.
+terragraph closes that gap without any of the three tradeoffs. Every root module stays completely standalone — its own backend, its own providers, its own resources, no reference to any other module — and a separate file declares the **wiring**: which output feeds which input. terragraph reads that file, works out the dependency order, and passes the real values through automatically as it applies each module, with no generated code and no shared state.
 
 ## Install
 
@@ -44,7 +44,7 @@ edge {
 terragraph apply --parallelism 2 --auto-approve
 ```
 
-`terragraph` resolves the graph, runs `terraform`/`tofu` for each node in dependency order, and passes `vpc`'s real `vpc_id` output into `eks`'s input at runtime, with no generated code and no shared state file. See [`examples/basic`](examples/basic) for this exact setup running end to end.
+`terragraph` resolves the graph, runs `terraform`/`tofu` for each node in dependency order, and passes `vpc`'s real `vpc_id` output into `eks`'s input at runtime. See [`examples/basic`](examples/basic) for this exact setup running end to end.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- README opening now names the three usual ways people close the module-to-module wiring gap: copy-paste, `terraform_remote_state`, or one giant workspace.
- Positions terragraph against all three: each root module stays standalone (no generated code, no shared state, no reference to another module), with wiring declared separately.

## Test plan
- [x] README-only wording change; no code or docs-generation paths touched.