### PR TITLE
ci: label issues from the bug form's OS and runtime fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      description: Which binary terragraph shelled out to. Pick "Both" only if you reproduced it on each.
+      options:
+        - Terraform
+        - OpenTofu
+        - Both
+    validations:
+      required: true
+
   - type: input
     id: tf-version
     attributes:
@@ -43,10 +55,25 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: dropdown
     id: os
     attributes:
-      label: OS / architecture
-      placeholder: "macOS 15 arm64, Ubuntu 24.04 amd64, ..."
+      label: Operating system
+      description: Pick every one you actually reproduced this on. Choose WSL on its own rather than also picking Linux or Windows, unless you confirmed those separately.
+      multiple: true
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - WSL
+        - Other
     validations:
       required: true
+
+  - type: input
+    id: os-detail
+    attributes:
+      label: OS version and architecture
+      placeholder: "macOS 15.2 arm64, Ubuntu 24.04 amd64, ..."
+    validations:
+      required: false

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,76 @@
+name: Label issues from form fields
+
+# The bug report form asks for OS and runtime as dropdowns, so those two labels
+# are a lookup, not a judgment call. Doing them here keeps them off the agent
+# labeler, which then only has to decide the `area:*` label that actually needs
+# reading the issue.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue to re-label"
+        required: true
+        type: number
+
+permissions:
+  issues: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.eventName === 'workflow_dispatch'
+              ? Number(context.payload.inputs.issue_number)
+              : context.payload.issue.number;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner, repo, issue_number: number,
+            });
+            const body = issue.body || '';
+
+            // Issue forms render each answer as "### <label>" followed by the value,
+            // and an unanswered optional field as "_No response_".
+            const answer = (heading) => {
+              const match = body.match(new RegExp(`^### ${heading}\\s*\\n+([^#]*)`, 'm'));
+              return match ? match[1].trim() : '';
+            };
+
+            const OS = { macos: 'os:macos', linux: 'os:linux', windows: 'os:windows', wsl: 'os:wsl' };
+            const RUNTIME = { terraform: 'runtime:terraform', opentofu: 'runtime:tofu' };
+
+            const desired = new Set();
+            for (const choice of answer('Operating system').split(',')) {
+              const label = OS[choice.trim().toLowerCase()];
+              if (label) desired.add(label);
+            }
+            const runtime = answer('Runtime').toLowerCase();
+            if (runtime === 'both') {
+              desired.add(RUNTIME.terraform);
+              desired.add(RUNTIME.opentofu);
+            } else if (RUNTIME[runtime]) {
+              desired.add(RUNTIME[runtime]);
+            }
+
+            // Only ever replace labels this workflow owns. Triage labels applied by
+            // hand or by the agent have to survive an edit to the form.
+            const managed = [...Object.values(OS), ...Object.values(RUNTIME)];
+            const existing = issue.labels.map((l) => (typeof l === 'string' ? l : l.name));
+            const next = [...new Set([...existing.filter((l) => !managed.includes(l)), ...desired])];
+
+            const unchanged = next.length === existing.length && next.every((l) => existing.includes(l));
+            if (unchanged) {
+              core.info(`#${number}: labels already correct`);
+              return;
+            }
+
+            await github.rest.issues.setLabels({ owner, repo, issue_number: number, labels: next });
+            core.info(`#${number}: ${next.join(', ')}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 Bug reports and feature requests go through the templates GitHub shows when you click "New issue" (free-form issues are disabled, so there's always one of these). Fill in what's asked, especially `terragraph --version` and a minimal `blueprint.hcl` for bug reports: without a repro, a bug report usually just sits until someone can construct one.
 
+If an issue picks up the `needs-repro` label, that is the ball being handed back to you: nobody could reproduce the problem from what is there yet. Reply with the missing blueprint or command and it goes back into the queue.
+
 ## Making a change
 
 External contributors: fork the repo and branch from `main`. Maintainers: branch directly on `origin`. Either way, branch names aren't enforced (a fork's branch lives outside this repo's server-side rules, so a name check would only ever apply unevenly); name it however's useful to you.


### PR DESCRIPTION
## Summary

The bug form asked for OS and runtime as free text, so neither could be labeled without guessing. Both are dropdowns now, and a small `github-script` step turns them into `os:*` and `runtime:*` labels on open, edit and reopen. The point is to leave the agent labeler with only the `area:*` call, which is the one that needs someone to actually read the issue; a lookup shouldn't cost a model round trip or be able to hallucinate.

WSL is its own option rather than a flavor of Linux or Windows, because a WSL-only reproduction usually points at something different from either.

## Verification

The step replaces only the labels it owns, so triage labels applied by hand or by the agent survive a form edit. Ran the parsing logic against rendered form bodies covering every dropdown combination:

```
os="macOS"            runtime=Terraform     -> [os:macos, runtime:terraform]
os="macOS, WSL"       runtime=OpenTofu      -> [os:macos, os:wsl, runtime:tofu]
os="Linux, Windows"   runtime=Both          -> [os:linux, os:windows, runtime:terraform, runtime:tofu]
os="Other"            runtime=Terraform     -> [runtime:terraform]
os="_No response_"    runtime=_No response_ -> []
os="WSL"              runtime=OpenTofu      -> [os:wsl, runtime:tofu]
```

`Other` and an unanswered dropdown apply nothing rather than forcing a label. Both YAML files parse, and the six labels already exist on the repo.

- [ ] `make check` passes locally (fmt, lint, docs, build, test)

## Checklist

- [ ] Tests added or updated for the behavior change
- [x] `docs/*.md` updated if this changes blueprint semantics, CLI flags, or an example's output (see [CONTRIBUTING.md](../CONTRIBUTING.md))