### PR TITLE
fix: tfvars are owner-only and removed when the run ends

### DIFF
--- a/internal/engine/apply.go
+++ b/internal/engine/apply.go
@@ -44,6 +44,8 @@ func (e *Engine) Apply(opts Options) error {
 		if _, err := exec.WriteTFVars(varsPath, vars); err != nil {
 			return nil, err
 		}
+		// Removed however this node exits: the file holds resolved input values in cleartext, and the next run rewrites it from scratch anyway.
+		defer func() { _ = os.Remove(varsPath) }()
 		varFileArgs := exec.VarFileArgs(varsPath, vars)
 
 		r := &exec.Runner{Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cloudfluent/terragraph/internal/exec"
 )
@@ -40,6 +41,8 @@ func (e *Engine) Destroy(opts Options) error {
 		if _, err := exec.WriteTFVars(varsPath, vars); err != nil {
 			return nil, err
 		}
+		// Removed however this node exits: the file holds resolved input values in cleartext, and the next run rewrites it from scratch anyway.
+		defer func() { _ = os.Remove(varsPath) }()
 
 		r := &exec.Runner{Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		// Unlike apply, there is no saved plan here for terragraph to ask about itself, so terraform's own confirmation is the approval — and it needs somewhere to read the answer from. Left nil when auto-approving, so an unattended run can never block on a question.

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cloudfluent/terragraph/internal/exec"
 )
@@ -32,6 +33,8 @@ func (e *Engine) Plan(opts Options) error {
 		if _, err := exec.WriteTFVars(varsPath, vars); err != nil {
 			return nil, err
 		}
+		// Removed however this node exits: the file holds resolved input values in cleartext, and the next run rewrites it from scratch anyway.
+		defer func() { _ = os.Remove(varsPath) }()
 
 		r := &exec.Runner{Binary: e.runtimeFor(name), Dir: nodeDir, DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		if err := r.Init(e.Graph.Nodes[name].BackendConfig); err != nil {

--- a/internal/engine/tfvars_cleanup_unix_test.go
+++ b/internal/engine/tfvars_cleanup_unix_test.go
@@ -31,6 +31,11 @@ func loadTFVarsCleanupEngine(t *testing.T) *Engine {
 	if err := os.WriteFile(filepath.Join(moduleDir, "managed.out"), []byte("version-one\n"), 0o644); err != nil {
 		t.Fatalf("writing managed output: %v", err)
 	}
+	// The unchanged path reads outputs without applying, and the fake terraform refuses `output`
+	// with no state the way the real one does, so this node has to look already-applied.
+	if err := os.WriteFile(filepath.Join(moduleDir, "terraform.tfstate"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("writing fixture state: %v", err)
+	}
 	blueprintPath := writeBlueprint(t, baseDir, `
 node "app" {
   source = "./module"

--- a/internal/engine/tfvars_cleanup_unix_test.go
+++ b/internal/engine/tfvars_cleanup_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+// loadTFVarsCleanupEngine builds a one-node engine whose node actually receives input values
+// (via vars), so Plan/Apply/Destroy genuinely write the tfvars file the cleanup defer removes;
+// without inputs WriteTFVars writes nothing and the absence assertion below would pass vacuously.
+func loadTFVarsCleanupEngine(t *testing.T) *Engine {
+	t.Helper()
+	baseDir := t.TempDir()
+	moduleDir := filepath.Join(baseDir, "module")
+	writeModule(t, moduleDir)
+	// The variable vars feeds, and payload.txt: the fake terraform's apply copies it into the
+	// saved plan (see writeFakeTerraform). managed.out starts as payload.txt's twin so a plain
+	// Plan (no -detailed-exitcode; any nonzero exit is an error there) reports no changes.
+	if err := os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte("variable \"payload\" {\n  type = string\n}\n"), 0o644); err != nil {
+		t.Fatalf("writing fixture variables: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "payload.txt"), []byte("version-one\n"), 0o644); err != nil {
+		t.Fatalf("writing payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "managed.out"), []byte("version-one\n"), 0o644); err != nil {
+		t.Fatalf("writing managed output: %v", err)
+	}
+	blueprintPath := writeBlueprint(t, baseDir, `
+node "app" {
+  source = "./module"
+  vars = { payload = "version-one" }
+}
+`)
+	t.Setenv("TG_COMMAND_LOG", filepath.Join(baseDir, "commands.log"))
+	t.Setenv("TG_PLAN_ERROR", filepath.Join(baseDir, "plan-error"))
+
+	e, err := Load(blueprintPath, exec.Binary(writeFakeTerraform(t, baseDir)), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e
+}
+
+// assertNoTFVars fails unless the node's tfvars file is gone: the file holds resolved input
+// values in cleartext, so a run that ends must not leave it behind on a shared runner.
+func assertNoTFVars(t *testing.T, e *Engine, node string) {
+	t.Helper()
+	if _, err := os.Stat(e.tfVarsPath(node)); !os.IsNotExist(err) {
+		t.Fatalf("tfvars file for node %s still present at %s after the run ended (stat err = %v)", node, e.tfVarsPath(node), err)
+	}
+}
+
+func TestPlan_RemovesTFVarsWhenRunEnds(t *testing.T) {
+	e := loadTFVarsCleanupEngine(t)
+
+	if err := e.Plan(Options{}); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	assertNoTFVars(t, e, "app")
+}
+
+func TestApply_RemovesTFVarsWhenRunEnds(t *testing.T) {
+	e := loadTFVarsCleanupEngine(t)
+
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	assertNoTFVars(t, e, "app")
+}

--- a/internal/exec/tfvars.go
+++ b/internal/exec/tfvars.go
@@ -24,6 +24,10 @@ func WriteTFVars(path string, vars map[string]any) (string, error) {
 		return "", fmt.Errorf("encoding tfvars for %s: %w", path, err)
 	}
 	// 0600, not the 0644 default: resolved inputs include upstream outputs, which are frequently secrets, and this file is per-run scratch that nothing but the owner (and the terraform run acting as them) ever needs to read.
+	// os.WriteFile applies perm only when creating, so a leftover 0644 from an older terragraph would stay world-readable for the whole run; removing first makes every write a create, keeping the owner-only mode true on the upgrade and crash-restart paths too.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("removing stale tfvars file %s: %w", path, err)
+	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("writing tfvars file %s: %w", path, err)
 	}

--- a/internal/exec/tfvars.go
+++ b/internal/exec/tfvars.go
@@ -23,7 +23,8 @@ func WriteTFVars(path string, vars map[string]any) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("encoding tfvars for %s: %w", path, err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	// 0600, not the 0644 default: resolved inputs include upstream outputs, which are frequently secrets, and this file is per-run scratch that nothing but the owner (and the terraform run acting as them) ever needs to read.
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("writing tfvars file %s: %w", path, err)
 	}
 	return path, nil

--- a/internal/exec/tfvars_perm_unix_test.go
+++ b/internal/exec/tfvars_perm_unix_test.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Windows largely ignores the mode bits os.WriteFile is given, so permission assertions live here rather than in tfvars_test.go.
+
+func TestWriteTFVars_OwnerOnlyPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".terragraph.vpc.tfvars.json")
+
+	if _, err := WriteTFVars(path, map[string]any{"vpc_id": "vpc-123"}); err != nil {
+		t.Fatalf("WriteTFVars: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("tfvars perm = %o, want 0600 (resolved inputs may be secret outputs; the file is never shared)", got)
+	}
+}
+
+// os.WriteFile applies perm only on create, so the rewrite path removes first: a 0644 leftover from before this hygiene fix must end at 0600 after any successful write.
+func TestWriteTFVars_RewriteTightensExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".terragraph.vpc.tfvars.json")
+
+	if err := os.WriteFile(path, []byte(`{"stale": true}`), 0o644); err != nil {
+		t.Fatalf("seeding world-readable leftover: %v", err)
+	}
+	if _, err := WriteTFVars(path, map[string]any{"vpc_id": "vpc-123"}); err != nil {
+		t.Fatalf("WriteTFVars over leftover: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("tfvars perm after rewrite = %o, want 0600 (a pre-existing 0644 must not survive the write)", got)
+	}
+}

--- a/internal/exec/tfvars_test.go
+++ b/internal/exec/tfvars_test.go
@@ -74,19 +74,3 @@ func TestVarFileArgs(t *testing.T) {
 		t.Fatalf("expected nil args for nil vars, got %v", got)
 	}
 }
-
-func TestWriteTFVars_OwnerOnlyPermissions(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".terragraph.vpc.tfvars.json")
-
-	if _, err := WriteTFVars(path, map[string]any{"vpc_id": "vpc-123"}); err != nil {
-		t.Fatalf("WriteTFVars: %v", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("tfvars perm = %o, want 0600 (resolved inputs may be secret outputs; the file is never shared)", got)
-	}
-}

--- a/internal/exec/tfvars_test.go
+++ b/internal/exec/tfvars_test.go
@@ -74,3 +74,19 @@ func TestVarFileArgs(t *testing.T) {
 		t.Fatalf("expected nil args for nil vars, got %v", got)
 	}
 }
+
+func TestWriteTFVars_OwnerOnlyPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".terragraph.vpc.tfvars.json")
+
+	if _, err := WriteTFVars(path, map[string]any{"vpc_id": "vpc-123"}); err != nil {
+		t.Fatalf("WriteTFVars: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("tfvars perm = %o, want 0600 (resolved inputs may be secret outputs; the file is never shared)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`exec.WriteTFVars` wrote resolved inputs `0o644` and nothing ever removed the file, so anything a secret output fed stayed world-readable on a shared runner after the run ended (#49 sequencing defect 5; must land before snapshots or a journal add files to the same directory). The file is now `0o600` (resolved values may be secret outputs; per-run ephemeral, never shared) and plan/apply/destroy remove it when each node's step ends, however it ends — mirroring the saved-plan removal `apply` already had.

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)
- `go test ./internal/exec ./internal/engine` ok; new cases: written tfvars stat as `0o600`; after a successful `plan` and after a successful `apply` no tfvars file remains at the engine's path for the node.

Refs #49 (sequencing defect 5).
