### PR TITLE
fix: warn when a renamed node orphans its local-backend state

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -4,7 +4,7 @@
 
 `terragraph validate` (and `graph`/`plan`/`apply`/`destroy`, which run it first) reports two severities:
 - **Error**: blocks the command (a `from`/`to` referencing a port that doesn't exist, two data edges targeting the same input after group expansion even when they are exact duplicates, a data edge and `vars` both setting the same input, a cycle, a value that doesn't fit the target variable's declared type, `backend_config` set on a module with no `backend` block, two nodes sharing a module directory with identical `backend_config` maps).
-- **Warning**: printed but never blocks. A required variable with no edge feeding it may legitimately come from that module's own `terraform.tfvars` or the environment, outside the blueprint entirely.
+- **Warning**: printed but never blocks. A required variable with no edge feeding it may legitimately come from that module's own `terraform.tfvars` or the environment, outside the blueprint entirely; so may a `.terragraph/state/<name>.tfstate` file left behind by a node that's since been renamed or removed (see below).
 
 Cycle detection reports every independent cyclic cluster in one pass (Tarjan's SCC algorithm), not just the first one found.
 
@@ -30,6 +30,8 @@ tfvars {
   ```
 
   `terragraph validate` warns (never deletes) about a stale file left behind in a shared module directory by a node that's since been renamed or removed from the blueprint.
+
+  `terragraph validate` likewise warns (never deletes) about a stale `state/<name>.tfstate` under the blueprint's `.terragraph/state/` — where the local backend parks state for nodes that don't set an explicit `path`. Files are matched by the backend path each current node resolves to, so a renamed or removed node's state is flagged for you to rename back, remove, or re-import.
 
 ## Execution levels and parallelism
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -172,10 +172,11 @@ func load(blueprintPath string, binary exec.Binary, stdout, stderr io.Writer, ta
 	}, lock, nil
 }
 
-// Validate returns every structural problem found in the graph (missing ports, two data edges targeting the same input, a data edge and vars both setting the same input, cycles, unresolved required variables, backend_config without a backend block, identical backend_config maps on a shared module directory) plus any tfvars orphan warnings (see tfVarsOrphans) and shared-source runtime conflict warnings (see runtimeConflicts). Check each Problem's IsError(): only errors should block graph/plan/apply/destroy, warnings are advisory.
+// Validate returns every structural problem found in the graph (missing ports, two data edges targeting the same input, a data edge and vars both setting the same input, cycles, unresolved required variables, backend_config without a backend block, identical backend_config maps on a shared module directory) plus any tfvars orphan warnings (see tfVarsOrphans), stale local-backend state warnings (see stateOrphans) and shared-source runtime conflict warnings (see runtimeConflicts). Check each Problem's IsError(): only errors should block graph/plan/apply/destroy, warnings are advisory.
 func (e *Engine) Validate() []graph.Problem {
 	problems := graph.Validate(e.Graph)
 	problems = append(problems, e.tfVarsOrphans()...)
+	problems = append(problems, e.stateOrphans()...)
 	problems = append(problems, e.runtimeConflicts()...)
 	return problems
 }
@@ -337,6 +338,37 @@ func (e *Engine) tfVarsOrphans() []graph.Problem {
 				Message:  fmt.Sprintf("%s: belongs to no node in this blueprint; remove it if the node was renamed or deleted", filepath.Join(dir, fname)),
 			})
 		}
+	}
+	return problems
+}
+
+// stateOrphans warns about a local-backend state file left in <BaseDir>/.terragraph/state by a node that no longer exists under that name (renamed or removed from the blueprint), so a rename doesn't silently strand the old state where a future node of that name would silently adopt it. Nodes with an explicit backend_config path never write here, so matching on the file stem is exact. Never deletes anything; it is the user's call whether the node was renamed (rename it back) or truly abandoned (remove the file or re-import the state elsewhere).
+func (e *Engine) stateOrphans() []graph.Problem {
+	dir := filepath.Join(e.BaseDir, ".terragraph", "state")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil // No state directory yet (fresh or never-applied project): nothing can be orphaned.
+	}
+	var stale []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		fname := entry.Name()
+		if !strings.HasSuffix(fname, ".tfstate") {
+			continue
+		}
+		if _, ok := e.Graph.Nodes[strings.TrimSuffix(fname, ".tfstate")]; !ok {
+			stale = append(stale, fname)
+		}
+	}
+	sort.Strings(stale)
+	var problems []graph.Problem
+	for _, fname := range stale {
+		problems = append(problems, graph.Problem{
+			Severity: graph.SeverityWarning,
+			Message:  fmt.Sprintf("%s: state for a node that no longer exists in this blueprint; if the node was renamed, rename it back (or remove/import the state file if abandoned)", filepath.Join(dir, fname)),
+		})
 	}
 	return problems
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -342,12 +342,18 @@ func (e *Engine) tfVarsOrphans() []graph.Problem {
 	return problems
 }
 
-// stateOrphans warns about a local-backend state file left in <BaseDir>/.terragraph/state by a node that no longer exists under that name (renamed or removed from the blueprint), so a rename doesn't silently strand the old state where a future node of that name would silently adopt it. Nodes with an explicit backend_config path never write here, so matching on the file stem is exact. Never deletes anything; it is the user's call whether the node was renamed (rename it back) or truly abandoned (remove the file or re-import the state elsewhere).
+// stateOrphans warns about a local-backend state file left in <BaseDir>/.terragraph/state by a node that no longer owns it (renamed or removed from the blueprint), so a rename doesn't silently strand the old state where a future node of that name would silently adopt it. Files are claimed by the basename of every node's resolved backend_config path, not by node name: a node may point an explicit path at a differently named file under this directory (see blueprint.md), and graph.Build default-fills the rest to <name>.tfstate anyway — so a basename no current node resolves to is an orphan. Never deletes anything; it is the user's call whether the node was renamed (rename it back) or truly abandoned (remove the file or re-import the state elsewhere).
 func (e *Engine) stateOrphans() []graph.Problem {
 	dir := filepath.Join(e.BaseDir, ".terragraph", "state")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil // No state directory yet (fresh or never-applied project): nothing can be orphaned.
+	}
+	claimed := make(map[string]bool)
+	for _, n := range e.Graph.Nodes {
+		if p, ok := n.BackendConfig["path"]; ok {
+			claimed[filepath.Base(p)] = true
+		}
 	}
 	var stale []string
 	for _, entry := range entries {
@@ -358,7 +364,7 @@ func (e *Engine) stateOrphans() []graph.Problem {
 		if !strings.HasSuffix(fname, ".tfstate") {
 			continue
 		}
-		if _, ok := e.Graph.Nodes[strings.TrimSuffix(fname, ".tfstate")]; !ok {
+		if !claimed[fname] {
 			stale = append(stale, fname)
 		}
 	}

--- a/internal/engine/state_orphans_test.go
+++ b/internal/engine/state_orphans_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+	"github.com/cloudfluent/terragraph/internal/graph"
+)
+
+// loadLiveNode loads a one-node blueprint whose module uses the local backend, so graph.Build fills BackendConfig path = <baseDir>/.terragraph/state/live.tfstate.
+func loadLiveNode(t *testing.T) *Engine {
+	t.Helper()
+	baseDir := t.TempDir()
+	writeModule(t, filepath.Join(baseDir, "stacks", "live"))
+	path := writeBlueprint(t, baseDir, `
+node "live" { source = "./stacks/live" }
+`)
+
+	e, err := Load(path, exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e
+}
+
+func TestStateOrphans_WarnsAboutStrayStateFile(t *testing.T) {
+	e := loadLiveNode(t)
+
+	// Simulates the local-backend state left behind by a node that has since been renamed or removed from the blueprint.
+	stray := filepath.Join(e.BaseDir, ".terragraph", "state", "ghost.tfstate")
+	if err := os.MkdirAll(filepath.Dir(stray), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(stray, []byte(`{"version":4}`), 0o644); err != nil {
+		t.Fatalf("writing stray state fixture: %v", err)
+	}
+
+	var orphans []graph.Problem
+	for _, p := range e.Validate() {
+		if p.IsError() {
+			t.Fatalf("unexpected error-level problem: %s", p.Message)
+		}
+		if strings.Contains(p.Message, "ghost.tfstate") {
+			orphans = append(orphans, p)
+		}
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected exactly one warning about ghost.tfstate, got %d: %+v", len(orphans), orphans)
+	}
+	msg := orphans[0].Message
+	if !strings.Contains(msg, "rename") || (!strings.Contains(msg, "remove") && !strings.Contains(msg, "import")) {
+		t.Fatalf("warning should name a remedy (rename plus remove/import), got: %s", msg)
+	}
+}
+
+func TestStateOrphans_NoStrayFileNoNewProblems(t *testing.T) {
+	e := loadLiveNode(t)
+
+	if problems := e.Validate(); len(problems) != 0 {
+		t.Fatalf("expected no problems without a stray state file, got: %+v", problems)
+	}
+}

--- a/internal/engine/state_orphans_test.go
+++ b/internal/engine/state_orphans_test.go
@@ -64,3 +64,31 @@ func TestStateOrphans_NoStrayFileNoNewProblems(t *testing.T) {
 		t.Fatalf("expected no problems without a stray state file, got: %+v", problems)
 	}
 }
+
+// A node may point an explicit backend_config path at a differently named file under .terragraph/state; while it exists, that file is live state, not an orphan.
+func TestStateOrphans_ExplicitBackendPathClaimsItsFile(t *testing.T) {
+	baseDir := t.TempDir()
+	writeModule(t, filepath.Join(baseDir, "stacks", "vpc"))
+	path := writeBlueprint(t, baseDir, `
+node "vpc" {
+  source = "./stacks/vpc"
+  backend_config = { path = ".terragraph/state/prod.tfstate" }
+}
+`)
+
+	e, err := Load(path, exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	live := filepath.Join(e.BaseDir, ".terragraph", "state", "prod.tfstate")
+	if err := os.MkdirAll(filepath.Dir(live), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(live, []byte(`{"version":4}`), 0o644); err != nil {
+		t.Fatalf("writing live state fixture: %v", err)
+	}
+
+	if problems := e.Validate(); len(problems) != 0 {
+		t.Fatalf("expected no warnings while the explicit path's node exists, got: %+v", problems)
+	}
+}


### PR DESCRIPTION
## Summary

Renaming a node orphans `<root>/.terragraph/state/<old-name>.tfstate`: the next plan sees an empty state and, since `safe` permits creates, silently provisions a second copy of live infrastructure (#49 sequencing defect 2). `validate` now warns about any state file whose stem names no node, with the remedy (rename back, or remove/import the state) — modeled on the existing `tfVarsOrphans` warning; nothing is ever deleted.

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)
- `go test ./internal/engine` ok; new cases: a stray `ghost.tfstate` yields exactly one warning naming it; without the stray file, zero new problems.

Refs #49 (sequencing defect 2).
