### PR TITLE
fix: destroy refuses --auto-approve when a node's approve level does not permit teardown

### DIFF
--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -9,6 +9,7 @@ terragraph destroy [flags]
 ### Options
 
 ```
+      --approve string    what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
       --auto-approve      skip interactive approval
   -h, --help              help for destroy
       --node string       restrict to a single node

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -129,6 +129,8 @@ If this is intended, declare approve = "all" on that node, or re-run with --appr
 
 This is checked whether or not anyone is watching. An interactive `yes` answers "apply this plan", not "override the standing policy"; overriding it is `--approve=all`, which is a visible, deliberate act.
 
+An unattended destroy (`--auto-approve`) is held to the same policy without a plan to read: teardown is delete-only, so it requires every node in scope to resolve to `approve = "all"`, while an interactive destroy stays gated by Terraform's own confirmation prompt.
+
 The check reads the saved plan file, so it cannot run on the `remote`/`cloud` backends, which have none. Apply stops on those nodes with an error rather than applying uninspected.
 
 ## Approval

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -285,6 +285,7 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 	var node string
 	var autoApprove bool
 	var parallelism int
+	var approve string
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Run terraform/tofu destroy across the graph in reverse dependency order",
@@ -297,12 +298,17 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 			if err := checkValidate(cmd, e); err != nil {
 				return err
 			}
-			return e.Destroy(engine.Options{Node: node, AutoApprove: autoApprove, Parallelism: parallelism})
+			level, err := blueprint.ParseApprove(approve)
+			if err != nil {
+				return err
+			}
+			return e.Destroy(engine.Options{Node: node, AutoApprove: autoApprove, Approve: level, Parallelism: parallelism})
 		},
 	}
 	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
+	cmd.Flags().StringVar(&approve, "approve", string(blueprint.ApproveSafe), "what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this")
 	return cmd
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -211,3 +211,23 @@ func TestGraph_DoesNotTakeBlueprintLock(t *testing.T) {
 		t.Fatalf("graph should not take the blueprint lock, stat error = %v", err)
 	}
 }
+
+// destroy must expose the same --approve escape hatch apply does: the engine gate resolves opts.Approve, so a CLI that never parses the flag leaves `destroy --auto-approve` with no unattended route for nodes that declared nothing. An unknown value fails in ParseApprove — proving registration, parsing, and the pass-through call order — without shelling out to terraform.
+func TestDestroy_ApproveFlagIsWired(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "blueprint.hcl"), `node "a" { source = "./stacks/a" }`)
+	writeFixtureFile(t, filepath.Join(dir, "stacks/a/main.tf"), `output "x" { value = "hi" }`)
+
+	root := NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"--blueprint", dir, "destroy", "--approve=bogus"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected an error for an unknown --approve value")
+	}
+	if !strings.Contains(err.Error(), "unknown approve level") || strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("expected --approve to reach blueprint.ParseApprove, got: %v", err)
+	}
+}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -26,7 +26,7 @@ func (e *Engine) Destroy(opts Options) error {
 		for _, level := range levels {
 			for _, name := range level {
 				if a := e.approveFor(name, opts.Approve); a != blueprint.ApproveAll {
-					return fmt.Errorf("destroy: node %s resolves to approve = %q, which does not permit teardown; set approve = \"all\" on the node (or its enclosing use) or run destroy without --auto-approve to approve interactively", name, a)
+					return fmt.Errorf("destroy: node %s resolves to approve = %q, which does not permit teardown; set approve = \"all\" on the node (or its enclosing use), pass --approve=all for this run only, or run destroy without --auto-approve to approve interactively", name, a)
 				}
 			}
 		}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cloudfluent/terragraph/internal/blueprint"
 	"github.com/cloudfluent/terragraph/internal/exec"
 )
 
@@ -14,6 +15,21 @@ func (e *Engine) Destroy(opts Options) error {
 	// Same reason Apply refuses it: concurrent nodes have their output buffered and flushed a node at a time, so terraform's confirmation prompt would be invisible until long after the answer was needed. Checked before taking the run lock, so an unrunnable combination fails immediately instead of after waiting for whatever else holds it.
 	if !opts.AutoApprove && opts.parallelism() > 1 {
 		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
+	}
+
+	// Teardown is delete-only, so approve = "all" is the only level that permits it (the same all-gating apply's notPermitted gives destroy actions). An interactive destroy keeps terraform's own confirmation as the human gate — approve governs what may happen *without* someone saying so — but --auto-approve removes that human, so every in-scope node must already have said yes; --approve=all can only fill a gap, never override a node's own declaration. Checked before any lock is taken, so a refusal fails immediately rather than after waiting on whatever holds it.
+	if opts.AutoApprove {
+		levels, err := e.executionLevels(opts, true)
+		if err != nil {
+			return err
+		}
+		for _, level := range levels {
+			for _, name := range level {
+				if a := e.approveFor(name, opts.Approve); a != blueprint.ApproveAll {
+					return fmt.Errorf("destroy: node %s resolves to approve = %q, which does not permit teardown; set approve = \"all\" on the node (or its enclosing use) or run destroy without --auto-approve to approve interactively", name, a)
+				}
+			}
+		}
 	}
 
 	unlock, err := e.lockRun()

--- a/internal/engine/destroy_approve_unix_test.go
+++ b/internal/engine/destroy_approve_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+// loadDestroyApproveEngine builds the standard one-node fake-terraform fixture with the node block left to the caller, so the destroy approve gate can be exercised end to end.
+func loadDestroyApproveEngine(t *testing.T, node string) (*Engine, string) {
+	t.Helper()
+	baseDir := t.TempDir()
+	writeModule(t, filepath.Join(baseDir, "module"))
+	if err := os.WriteFile(filepath.Join(baseDir, "module", "payload.txt"), []byte("version-one\n"), 0o644); err != nil {
+		t.Fatalf("writing payload: %v", err)
+	}
+	path := writeBlueprint(t, baseDir, node)
+	commandLog := filepath.Join(baseDir, "commands.log")
+	t.Setenv("TG_COMMAND_LOG", commandLog)
+	t.Setenv("TG_PLAN_ERROR", filepath.Join(baseDir, "plan-error"))
+
+	e, err := Load(path, exec.Binary(writeFakeTerraform(t, baseDir)), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e, commandLog
+}
+
+// Teardown is delete-only, so an unattended destroy is permitted by approve = "all" alone; a node that said less is refused before anything runs, and --approve=all cannot speak for it, because the node's own declaration wins — the same layering apply already relies on.
+func TestDestroy_ApproveGateRefusesUnattendedTeardown(t *testing.T) {
+	e, commandLog := loadDestroyApproveEngine(t, `
+node "guarded" {
+  source  = "./module"
+  approve = "none"
+}
+`)
+
+	err := e.Destroy(Options{AutoApprove: true})
+	if err == nil {
+		t.Fatal(`expected an unattended destroy to be refused at approve = "none"`)
+	}
+	for _, want := range []string{"guarded", `approve = "none"`, `set approve = "all"`, "--auto-approve"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected the error to mention %q, got: %v", want, err)
+		}
+	}
+	// The run-wide flag fills a gap; it never overrides what the node declared.
+	if err := e.Destroy(Options{AutoApprove: true, Approve: blueprint.ApproveAll}); err == nil {
+		t.Fatal(`expected --approve=all not to override the node's own approve = "none"`)
+	}
+	// Refused before any lock was taken, so nothing was touched — a log that never came into being is the strongest form of that.
+	data, readErr := os.ReadFile(commandLog)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("reading command log: %v", readErr)
+	}
+	if got := strings.Count(string(data), "destroy\n"); got != 0 {
+		t.Fatalf("destroy count = %d, want 0; log:\n%s", got, data)
+	}
+}
+
+// The run-wide default fills a gap nothing else spoke to, so --approve=all permits unattended teardown of nodes that declared nothing — the one-off route for an intentional destroy.
+func TestDestroy_ApproveGateRunLevelPermitsUnattendedTeardown(t *testing.T) {
+	e, _ := loadDestroyApproveEngine(t, `
+node "guarded" { source = "./module" }
+`)
+
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := e.Destroy(Options{AutoApprove: true, Approve: blueprint.ApproveAll}); err != nil {
+		t.Fatalf("expected --approve=all to permit unattended teardown: %v", err)
+	}
+}
+
+// A node declaring approve = "none" can still be torn down by a human: interactive destroy's gate is terraform's own confirmation prompt, which is exactly the someone-saying-so that approve levels defer the decision to.
+func TestDestroy_ApproveGateInteractiveStaysHumanGated(t *testing.T) {
+	e, _ := loadDestroyApproveEngine(t, `
+node "guarded" {
+  source  = "./module"
+  approve = "none"
+}
+`)
+
+	e.Stdin = strings.NewReader("yes\n")
+	if err := e.Destroy(Options{}); err != nil {
+		t.Fatalf("expected interactive destroy to be gated by terraform's prompt, not the approve level: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The `approve` guard was apply-only: `terragraph destroy --auto-approve` tore down a node declaring `approve = "none"` (#49 sequencing defect 1). Unattended teardown is delete-only and only `approve = "all"` permits delete, so `destroy --auto-approve` now refuses any in-scope node that resolves below `all`, naming the node, its resolved level, and the remedy (set `approve = "all"` on the node or its enclosing use, or run destroy without `--auto-approve` to approve interactively). Interactive destroy is unchanged — terraform's own prompt is the human gate, which is what `approve` means ("what a node may do without saying so"). I wrote this because the one guard the product advertises must cover its most destructive command.

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)
- `go test ./internal/engine` ok; new cases: unattended teardown of `approve = "none"` refused (and run-level `--approve=all` does not override a node's own declaration, matching `approveFor` layering); undeclared node + run-level `all` proceeds; interactive destroy still proceeds.

Refs #49 (sequencing defect 1).
