### PR TITLE
feat: add two-sided contracts to data edges

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -96,7 +96,7 @@ edge {
 }
 ```
 
-Both blocks and all three fields are required when `contract` is present. `type` is a quoted Terraform type constraint such as `"string"`, `"list(string)"`, or `"object({ id = string })"`. Validation reports an Error when the producer type cannot be safely converted to the consumer type, when a nullable producer feeds a non-nullable consumer, or when a sensitive producer feeds a consumer that does not accept sensitive values. When Terraform module metadata exposes the endpoint type or sensitivity, the contract is also checked against that declaration.
+Both blocks and all three fields are required when `contract` is present. `type` is a quoted Terraform type constraint such as `"string"`, `"list(string)"`, or `"object({ id = string })"`. Validation reports an Error when the producer type cannot be safely converted to the consumer type, when a nullable producer feeds a non-nullable consumer, or when a sensitive producer feeds a consumer that does not accept sensitive values. When Terraform module metadata exposes endpoint types or source-output sensitivity, the contract is also checked against that declaration. A target variable's `sensitive` flag is not an input constraint: Terraform can pass a sensitive value into an ordinary variable and continues to propagate its sensitivity.
 
 Contracts are only valid on data edges. Ordering-only edges carry no value to describe. An edge using nested `input` shorthand declares the contract inside each input, because each expanded binding can have a different agreement:
 

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -72,6 +72,60 @@ When you own both modules, the better reduction is still one `object`-typed outp
 
 Either endpoint may be a group instance (`use.<name>`), and each expanded edge then resolves through that instance's `export` exactly as a separately written one would, fan-out included: see [groups.md](groups.md).
 
+## Optional contracts on data edges
+
+A data edge may declare an optional two-sided contract. The graph remains directed from `from` to `to`: `producer` records what the source output guarantees, and `consumer` records what the target input accepts. This adds validation at the boundary; it does not create a reverse edge or change execution order.
+
+```hcl
+edge {
+  from = node.vpc.output.vpc_id
+  to   = node.eks.input.vpc_id
+
+  contract {
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}
+```
+
+Both blocks and all three fields are required when `contract` is present. `type` is a quoted Terraform type constraint such as `"string"`, `"list(string)"`, or `"object({ id = string })"`. Validation reports an Error when the producer type cannot be safely converted to the consumer type, when a nullable producer feeds a non-nullable consumer, or when a sensitive producer feeds a consumer that does not accept sensitive values. When Terraform module metadata exposes the endpoint type or sensitivity, the contract is also checked against that declaration.
+
+Contracts are only valid on data edges. Ordering-only edges carry no value to describe. An edge using nested `input` shorthand declares the contract inside each input, because each expanded binding can have a different agreement:
+
+```hcl
+edge {
+  from = node.vpc
+  to   = node.eks
+
+  input "vpc_id" {
+    from = output.vpc_id
+
+    contract {
+      producer {
+        type      = "string"
+        nullable  = false
+        sensitive = false
+      }
+      consumer {
+        type      = "string"
+        nullable  = false
+        sensitive = false
+      }
+    }
+  }
+}
+```
+
+Omitting `contract` preserves existing edge behavior. Contracts also survive `use` export expansion and fan-out, so validation is applied to every resulting leaf binding.
+
 ## Reusing the same module across instances
 
 A node can reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding. If the module declares `backend "local"` (an empty block is enough) and the node does not set `path`, terragraph fills `path` to `<blueprint dir>/.terragraph/state/<node>.tfstate` (absolute) and passes it as `terraform init -backend-config=path=...`. An explicit `path` wins.

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -37,6 +37,8 @@ edge {
 }
 ```
 
+Data edges also complete an optional [`contract`](blueprint.md#optional-contracts-on-data-edges) block. Inside it, completion offers the required `producer` and `consumer` blocks and their `type`, `nullable`, and `sensitive` fields. The same completion is available inside each nested `input` block.
+
 ## Go to definition
 
 `Cmd+Click` (macOS), `Ctrl+Click` (Windows/Linux), or `F12` on `node.vpc` or `runtime.tofu` jumps to its declaration, including nodes and runtimes declared in another `.hcl` file in the same blueprint directory.

--- a/examples/basic/blueprint.hcl
+++ b/examples/basic/blueprint.hcl
@@ -13,6 +13,19 @@ node "eks2" {
 edge {
   from = node.vpc.output.vpc_id
   to   = node.eks.input.vpc_id
+
+  contract {
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
 }
 
 edge {

--- a/internal/blueprint/edge_contract_test.go
+++ b/internal/blueprint/edge_contract_test.go
@@ -1,0 +1,214 @@
+package blueprint
+
+import (
+	"strings"
+	"testing"
+)
+
+const completeEdgeContract = `
+  contract {
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = true
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = true
+    }
+  }
+`
+
+func TestParseFile_DataEdgeContract(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a.output.id
+  to   = node.b.input.id
+`+completeEdgeContract+`}
+`)
+
+	bp, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	contract := bp.Edges[0].Contract
+	if contract == nil {
+		t.Fatal("expected edge contract")
+	}
+	if contract.Producer.Type != "string" || contract.Producer.Nullable || !contract.Producer.Sensitive {
+		t.Fatalf("unexpected producer contract: %+v", contract.Producer)
+	}
+	if contract.Consumer.Type != "string" || contract.Consumer.Nullable || !contract.Consumer.Sensitive {
+		t.Fatalf("unexpected consumer contract: %+v", contract.Consumer)
+	}
+}
+
+func TestParseFile_NestedInputContract(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a
+  to   = node.b
+  input "id" {
+    from = output.id
+`+completeEdgeContract+`  }
+}
+`)
+
+	bp, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(bp.Edges) != 1 || bp.Edges[0].Contract == nil {
+		t.Fatalf("expected expanded edge contract, got %+v", bp.Edges)
+	}
+}
+
+func TestParseFile_OrderingEdgeContractRejected(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a
+  to   = node.b
+`+completeEdgeContract+`}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "data edge") {
+		t.Fatalf("error = %v, want data-edge contract rejection", err)
+	}
+}
+
+func TestParseFile_EdgeContractRequiresBothRoles(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a.output.id
+  to   = node.b.input.id
+  contract {
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "consumer") {
+		t.Fatalf("error = %v, want missing consumer error", err)
+	}
+}
+
+func TestParseFile_EdgeContractRequiresEveryField(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a.output.id
+  to   = node.b.input.id
+  contract {
+    producer {
+      type     = "string"
+      nullable = false
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "sensitive") {
+		t.Fatalf("error = %v, want missing sensitive error", err)
+	}
+}
+
+func TestParseFile_EdgeContractRejectsInvalidTypeConstraint(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a.output.id
+  to   = node.b.input.id
+  contract {
+    producer {
+      type      = "not_a_terraform_type"
+      nullable  = false
+      sensitive = false
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "type") || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("error = %v, want invalid type constraint error", err)
+	}
+}
+
+func TestParseFile_EdgeContractRejectsDuplicateRole(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a.output.id
+  to   = node.b.input.id
+  contract {
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+    producer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+    consumer {
+      type      = "string"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "exactly one producer") {
+		t.Fatalf("error = %v, want duplicate producer error", err)
+	}
+}
+
+func TestParseFile_ParentContractWithInputBlocksRejected(t *testing.T) {
+	path := writeTemp(t, `
+node "a" { source = "./a" }
+node "b" { source = "./b" }
+edge {
+  from = node.a
+  to   = node.b
+`+completeEdgeContract+`
+  input "id" { from = output.id }
+}
+`)
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "inside the input block") {
+		t.Fatalf("error = %v, want per-input contract error", err)
+	}
+}

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -80,11 +81,28 @@ var edgeSchema = &hcl.BodySchema{
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "input", LabelNames: []string{"name"}},
+		{Type: "contract"},
 	},
 }
 
 var edgeInputSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{{Name: "from", Required: true}},
+	Blocks:     []hcl.BlockHeaderSchema{{Type: "contract"}},
+}
+
+var edgeContractSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "producer"},
+		{Type: "consumer"},
+	},
+}
+
+var contractSideSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "type", Required: true},
+		{Name: "nullable", Required: true},
+		{Name: "sensitive", Required: true},
+	},
 }
 
 var groupBodySchema = &hcl.BodySchema{
@@ -753,7 +771,14 @@ func parseEdgeBlock(block *hcl.Block) ([]Edge, error) {
 		return nil, err
 	}
 
+	contracts := content.Blocks.OfType("contract")
+	if len(contracts) > 1 {
+		return nil, fmt.Errorf("%s: duplicate contract block", contracts[1].DefRange)
+	}
 	if inputs := content.Blocks.OfType("input"); len(inputs) > 0 {
+		if len(contracts) > 0 {
+			return nil, fmt.Errorf("%s: an edge with nested input blocks declares each contract inside the input block", contracts[0].DefRange)
+		}
 		return parseEdgeInputs(block, inputs, from, to)
 	}
 
@@ -774,7 +799,19 @@ func parseEdgeBlock(block *hcl.Block) ([]Edge, error) {
 		}
 	}
 
-	return []Edge{{From: from, To: to}}, nil
+	var contract *EdgeContract
+	if len(contracts) == 1 {
+		if !from.IsPort() {
+			return nil, fmt.Errorf("%s: a contract can only be declared on a data edge", contracts[0].DefRange)
+		}
+		parsed, err := parseEdgeContract(contracts[0])
+		if err != nil {
+			return nil, err
+		}
+		contract = &parsed
+	}
+
+	return []Edge{{From: from, To: to, Contract: contract}}, nil
 }
 
 // parseEdgeInputs expands an edge's nested `input "<var>" { from = output.<attr> }` blocks into one data edge each, between the same pair of endpoints the enclosing edge names. The shape deliberately mirrors a group's export input: a block label naming the destination input, and one attribute saying where the value comes from. Its purpose is only to stop a pair of modules that already expose many flat variables from needing one near-identical `edge` block per variable; nothing about the resulting graph differs from having written them out.
@@ -806,12 +843,83 @@ func parseEdgeInputs(block *hcl.Block, inputs hcl.Blocks, from, to PortRef) ([]E
 			return nil, err
 		}
 
+		contracts := ic.Blocks.OfType("contract")
+		if len(contracts) > 1 {
+			return nil, fmt.Errorf("%s: duplicate contract block", contracts[1].DefRange)
+		}
+		var contract *EdgeContract
+		if len(contracts) == 1 {
+			parsed, err := parseEdgeContract(contracts[0])
+			if err != nil {
+				return nil, err
+			}
+			contract = &parsed
+		}
+
 		edges = append(edges, Edge{
-			From: PortRef{Entity: from.Entity, Node: from.Node, Kind: PortOutput, Name: output},
-			To:   PortRef{Entity: to.Entity, Node: to.Node, Kind: PortInput, Name: name},
+			From:     PortRef{Entity: from.Entity, Node: from.Node, Kind: PortOutput, Name: output},
+			To:       PortRef{Entity: to.Entity, Node: to.Node, Kind: PortInput, Name: name},
+			Contract: contract,
 		})
 	}
 	return edges, nil
+}
+
+func parseEdgeContract(block *hcl.Block) (EdgeContract, error) {
+	content, diags := block.Body.Content(edgeContractSchema)
+	if diags.HasErrors() {
+		return EdgeContract{}, fmt.Errorf("%s: %s", block.DefRange, diags.Error())
+	}
+	producers := content.Blocks.OfType("producer")
+	consumers := content.Blocks.OfType("consumer")
+	if len(producers) != 1 || len(consumers) != 1 {
+		return EdgeContract{}, fmt.Errorf("%s: contract requires exactly one producer block and one consumer block", block.DefRange)
+	}
+	producer, err := parseContractSide(producers[0], "producer")
+	if err != nil {
+		return EdgeContract{}, err
+	}
+	consumer, err := parseContractSide(consumers[0], "consumer")
+	if err != nil {
+		return EdgeContract{}, err
+	}
+	return EdgeContract{Producer: producer, Consumer: consumer}, nil
+}
+
+func parseContractSide(block *hcl.Block, role string) (ContractSide, error) {
+	content, diags := block.Body.Content(contractSideSchema)
+	if diags.HasErrors() {
+		return ContractSide{}, fmt.Errorf("%s: %s", block.DefRange, diags.Error())
+	}
+	typeValue, diags := content.Attributes["type"].Expr.Value(nil)
+	if diags.HasErrors() || typeValue.IsNull() || typeValue.Type() != cty.String {
+		return ContractSide{}, fmt.Errorf("%s: contract %s type must be a literal string", content.Attributes["type"].Range, role)
+	}
+	typeName := typeValue.AsString()
+	typeExpr, typeDiags := hclsyntax.ParseExpression([]byte(typeName), "<contract type>", hcl.InitialPos)
+	if typeDiags.HasErrors() {
+		return ContractSide{}, fmt.Errorf("%s: contract %s type %q is invalid: %s", content.Attributes["type"].Range, role, typeName, typeDiags.Error())
+	}
+	if _, typeDiags = typeexpr.TypeConstraint(typeExpr); typeDiags.HasErrors() {
+		return ContractSide{}, fmt.Errorf("%s: contract %s type %q is invalid: %s", content.Attributes["type"].Range, role, typeName, typeDiags.Error())
+	}
+	readBool := func(name string) (bool, error) {
+		attr := content.Attributes[name]
+		value, valueDiags := attr.Expr.Value(nil)
+		if valueDiags.HasErrors() || value.IsNull() || value.Type() != cty.Bool {
+			return false, fmt.Errorf("%s: contract %s %s must be a literal bool", attr.Range, role, name)
+		}
+		return value.True(), nil
+	}
+	nullable, err := readBool("nullable")
+	if err != nil {
+		return ContractSide{}, err
+	}
+	sensitive, err := readBool("sensitive")
+	if err != nil {
+		return ContractSide{}, err
+	}
+	return ContractSide{Type: typeName, Nullable: nullable, Sensitive: sensitive}, nil
 }
 
 // parseRelativeOutputRef reads the `from = output.<attr>` attribute of an edge's nested input block and returns just the attribute name. The reference is relative on purpose: the enclosing edge already names exactly one source, so repeating it on every nested block would add a second place for it to disagree with itself. An absolute reference is rejected rather than accepted-if-it-matches, so there is only ever one spelling to read.

--- a/internal/blueprint/types.go
+++ b/internal/blueprint/types.go
@@ -78,8 +78,22 @@ func IsRemote(src string) bool {
 //
 // One Edge is not necessarily one `edge` block: a block wiring several outputs of one node into several inputs of another can spell that as nested `input` blocks, which parseEdgeInputs expands into one Edge each before any of this package's callers see them. There is deliberately no field here recording that, so no consumer of a Blueprint can behave differently depending on how a pair of ports was written.
 type Edge struct {
-	From PortRef
-	To   PortRef
+	From     PortRef
+	To       PortRef
+	Contract *EdgeContract
+}
+
+// ContractSide is one half of an edge-local contract: the producer guarantees what its output may carry, while the consumer states what its input accepts.
+type ContractSide struct {
+	Type      string
+	Nullable  bool
+	Sensitive bool
+}
+
+// EdgeContract makes one directed data binding a two-sided agreement without changing the graph's execution direction.
+type EdgeContract struct {
+	Producer ContractSide
+	Consumer ContractSide
 }
 
 // IsDataEdge reports whether this edge carries a value (explicit) as opposed to only constraining execution order (implicit).

--- a/internal/graph/contract.go
+++ b/internal/graph/contract.go
@@ -1,0 +1,91 @@
+package graph
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// edgeContractProblems checks the reviewed boundary against both endpoint modules so a contract cannot be internally compatible while contradicting the Terraform configuration that will execute it.
+func edgeContractProblems(g *Graph) []Problem {
+	var problems []Problem
+	for _, edge := range g.Edges {
+		if edge.Contract == nil {
+			continue
+		}
+		if !edge.IsDataEdge() {
+			problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s -> %s: contract is only valid on a data edge; remove it or name output and input ports", edge.From, edge.To)})
+			continue
+		}
+
+		producer := edge.Contract.Producer
+		consumer := edge.Contract.Consumer
+		compatible, err := safelyConvertible(producer.Type, consumer.Type)
+		if err != nil {
+			problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s -> %s: invalid contract type: %v", edge.From, edge.To, err)})
+		} else if !compatible {
+			problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s (%s) -> %s (%s): contract types are not safely convertible; change the producer guarantee or consumer requirement", edge.From, producer.Type, edge.To, consumer.Type)})
+		}
+		if producer.Nullable && !consumer.Nullable {
+			problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s -> %s: producer may be null but consumer requires non-null; change one side of the contract", edge.From, edge.To)})
+		}
+		if producer.Sensitive && !consumer.Sensitive {
+			problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s -> %s: producer is sensitive but consumer does not accept sensitive values; mark the consumer sensitive or remove the binding", edge.From, edge.To)})
+		}
+
+		from := g.Nodes[edge.From.Node]
+		if output, ok := from.Schema.OutputDetails[edge.From.Name]; ok {
+			if output.Type != "" {
+				proven, typeErr := safelyConvertible(output.Type, producer.Type)
+				if typeErr != nil || !proven {
+					problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: producer contract type %s does not match module output type %s; update the contract or output", edge.From, producer.Type, output.Type)})
+				}
+			}
+			if output.Sensitive && !producer.Sensitive {
+				problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: module output is sensitive but producer contract is not; set sensitive = true", edge.From)})
+			}
+		}
+
+		to := g.Nodes[edge.To.Node]
+		if input, ok := to.Schema.Variables[edge.To.Name]; ok {
+			if input.Type != "" {
+				accepted, typeErr := safelyConvertible(consumer.Type, input.Type)
+				if typeErr != nil || !accepted {
+					problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: consumer contract type %s does not match module input type %s; update the contract or variable", edge.To, consumer.Type, input.Type)})
+				}
+			}
+			if consumer.Sensitive && !input.Sensitive {
+				problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: consumer accepts sensitive values but module input is not declared sensitive; set sensitive = true on the variable", edge.To)})
+			}
+		}
+	}
+	return problems
+}
+
+func safelyConvertible(from, to string) (bool, error) {
+	fromType, err := contractType(from)
+	if err != nil {
+		return false, err
+	}
+	toType, err := contractType(to)
+	if err != nil {
+		return false, err
+	}
+	return fromType.Equals(toType) || convert.GetConversion(fromType, toType) != nil, nil
+}
+
+func contractType(raw string) (cty.Type, error) {
+	expr, diags := hclsyntax.ParseExpression([]byte(raw), "<contract type>", hcl.InitialPos)
+	if diags.HasErrors() {
+		return cty.NilType, fmt.Errorf("type %q is invalid: %s", raw, diags.Error())
+	}
+	resolved, diags := typeexpr.TypeConstraint(expr)
+	if diags.HasErrors() {
+		return cty.NilType, fmt.Errorf("type %q is invalid: %s", raw, diags.Error())
+	}
+	return resolved, nil
+}

--- a/internal/graph/contract.go
+++ b/internal/graph/contract.go
@@ -58,9 +58,6 @@ func edgeContractProblems(g *Graph) []Problem {
 					problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: consumer contract type %s does not match module input type %s; update the contract or variable", edge.To, consumer.Type, input.Type)})
 				}
 			}
-			if consumer.Sensitive && !input.Sensitive {
-				problems = append(problems, Problem{Severity: SeverityError, Message: fmt.Sprintf("%s: consumer accepts sensitive values but module input is not declared sensitive; set sensitive = true on the variable", edge.To)})
-			}
 		}
 	}
 	return problems

--- a/internal/graph/contract_test.go
+++ b/internal/graph/contract_test.go
@@ -1,0 +1,140 @@
+package graph
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/module"
+)
+
+func contractedEdge(producerType, consumerType string, producerNullable, consumerNullable, producerSensitive, consumerSensitive bool) blueprint.Edge {
+	edge := dataEdge("a", "id", "b", "id")
+	edge.Contract = &blueprint.EdgeContract{
+		Producer: blueprint.ContractSide{Type: producerType, Nullable: producerNullable, Sensitive: producerSensitive},
+		Consumer: blueprint.ContractSide{Type: consumerType, Nullable: consumerNullable, Sensitive: consumerSensitive},
+	}
+	return edge
+}
+
+func contractGraph(edge blueprint.Edge) *Graph {
+	g := newGraph([]string{"a", "b"}, []blueprint.Edge{edge})
+	g.Nodes["a"].Schema.Outputs["id"] = true
+	g.Nodes["a"].Schema.OutputDetails = map[string]module.Output{"id": {Name: "id"}}
+	g.Nodes["b"].Schema.Variables["id"] = module.Variable{Name: "id", Type: "string"}
+	return g
+}
+
+func contractMessages(g *Graph) string {
+	problems := Validate(g)
+	messages := make([]string, len(problems))
+	for i, problem := range problems {
+		messages[i] = problem.Message
+	}
+	return strings.Join(messages, "\n")
+}
+
+func TestValidate_CompatibleEdgeContract(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, false, false))
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
+func TestValidate_EdgeContractRejectsUnsafeTypeConversion(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "number", false, false, false, false))
+	if got := contractMessages(g); !strings.Contains(got, "types are not safely convertible") {
+		t.Fatalf("problems = %q, want type incompatibility", got)
+	}
+}
+
+func TestValidate_EdgeContractRejectsNullableProducer(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", true, false, false, false))
+	if got := contractMessages(g); !strings.Contains(got, "may be null") {
+		t.Fatalf("problems = %q, want nullability incompatibility", got)
+	}
+}
+
+func TestValidate_EdgeContractRejectsSensitiveProducer(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, true, false))
+	if got := contractMessages(g); !strings.Contains(got, "does not accept sensitive") {
+		t.Fatalf("problems = %q, want sensitivity incompatibility", got)
+	}
+}
+
+func TestValidate_EdgeContractChecksConsumerModuleType(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, false, false))
+	g.Nodes["b"].Schema.Variables["id"] = module.Variable{Name: "id", Type: "number"}
+	if got := contractMessages(g); !strings.Contains(got, "consumer contract type string") || !strings.Contains(got, "module input type number") {
+		t.Fatalf("problems = %q, want consumer/module type mismatch", got)
+	}
+}
+
+func TestValidate_EdgeContractChecksProducerModuleType(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, false, false))
+	g.Nodes["a"].Schema.OutputDetails["id"] = module.Output{Name: "id", Type: "object({ id = string })"}
+	if got := contractMessages(g); !strings.Contains(got, "producer contract type string") || !strings.Contains(got, "module output type object({ id = string })") {
+		t.Fatalf("problems = %q, want producer/module type mismatch", got)
+	}
+}
+
+func TestValidate_EdgeContractChecksProducerModuleSensitivity(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, false, false))
+	g.Nodes["a"].Schema.OutputDetails["id"] = module.Output{Name: "id", Sensitive: true}
+	if got := contractMessages(g); !strings.Contains(got, "module output is sensitive") {
+		t.Fatalf("problems = %q, want producer/module sensitivity mismatch", got)
+	}
+}
+
+func TestValidate_EdgeContractChecksModuleSensitivity(t *testing.T) {
+	g := contractGraph(contractedEdge("string", "string", false, false, true, true))
+	g.Nodes["a"].Schema.OutputDetails["id"] = module.Output{Name: "id", Sensitive: true}
+	if got := contractMessages(g); !strings.Contains(got, "module input is not declared sensitive") {
+		t.Fatalf("problems = %q, want consumer/module sensitivity mismatch", got)
+	}
+}
+
+func TestValidate_UncontractedEdgeKeepsLegacyBehavior(t *testing.T) {
+	g := contractGraph(dataEdge("a", "id", "b", "id"))
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
+func TestBuild_GroupExpansionPreservesEdgeContract(t *testing.T) {
+	root, bpPath := setupGroupFixture(t)
+	writeFixtureFile(t, filepath.Join(root, "groups/g/group.hcl"), `
+group "g" {
+  node "a" { source = "../../modules/a" }
+  node "b" { source = "../../modules/b" }
+
+  export {
+    input "x" { to = [node.a.input.x, node.b.input.z] }
+    output "y" { from = node.a.output.y }
+  }
+}
+`)
+	bp, err := blueprint.ParseFile(bpPath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	bp.Edges[0].Contract = contractedEdge("string", "string", false, false, false, false).Contract
+
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	found := map[string]bool{}
+	for _, edge := range g.Edges {
+		if edge.From.Node == "vpc" {
+			found[edge.To.Node] = true
+			if edge.Contract == nil || edge.Contract.Producer.Type != "string" || edge.Contract.Consumer.Type != "string" {
+				t.Fatalf("expanded edge lost contract: %+v", edge)
+			}
+		}
+	}
+	if !found["inst.a"] || !found["inst.b"] || len(found) != 2 {
+		t.Fatalf("contracted edge did not fan out to both leaves: %+v", g.Edges)
+	}
+}

--- a/internal/graph/contract_test.go
+++ b/internal/graph/contract_test.go
@@ -87,11 +87,11 @@ func TestValidate_EdgeContractChecksProducerModuleSensitivity(t *testing.T) {
 	}
 }
 
-func TestValidate_EdgeContractChecksModuleSensitivity(t *testing.T) {
+func TestValidate_EdgeContractAllowsSensitiveValueIntoOrdinaryModuleVariable(t *testing.T) {
 	g := contractGraph(contractedEdge("string", "string", false, false, true, true))
 	g.Nodes["a"].Schema.OutputDetails["id"] = module.Output{Name: "id", Sensitive: true}
-	if got := contractMessages(g); !strings.Contains(got, "module input is not declared sensitive") {
-		t.Fatalf("problems = %q, want consumer/module sensitivity mismatch", got)
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("problems = %v, want ordinary variable to accept a sensitive value", problems)
 	}
 }
 

--- a/internal/graph/group.go
+++ b/internal/graph/group.go
@@ -198,7 +198,7 @@ func rewriteEdge(e blueprint.Edge, uses map[string]useInfo, qualify func(string)
 	out := make([]blueprint.Edge, 0, len(froms)*len(tos))
 	for _, f := range froms {
 		for _, t := range tos {
-			out = append(out, blueprint.Edge{From: f, To: t})
+			out = append(out, blueprint.Edge{From: f, To: t, Contract: e.Contract})
 		}
 	}
 	return out, nil

--- a/internal/graph/validate.go
+++ b/internal/graph/validate.go
@@ -120,6 +120,7 @@ func Validate(g *Graph) []Problem {
 		})
 	}
 
+	problems = append(problems, edgeContractProblems(g)...)
 	problems = append(problems, backendProblems(g)...)
 	problems = append(problems, remoteLockProblems(g)...)
 

--- a/internal/language/workspace.go
+++ b/internal/language/workspace.go
@@ -336,9 +336,25 @@ var completionSchemas = map[string][]attributeSpec{
 		{name: "from", insert: "from = node.", detail: "required output reference", documentation: "Source node output, or a bare node for an ordering-only edge."},
 		{name: "to", insert: "to = node.", detail: "required input reference", documentation: "Target node input, or a bare node for an ordering-only edge."},
 		{name: "input", insert: "input \"name\" {\n  from = output.\n}", detail: "Edge block", documentation: "Wires one more output of this edge's from node into an input of its to node. Only on an edge whose from and to are bare references."},
+		{name: "contract", insert: "contract {\n  producer {\n    type      = \"string\"\n    nullable  = false\n    sensitive = false\n  }\n  consumer {\n    type      = \"string\"\n    nullable  = false\n    sensitive = false\n  }\n}", detail: "Optional edge contract", documentation: "Declares the producer guarantee and consumer requirement for this data binding."},
 	},
 	"edge.input": {
 		{name: "from", insert: "from = output.", detail: "required output reference", documentation: "Which output of the edge's own from node feeds this input. Relative: the source node is not repeated here."},
+		{name: "contract", insert: "contract {\n  producer {\n    type      = \"string\"\n    nullable  = false\n    sensitive = false\n  }\n  consumer {\n    type      = \"string\"\n    nullable  = false\n    sensitive = false\n  }\n}", detail: "Optional edge contract", documentation: "Declares the producer guarantee and consumer requirement for this input binding."},
+	},
+	"contract": {
+		{name: "producer", insert: "producer {\n  type      = \"string\"\n  nullable  = false\n  sensitive = false\n}", detail: "Required contract block", documentation: "Declares what the source output guarantees."},
+		{name: "consumer", insert: "consumer {\n  type      = \"string\"\n  nullable  = false\n  sensitive = false\n}", detail: "Required contract block", documentation: "Declares what the target input accepts."},
+	},
+	"producer": {
+		{name: "type", insert: "type = \"string\"", detail: "required type constraint", documentation: "Terraform type constraint guaranteed by the producer."},
+		{name: "nullable", insert: "nullable = false", detail: "required bool", documentation: "Whether the producer may return null."},
+		{name: "sensitive", insert: "sensitive = false", detail: "required bool", documentation: "Whether the producer value is sensitive."},
+	},
+	"consumer": {
+		{name: "type", insert: "type = \"string\"", detail: "required type constraint", documentation: "Terraform type constraint accepted by the consumer."},
+		{name: "nullable", insert: "nullable = false", detail: "required bool", documentation: "Whether the consumer accepts null."},
+		{name: "sensitive", insert: "sensitive = false", detail: "required bool", documentation: "Whether the consumer accepts a sensitive value."},
 	},
 	"runtime": {
 		{name: "binary", insert: "binary = \"\"", detail: "required string", documentation: "Terraform or OpenTofu binary path, or a command resolved from PATH."},
@@ -581,7 +597,7 @@ func enclosingNamedBlock(text []byte, offset int, name string) (start, end int, 
 	return brace, len(text), true
 }
 
-var blockHeader = regexp.MustCompile(`(?s)(node|edge|runtime|group|use|vendor|tfvars|lock|s3|export|input|output)\s*(?:"[^\"]*")?\s*$`)
+var blockHeader = regexp.MustCompile(`(?s)(node|edge|runtime|group|use|vendor|tfvars|lock|s3|export|input|output|contract|producer|consumer)\s*(?:"[^\"]*")?\s*$`)
 
 // openBlock is one Blueprint block still open at some offset: its keyword (empty
 // for a brace that opens an object rather than a block, e.g. vars or env) and the

--- a/internal/language/workspace_test.go
+++ b/internal/language/workspace_test.go
@@ -289,6 +289,29 @@ edge {
 	}
 }
 
+func TestWorkspaceCompletesEdgeContractBlocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blueprint.hcl")
+	for _, tc := range []struct {
+		name, text, want string
+	}{
+		{"direct edge", "edge {\n  __CURSOR__\n}", "contract"},
+		{"nested input", "edge {\n  input \"id\" {\n    __CURSOR__\n  }\n}", "contract"},
+		{"contract", "edge {\n  contract {\n    __CURSOR__\n  }\n}", "producer"},
+		{"producer", "edge {\n  contract {\n    producer {\n      __CURSOR__\n    }\n  }\n}", "nullable"},
+		{"consumer", "edge {\n  contract {\n    consumer {\n      __CURSOR__\n    }\n  }\n}", "sensitive"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clean, offset := cursor(tc.text, "__CURSOR__")
+			ws := NewWorkspace(dir)
+			ws.SetDocument(path, []byte(clean))
+			if items := ws.Complete(context.Background(), path, offset); !contains(items, tc.want) {
+				t.Fatalf("completion %q missing from %#v", tc.want, items)
+			}
+		})
+	}
+}
+
 func TestWorkspaceDiagnosesEdgeInputBlockPorts(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "stacks", "vpc", "main.tf"), `output "vpc_id" { value = "x" }`)


### PR DESCRIPTION
## Summary

- add optional edge-local `contract` blocks with required producer and consumer guarantees
- validate Terraform type conversion, nullability, sensitivity, and inspectable module metadata without changing DAG direction
- preserve contracts through nested-input and group fan-out expansion, with Blueprint IntelliSense completion and documentation

This intentionally implements only the edge-local contract slice accepted in #49; it does not add a separate contract language or bidirectional execution.

Fixes #52.

## Verification

```text
$ mise x go@1.27.1 -- go test ./internal/blueprint ./internal/graph ./internal/language -count=1
ok  github.com/cloudfluent/terragraph/internal/blueprint
ok  github.com/cloudfluent/terragraph/internal/graph
ok  github.com/cloudfluent/terragraph/internal/language

$ mise x go@1.27.1 -- make check
golangci-lint fmt --diff: clean
golangci-lint run ./...: 0 issues
generated CLI docs: clean
go test -race: all packages passed
VS Code tsc/eslint/prettier checks: passed

$ git diff --check
(no output)
```

## Review

Independent Tier 2 diff review: PASS. Its only minor suggestion was addressed by extending the group-expansion test to assert contract preservation on every fan-out leaf.
