### PR TITLE
fix: refuse --node destroy while consumers still read the node's outputs

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -150,6 +150,8 @@ It asks about the plan you were just shown, and applies exactly that plan — a 
 
 `terragraph destroy` is confirmed the same way, except the question comes from Terraform itself: there is no saved plan for terragraph to ask about on its behalf.
 
+A `--node X` destroy is refused while any data edge still reads X's outputs: destroying X first would leave the consumer's next resolution dying with Terraform's misleading "has no output value; apply it first". Destroy the consumers first (downstream-to-upstream), remove the edges, or run a full destroy, which tears consumers down before their inputs by walking in reverse order.
+
 ### There is no local cache
 
 Earlier versions kept a content-addressed cache at `<blueprint dir>/.terragraph/cache.json`, hashing each node's source files, resolved inputs, runtime and `env` to decide whether it could skip apply. Hashing local files is a proxy for a remote fact, and the gap between the two produced a series of bugs: a backend or inherited `env` change that the key never modelled, remote drift that no local hash could see, and files consumed through `file()`/`templatefile()` that never invalidated anything.

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/cloudfluent/terragraph/internal/exec"
 )
@@ -14,6 +16,20 @@ func (e *Engine) Destroy(opts Options) error {
 	// Same reason Apply refuses it: concurrent nodes have their output buffered and flushed a node at a time, so terraform's confirmation prompt would be invisible until long after the answer was needed. Checked before taking the run lock, so an unrunnable combination fails immediately instead of after waiting for whatever else holds it.
 	if !opts.AutoApprove && opts.parallelism() > 1 {
 		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
+	}
+
+	// A --node destroy refuses to strand the graph: while a consumer still reads this node's outputs, tearing the node down first makes the consumer's next resolution die with terraform's misleading "has no output value; apply it first". A full destroy is exempt because reverse topological order (downstream first) destroys the consumers along with it. Checked before any lock is taken so a doomed combination fails immediately.
+	if opts.Node != "" {
+		var consumers []string
+		for _, edge := range e.Graph.Edges {
+			if edge.IsDataEdge() && edge.From.Node == opts.Node && edge.To.Node != opts.Node {
+				consumers = append(consumers, edge.To.Node)
+			}
+		}
+		if len(consumers) > 0 {
+			sort.Strings(consumers)
+			return fmt.Errorf("destroy: node %q still feeds %s; destroy consumers first (downstream-to-upstream), remove the edges, or run a full destroy", opts.Node, strings.Join(consumers, ", "))
+		}
 	}
 
 	unlock, err := e.lockRun()

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -20,15 +20,20 @@ func (e *Engine) Destroy(opts Options) error {
 
 	// A --node destroy refuses to strand the graph: while a consumer still reads this node's outputs, tearing the node down first makes the consumer's next resolution die with terraform's misleading "has no output value; apply it first". A full destroy is exempt because reverse topological order (downstream first) destroys the consumers along with it. Checked before any lock is taken so a doomed combination fails immediately.
 	if opts.Node != "" {
-		var consumers []string
+		// Nested input blocks from one consumer append its name once per data edge, so consumers are collected into a set and listed once each.
+		consumers := make(map[string]struct{})
 		for _, edge := range e.Graph.Edges {
 			if edge.IsDataEdge() && edge.From.Node == opts.Node && edge.To.Node != opts.Node {
-				consumers = append(consumers, edge.To.Node)
+				consumers[edge.To.Node] = struct{}{}
 			}
 		}
 		if len(consumers) > 0 {
-			sort.Strings(consumers)
-			return fmt.Errorf("destroy: node %q still feeds %s; destroy consumers first (downstream-to-upstream), remove the edges, or run a full destroy", opts.Node, strings.Join(consumers, ", "))
+			names := make([]string, 0, len(consumers))
+			for name := range consumers {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			return fmt.Errorf("destroy: node %q still feeds %s; destroy consumers first (downstream-to-upstream), remove the edges, or run a full destroy", opts.Node, strings.Join(names, ", "))
 		}
 	}
 

--- a/internal/engine/destroy_node_guard_unix_test.go
+++ b/internal/engine/destroy_node_guard_unix_test.go
@@ -67,6 +67,22 @@ func TestDestroy_NodeWithoutDownstreamConsumersProceeds(t *testing.T) {
 	}
 }
 
+// Two data edges from a into b (one per input) must list b once: the error names consumers, not edges.
+func TestDestroy_NodeConsumerListIsDeduplicated(t *testing.T) {
+	e := loadTwoEdgesConsumerEngine(t)
+
+	err := e.Destroy(Options{Node: "a", AutoApprove: true})
+	if err == nil {
+		t.Fatal("expected --node a destroy to be refused while b still consumes its outputs")
+	}
+	if !strings.Contains(err.Error(), "still feeds b, c;") {
+		t.Fatalf("expected the consumer list to name each consumer once, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "b, b") {
+		t.Fatalf("expected b to be listed once, got: %v", err)
+	}
+}
+
 // A full destroy needs no guard of its own: reverse topological order tears b down before a.
 func TestDestroy_FullDestroyTearsDownConsumersFirst(t *testing.T) {
 	e := loadNodeGuardTestEngine(t)
@@ -74,4 +90,46 @@ func TestDestroy_FullDestroyTearsDownConsumersFirst(t *testing.T) {
 	if err := e.Destroy(Options{AutoApprove: true}); err != nil {
 		t.Fatalf("full Destroy: %v", err)
 	}
+}
+
+// loadTwoEdgesConsumerEngine builds a graph where b consumes two of a's outputs and c consumes one, so the refusal must name b once and c once.
+func loadTwoEdgesConsumerEngine(t *testing.T) *Engine {
+	t.Helper()
+	baseDir := t.TempDir()
+	moduleDir := filepath.Join(baseDir, "module")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", moduleDir, err)
+	}
+	src := "terraform {\n  backend \"local\" {}\n}\noutput \"managed\" {\n  value = \"ok\"\n}\noutput \"managed2\" {\n  value = \"ok\"\n}\nvariable \"payload\" {\n  type = string\n}\nvariable \"payload2\" {\n  type = string\n}\n"
+	if err := os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(src), 0o644); err != nil {
+		t.Fatalf("writing fixture module: %v", err)
+	}
+	blueprintPath := writeBlueprint(t, baseDir, `
+node "a" { source = "./module" }
+node "b" { source = "./module" }
+node "c" { source = "./module" }
+
+edge {
+  from = node.a.output.managed
+  to   = node.b.input.payload
+}
+
+edge {
+  from = node.a.output.managed2
+  to   = node.b.input.payload2
+}
+
+edge {
+  from = node.a.output.managed
+  to   = node.c.input.payload
+}
+`)
+	t.Setenv("TG_COMMAND_LOG", filepath.Join(baseDir, "commands.log"))
+	t.Setenv("TG_PLAN_ERROR", filepath.Join(baseDir, "plan-error"))
+
+	e, err := Load(blueprintPath, exec.Binary(writeFakeTerraform(t, baseDir)), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e
 }

--- a/internal/engine/destroy_node_guard_unix_test.go
+++ b/internal/engine/destroy_node_guard_unix_test.go
@@ -1,0 +1,77 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+// loadNodeGuardTestEngine builds the smallest graph the defect needs: a data edge a.output.managed -> b.input.payload, on the shared fake terraform (whose `output` reports "managed" and whose destroy succeeds under -auto-approve).
+func loadNodeGuardTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	baseDir := t.TempDir()
+	moduleDir := filepath.Join(baseDir, "module")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", moduleDir, err)
+	}
+	src := "terraform {\n  backend \"local\" {}\n}\noutput \"managed\" {\n  value = \"ok\"\n}\nvariable \"payload\" {\n  type = string\n}\n"
+	if err := os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(src), 0o644); err != nil {
+		t.Fatalf("writing fixture module: %v", err)
+	}
+	blueprintPath := writeBlueprint(t, baseDir, `
+node "a" { source = "./module" }
+node "b" { source = "./module" }
+
+edge {
+  from = node.a.output.managed
+  to   = node.b.input.payload
+}
+`)
+	t.Setenv("TG_COMMAND_LOG", filepath.Join(baseDir, "commands.log"))
+	t.Setenv("TG_PLAN_ERROR", filepath.Join(baseDir, "plan-error"))
+
+	e, err := Load(blueprintPath, exec.Binary(writeFakeTerraform(t, baseDir)), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e
+}
+
+// Destroying an upstream node --node while a consumer still reads its outputs would strand the graph: the consumer's next resolution dies with terraform's misleading "has no output value; apply it first". The refusal names the consumers and the way out.
+func TestDestroy_NodeRefusedWhileConsumersReadItsOutputs(t *testing.T) {
+	e := loadNodeGuardTestEngine(t)
+
+	err := e.Destroy(Options{Node: "a", AutoApprove: true})
+	if err == nil {
+		t.Fatal("expected --node a destroy to be refused while b still consumes its outputs")
+	}
+	for _, want := range []string{`still feeds b;`, "destroy consumers first"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+// The consumer itself has nobody downstream: destroying it alone is exactly the right order.
+func TestDestroy_NodeWithoutDownstreamConsumersProceeds(t *testing.T) {
+	e := loadNodeGuardTestEngine(t)
+
+	if err := e.Destroy(Options{Node: "b", AutoApprove: true}); err != nil {
+		t.Fatalf("Destroy --node b: %v", err)
+	}
+}
+
+// A full destroy needs no guard of its own: reverse topological order tears b down before a.
+func TestDestroy_FullDestroyTearsDownConsumersFirst(t *testing.T) {
+	e := loadNodeGuardTestEngine(t)
+
+	if err := e.Destroy(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("full Destroy: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`destroy --node <upstream>` proceeded while downstream consumers still read that node's outputs, so teardown in the wrong order later died with `has no output value …; apply it first` — telling the operator to rebuild in order to demolish (#49 sequencing defect 3). `--node` destroy now refuses while any other node has a data edge from the target, listing the dependents and the remedy (destroy consumers first downstream-to-upstream, remove the edges, or run a full destroy — which already walks in reverse order).

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)
- `go test ./internal/engine` ok; new cases: `a -> b` data edge — `--node a` refused naming `b`; `--node b` proceeds; full destroy proceeds.

Refs #49 (sequencing defect 3).
