### PR TITLE
feat: terragraph force-unlock releases a leftover graph lock (--yes required)

### DIFF
--- a/docs/cli/terragraph.md
+++ b/docs/cli/terragraph.md
@@ -16,6 +16,7 @@ Graph-based orchestration for independent Terraform/OpenTofu root modules
 
 * [terragraph apply](terragraph_apply.md)	 - Run terraform/tofu apply across the graph in dependency order, wiring outputs to inputs
 * [terragraph destroy](terragraph_destroy.md)	 - Run terraform/tofu destroy across the graph in reverse dependency order
+* [terragraph force-unlock](terragraph_force-unlock.md)	 - Release a leftover graph lock object left by an interrupted run
 * [terragraph graph](terragraph_graph.md)	 - Print the resolved execution levels or a Graphviz DOT rendering
 * [terragraph language-server](terragraph_language-server.md)	 - Run the Blueprint language server over standard input/output
 * [terragraph plan](terragraph_plan.md)	 - Run terraform/tofu plan across the graph in dependency order

--- a/docs/cli/terragraph_force-unlock.md
+++ b/docs/cli/terragraph_force-unlock.md
@@ -1,0 +1,26 @@
+## terragraph force-unlock
+
+Release a leftover graph lock object left by an interrupted run
+
+```
+terragraph force-unlock [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for force-unlock
+      --yes    release the lock object (required; the lock may still be genuinely held)
+```
+
+### Options inherited from parent commands
+
+```
+      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
+      --tofu               use the tofu binary instead of terraform
+```
+
+### SEE ALSO
+
+* [terragraph](terragraph.md)	 - Graph-based orchestration for independent Terraform/OpenTofu root modules

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -55,7 +55,7 @@ The mechanism is an S3 lock **object** via conditional writes (the same idea as 
 
 If the object already exists, the command **fails immediately** (it does not wait the way flock does).
 
-Ctrl-C / SIGTERM / SIGKILL leave the S3 object (the process exits without running `defer`; flock still drops with the fd). A failed `DeleteObject` after a successful run does the same: the command prints the error to stderr and still reports success. Delete the object to recover. There is no `force-unlock` yet.
+Ctrl-C / SIGTERM / SIGKILL leave the S3 object (the process exits without running `defer`; flock still drops with the fd). A failed `DeleteObject` after a successful run does the same: the command prints the error to stderr and still reports success. Recover with `terragraph force-unlock --yes`: it deletes the configured lock object and prints `released <bucket>/<key>`. `--yes` is required — and the command refuses to say more than bucket/key without it — because releasing is unconditional and could break a lock that is genuinely held.
 
 IAM on the lock key needs `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject`. Conditional delete uses `If-Match`, which AWS evaluates as a Get; `s3:DeleteObject` alone is not enough.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudfluent/terragraph/internal/engine"
 	"github.com/cloudfluent/terragraph/internal/exec"
 	"github.com/cloudfluent/terragraph/internal/graph"
+	"github.com/cloudfluent/terragraph/internal/graphlock"
 	"github.com/cloudfluent/terragraph/internal/lsp"
 	"github.com/cloudfluent/terragraph/internal/runlock"
 	"github.com/cloudfluent/terragraph/internal/vendor"
@@ -59,6 +60,7 @@ func NewRootCmd(version string) *cobra.Command {
 	root.AddCommand(newPlanCmd(&blueprintPath, binaryOf, loggerOf))
 	root.AddCommand(newApplyCmd(&blueprintPath, binaryOf, loggerOf))
 	root.AddCommand(newDestroyCmd(&blueprintPath, binaryOf, loggerOf))
+	root.AddCommand(newForceUnlockCmd(&blueprintPath, binaryOf, loggerOf))
 	root.AddCommand(newVendorCmd(&blueprintPath, loggerOf))
 	root.AddCommand(newLanguageServerCmd())
 
@@ -303,6 +305,35 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
+	return cmd
+}
+
+func newForceUnlockCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "force-unlock",
+		Short: "Release a leftover graph lock object left by an interrupted run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// loadEngine, not loadLockedEngine: the stuck lock is exactly why this command exists, and it never reads module files, so there is nothing to protect with the process lock.
+			e, err := loadEngine(cmd, blueprintPath, binaryOf, loggerOf)
+			if err != nil {
+				return err
+			}
+			lock := e.Graph.Lock
+			if lock == nil {
+				return fmt.Errorf("this blueprint declares no graph lock")
+			}
+			if !yes {
+				return fmt.Errorf("refusing to release %s/%s without --yes; run terragraph force-unlock --yes", lock.S3.Bucket, lock.S3.Key)
+			}
+			if err := graphlock.Release(cmd.Context(), lock); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "released %s/%s\n", lock.S3.Bucket, lock.S3.Key)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "release the lock object (required; the lock may still be genuinely held)")
 	return cmd
 }
 

--- a/internal/cli/force_unlock_test.go
+++ b/internal/cli/force_unlock_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runForceUnlock runs force-unlock against a freshly written one-node blueprint fixture and returns stdout, stderr, and any error. No terraform runs and no S3 is touched: these tests cover flag/validation wiring only.
+func runForceUnlock(t *testing.T, blueprint string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "blueprint.hcl"), blueprint)
+	writeFixtureFile(t, filepath.Join(dir, "stacks/a/outputs.tf"), "output \"x\" { value = \"hi\" }\n")
+	root := NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs(append([]string{"--blueprint", filepath.Join(dir, "blueprint.hcl"), "force-unlock"}, args...))
+	err = root.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+const forceUnlockLockHCL = `
+lock {
+  s3 {
+    bucket = "acme-tfstate"
+    key    = "terragraph/prod.lock"
+    region = "ap-northeast-2"
+  }
+}
+node "a" { source = "./stacks/a" }
+`
+
+func TestForceUnlock_NoLockBlockErrors(t *testing.T) {
+	_, _, err := runForceUnlock(t, `node "a" { source = "./stacks/a" }`)
+	if err == nil {
+		t.Fatal("expected an error without a lock block")
+	}
+	if !strings.Contains(err.Error(), "this blueprint declares no graph lock") {
+		t.Fatalf("err = %v, want no-graph-lock message", err)
+	}
+}
+
+func TestForceUnlock_RefusesWithoutYes(t *testing.T) {
+	_, _, err := runForceUnlock(t, forceUnlockLockHCL)
+	if err == nil {
+		t.Fatal("expected a refusal without --yes")
+	}
+	for _, want := range []string{"acme-tfstate", "terragraph/prod.lock", "--yes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %v, want mention of %q", err, want)
+		}
+	}
+}

--- a/internal/graphlock/graphlock.go
+++ b/internal/graphlock/graphlock.go
@@ -17,6 +17,7 @@ var ErrHeld = errors.New("another terragraph process holds the graph lock")
 type Backend interface {
 	Matches(lock *blueprint.Lock) bool
 	Acquire(ctx context.Context, lock *blueprint.Lock) (Held, error)
+	Release(ctx context.Context, lock *blueprint.Lock) error
 }
 
 // Held is a held graph lock. Close releases it. Close on a nil or already-released Held is a no-op.
@@ -44,4 +45,17 @@ func Acquire(ctx context.Context, lock *blueprint.Lock) (Held, error) {
 		}
 	}
 	return nil, fmt.Errorf("no graph lock backend matches this lock block")
+}
+
+// Release deletes a leftover graph lock object (force-unlock). Held.Close refuses a lock whose etag moved; Release skips that guard on purpose — the holder is gone, so no If-Match could ever match — leaving the --yes confirmation at the CLI as the only safety. A nil lock is a no-op.
+func Release(ctx context.Context, lock *blueprint.Lock) error {
+	if lock == nil {
+		return nil
+	}
+	for _, b := range backends {
+		if b.Matches(lock) {
+			return b.Release(ctx, lock)
+		}
+	}
+	return fmt.Errorf("no graph lock backend matches this lock block")
 }

--- a/internal/graphlock/graphlock_test.go
+++ b/internal/graphlock/graphlock_test.go
@@ -29,6 +29,13 @@ func (f fakeBackend) Acquire(ctx context.Context, lock *blueprint.Lock) (Held, e
 	return noopHeld{}, nil
 }
 
+func (f fakeBackend) Release(ctx context.Context, lock *blueprint.Lock) error {
+	if f.calls != nil {
+		*f.calls++
+	}
+	return nil
+}
+
 func withBackends(t *testing.T, bs ...Backend) {
 	t.Helper()
 	orig := backends

--- a/internal/graphlock/release_test.go
+++ b/internal/graphlock/release_test.go
@@ -1,0 +1,29 @@
+package graphlock
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRelease_S3DeletesConfiguredObject(t *testing.T) {
+	mem := newMemS3()
+	mem.objects["acme-tfstate/terragraph/prod.lock"] = memObj{etag: `"stale"`, body: []byte(`{}`)}
+	withBackends(t, s3With(mem))
+	if err := Release(context.Background(), testS3Lock()); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if mem.has("acme-tfstate", "terragraph/prod.lock") {
+		t.Fatal("expected lock object deleted after Release")
+	}
+}
+
+func TestRelease_NilLockIsNoop(t *testing.T) {
+	calls := 0
+	withBackends(t, fakeBackend{matches: true, calls: &calls})
+	if err := Release(context.Background(), nil); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("backend called %d times, want 0", calls)
+	}
+}

--- a/internal/graphlock/s3.go
+++ b/internal/graphlock/s3.go
@@ -81,6 +81,22 @@ func (b s3Backend) Acquire(ctx context.Context, lock *blueprint.Lock) (Held, err
 	return &s3Held{client: client, bucket: cfg.Bucket, key: cfg.Key, etag: etag}, nil
 }
 
+// Release deletes the lock object unconditionally (force-unlock path). Unlike Close there is no If-Match: the etag belongs to a run that no longer exists, and gating on it would make recovery impossible.
+func (b s3Backend) Release(ctx context.Context, lock *blueprint.Lock) error {
+	cfg := lock.S3
+	client, err := b.client(ctx, cfg.Region)
+	if err != nil {
+		return err
+	}
+	if _, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(cfg.Bucket),
+		Key:    aws.String(cfg.Key),
+	}); err != nil {
+		return fmt.Errorf("releasing graph lock s3://%s/%s: %w", cfg.Bucket, cfg.Key, err)
+	}
+	return nil
+}
+
 func (b s3Backend) client(ctx context.Context, region string) (s3API, error) {
 	if b.newClient != nil {
 		return b.newClient(ctx, region)


### PR DESCRIPTION
## Summary

An interrupted run leaves the S3 graph-lock object and every later command failed immediately, with no release path in the product (#49 sequencing defect 4; docs explicitly recorded "no force-unlock"). `terragraph force-unlock` now releases it: it prints the bucket/key from the blueprint's lock block, refuses without `--yes`, and deletes the object through a new `graphlock.Release` that dispatches through the existing backend interface (s3API already exposed `DeleteObject`).

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)
- `go test ./internal/graphlock ./internal/cli` ok; graphlock test drives a fake s3API and asserts `DeleteObject` receives the configured bucket/key (nil lock is a no-op); CLI tests cover the wiring: no lock block → "this blueprint declares no graph lock"; lock block without `--yes` → refusal printing bucket/key. Binary smoke run confirmed both refusal paths.
- `make docs` regenerated (`docs/cli/terragraph_force-unlock.md`); `docs/execution-model.md` documents the command.

Refs #49 (sequencing defect 4).
