### PR TITLE
fix: destroy's approve gate checks what a node declared

### DIFF
--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -9,7 +9,6 @@ terragraph destroy [flags]
 ### Options
 
 ```
-      --approve string    what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
       --auto-approve      skip interactive approval
   -h, --help              help for destroy
       --node string       restrict to a single node

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -131,7 +131,9 @@ If this is intended, declare approve = "all" on that node, or re-run with --appr
 
 This is checked whether or not anyone is watching. An interactive `yes` answers "apply this plan", not "override the standing policy"; overriding it is `--approve=all`, which is a visible, deliberate act.
 
-An unattended destroy (`--auto-approve`) is held to the same policy without a plan to read: teardown is delete-only, so it requires every node in scope to resolve to `approve = "all"`, while an interactive destroy stays gated by Terraform's own confirmation prompt.
+`destroy` is held to the same policy without a plan to read. Teardown is delete-only, so a node that **declared** anything short of `approve = "all"` has already said it must not be torn down, and destroy refuses before anything runs — with or without `--auto-approve`, for the same reason apply's check does not care whether anyone is watching. A node that declared nothing is unaffected: `terragraph destroy` on an ordinary blueprint behaves exactly as it always has, gated by Terraform's own confirmation prompt.
+
+There is deliberately no `--approve` flag on `destroy`. The layering rule is that a run-wide flag only fills a gap nothing else spoke to, so it could never permit a teardown the blueprint refused; changing the node's own `approve` is the only route, and that goes through review.
 
 The check reads the saved plan file, so it cannot run on the `remote`/`cloud` backends, which have none. Apply stops on those nodes with an error rather than applying uninspected.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -287,7 +287,6 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 	var node string
 	var autoApprove bool
 	var parallelism int
-	var approve string
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Run terraform/tofu destroy across the graph in reverse dependency order",
@@ -300,17 +299,13 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 			if err := checkValidate(cmd, e); err != nil {
 				return err
 			}
-			level, err := blueprint.ParseApprove(approve)
-			if err != nil {
-				return err
-			}
-			return e.Destroy(engine.Options{Node: node, AutoApprove: autoApprove, Approve: level, Parallelism: parallelism})
+			return e.Destroy(engine.Options{Node: node, AutoApprove: autoApprove, Parallelism: parallelism})
 		},
 	}
 	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
-	cmd.Flags().StringVar(&approve, "approve", string(blueprint.ApproveSafe), "what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this")
+	// No --approve here, unlike apply: destroy's gate reads what a node declared, and the layering rule is that a CLI flag only fills a gap nothing else spoke to — so a flag could never permit a teardown the blueprint refused, and offering one would only suggest otherwise.
 	return cmd
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -211,23 +211,3 @@ func TestGraph_DoesNotTakeBlueprintLock(t *testing.T) {
 		t.Fatalf("graph should not take the blueprint lock, stat error = %v", err)
 	}
 }
-
-// destroy must expose the same --approve escape hatch apply does: the engine gate resolves opts.Approve, so a CLI that never parses the flag leaves `destroy --auto-approve` with no unattended route for nodes that declared nothing. An unknown value fails in ParseApprove — proving registration, parsing, and the pass-through call order — without shelling out to terraform.
-func TestDestroy_ApproveFlagIsWired(t *testing.T) {
-	dir := t.TempDir()
-	writeFixtureFile(t, filepath.Join(dir, "blueprint.hcl"), `node "a" { source = "./stacks/a" }`)
-	writeFixtureFile(t, filepath.Join(dir, "stacks/a/main.tf"), `output "x" { value = "hi" }`)
-
-	root := NewRootCmd("test")
-	var outBuf, errBuf bytes.Buffer
-	root.SetOut(&outBuf)
-	root.SetErr(&errBuf)
-	root.SetArgs([]string{"--blueprint", dir, "destroy", "--approve=bogus"})
-	err := root.Execute()
-	if err == nil {
-		t.Fatal("expected an error for an unknown --approve value")
-	}
-	if !strings.Contains(err.Error(), "unknown approve level") || strings.Contains(err.Error(), "unknown flag") {
-		t.Fatalf("expected --approve to reach blueprint.ParseApprove, got: %v", err)
-	}
-}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -18,17 +18,15 @@ func (e *Engine) Destroy(opts Options) error {
 		return fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
 	}
 
-	// Teardown is delete-only, so approve = "all" is the only level that permits it (the same all-gating apply's notPermitted gives destroy actions). An interactive destroy keeps terraform's own confirmation as the human gate — approve governs what may happen *without* someone saying so — but --auto-approve removes that human, so every in-scope node must already have said yes; --approve=all can only fill a gap, never override a node's own declaration. Checked before any lock is taken, so a refusal fails immediately rather than after waiting on whatever holds it.
-	if opts.AutoApprove {
-		levels, err := e.executionLevels(opts, true)
-		if err != nil {
-			return err
-		}
-		for _, level := range levels {
-			for _, name := range level {
-				if a := e.approveFor(name, opts.Approve); a != blueprint.ApproveAll {
-					return fmt.Errorf("destroy: node %s resolves to approve = %q, which does not permit teardown; set approve = \"all\" on the node (or its enclosing use), pass --approve=all for this run only, or run destroy without --auto-approve to approve interactively", name, a)
-				}
+	// Teardown is delete-only, so a node that declared anything short of approve = "all" has already said it must not be torn down unattended. This reads the declaration (graph.Node.Approve, "" when neither the node nor an enclosing use ever spoke) rather than approveFor's resolved level, which fills blanks down to ApproveSafe and would therefore refuse every node in an ordinary blueprint while a node that explicitly declared "none" still slipped through interactively — the inverse of the point. A declaration holds whether or not someone is watching, the same rule apply's gate follows. Checked before any lock is taken, so a refusal fails immediately rather than after waiting on whatever holds it.
+	levels, err := e.executionLevels(opts, true)
+	if err != nil {
+		return err
+	}
+	for _, level := range levels {
+		for _, name := range level {
+			if a := e.Graph.Nodes[name].Approve; a != "" && a != blueprint.ApproveAll {
+				return fmt.Errorf("destroy: node %s declares approve = %q, which does not permit teardown; change it to %q on that node (or its enclosing use) if tearing it down is intended", name, a, blueprint.ApproveAll)
 			}
 		}
 	}

--- a/internal/engine/destroy_approve_unix_test.go
+++ b/internal/engine/destroy_approve_unix_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudfluent/terragraph/internal/blueprint"
 	"github.com/cloudfluent/terragraph/internal/exec"
 )
 
@@ -33,8 +32,8 @@ func loadDestroyApproveEngine(t *testing.T, node string) (*Engine, string) {
 	return e, commandLog
 }
 
-// Teardown is delete-only, so an unattended destroy is permitted by approve = "all" alone; a node that said less is refused before anything runs, and --approve=all cannot speak for it, because the node's own declaration wins — the same layering apply already relies on.
-func TestDestroy_ApproveGateRefusesUnattendedTeardown(t *testing.T) {
+// A node that declared approve = "none" has said it must not be torn down, and destroy refuses before taking any lock. The declaration is what is read, not the resolved level: reading approveFor would fill blanks down to "safe" and refuse every ordinary node instead.
+func TestDestroy_RefusesANodeThatDeclaredLessThanAll(t *testing.T) {
 	e, commandLog := loadDestroyApproveEngine(t, `
 node "guarded" {
   source  = "./module"
@@ -44,16 +43,12 @@ node "guarded" {
 
 	err := e.Destroy(Options{AutoApprove: true})
 	if err == nil {
-		t.Fatal(`expected an unattended destroy to be refused at approve = "none"`)
+		t.Fatal(`expected destroy to be refused at approve = "none"`)
 	}
-	for _, want := range []string{"guarded", `approve = "none"`, `set approve = "all"`, "--auto-approve"} {
+	for _, want := range []string{"guarded", `approve = "none"`, `"all"`} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected the error to mention %q, got: %v", want, err)
 		}
-	}
-	// The run-wide flag fills a gap; it never overrides what the node declared.
-	if err := e.Destroy(Options{AutoApprove: true, Approve: blueprint.ApproveAll}); err == nil {
-		t.Fatal(`expected --approve=all not to override the node's own approve = "none"`)
 	}
 	// Refused before any lock was taken, so nothing was touched — a log that never came into being is the strongest form of that.
 	data, readErr := os.ReadFile(commandLog)
@@ -65,22 +60,8 @@ node "guarded" {
 	}
 }
 
-// The run-wide default fills a gap nothing else spoke to, so --approve=all permits unattended teardown of nodes that declared nothing — the one-off route for an intentional destroy.
-func TestDestroy_ApproveGateRunLevelPermitsUnattendedTeardown(t *testing.T) {
-	e, _ := loadDestroyApproveEngine(t, `
-node "guarded" { source = "./module" }
-`)
-
-	if err := e.Apply(Options{AutoApprove: true}); err != nil {
-		t.Fatalf("Apply: %v", err)
-	}
-	if err := e.Destroy(Options{AutoApprove: true, Approve: blueprint.ApproveAll}); err != nil {
-		t.Fatalf("expected --approve=all to permit unattended teardown: %v", err)
-	}
-}
-
-// A node declaring approve = "none" can still be torn down by a human: interactive destroy's gate is terraform's own confirmation prompt, which is exactly the someone-saying-so that approve levels defer the decision to.
-func TestDestroy_ApproveGateInteractiveStaysHumanGated(t *testing.T) {
+// The declaration holds whether or not anyone is watching, the same rule apply's gate follows: an interactive "yes" answers "tear down this node", not "override the standing policy". Without this, approve = "none" protected nothing the moment someone was at the terminal.
+func TestDestroy_RefusesADeclaredNodeEvenInteractively(t *testing.T) {
 	e, _ := loadDestroyApproveEngine(t, `
 node "guarded" {
   source  = "./module"
@@ -89,7 +70,21 @@ node "guarded" {
 `)
 
 	e.Stdin = strings.NewReader("yes\n")
-	if err := e.Destroy(Options{}); err != nil {
-		t.Fatalf("expected interactive destroy to be gated by terraform's prompt, not the approve level: %v", err)
+	if err := e.Destroy(Options{}); err == nil {
+		t.Fatal(`expected an interactive destroy to be refused at approve = "none"`)
+	}
+}
+
+// Nothing in the node's chain ever spoke, so nothing is being overridden and teardown proceeds — the ordinary blueprint, unchanged by this gate.
+func TestDestroy_PermitsANodeThatDeclaredNothing(t *testing.T) {
+	e, _ := loadDestroyApproveEngine(t, `
+node "guarded" { source = "./module" }
+`)
+
+	if err := e.Apply(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := e.Destroy(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("expected teardown of an undeclared node to proceed: %v", err)
 	}
 }

--- a/internal/engine/tfvars_cleanup_unix_test.go
+++ b/internal/engine/tfvars_cleanup_unix_test.go
@@ -78,3 +78,13 @@ func TestApply_RemovesTFVarsWhenRunEnds(t *testing.T) {
 	}
 	assertNoTFVars(t, e, "app")
 }
+
+// destroy writes the same cleartext file the other two do — and its resolved inputs can feed count/for_each, so a stale one left behind is the worst of the three to reuse. The node declares nothing, so the approve gate lets teardown through.
+func TestDestroy_RemovesTFVarsWhenRunEnds(t *testing.T) {
+	e := loadTFVarsCleanupEngine(t)
+
+	if err := e.Destroy(Options{AutoApprove: true}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	assertNoTFVars(t, e, "app")
+}


### PR DESCRIPTION
## What this fixes

#54 landed a gate on `destroy --auto-approve`, but it reads `approveFor`, which fills blanks down to `ApproveSafe`. So it catches the wrong node:

| node | before #54 | after #54 | this PR |
|---|---|---|---|
| declares nothing | destroyed | interactive: destroyed<br>`--auto-approve`: **refused** | destroyed |
| `approve = "none"` | destroyed | interactive: **destroyed**<br>`--auto-approve`: refused | **refused** |
| `approve = "all"` | destroyed | destroyed | destroyed |

It misses the node someone deliberately protected — the case #54 was filed for — and refuses every ordinary node, which breaks every existing `terragraph destroy --auto-approve`, including tearing down an already-empty environment.

## What changed

The gate now reads `graph.Node.Approve`: the node's own declaration plus the `use` cascade, `""` when nothing in that chain ever spoke.

The `--auto-approve` condition is gone, so a declaration holds whether or not someone is at the terminal — the rule `apply` already follows: *"checked whether or not anyone is watching. An interactive `yes` answers 'apply this plan', not 'override the standing policy'."*

`--approve` is dropped from `destroy`. A run-wide flag only fills a gap nothing else spoke to, so it could never permit a teardown the blueprint refused; offering one would suggest otherwise.

Net effect on a blueprint that declares nothing: identical to before #54. This is no longer a breaking change, which makes the `fix:` label accurate again.

## Also here

`destroy` had the tfvars-cleanup `defer` from #58 but no test covering it — three call sites, two tests. It is the file this batch edits most, and the one where a stale tfvars matters most since its resolved inputs can feed `count` / `for_each`.

## Verification

```
$ make check
EXIT=0
```

Tests rewritten for the new semantics rather than adjusted: a declared node is refused unattended, a declared node is refused *interactively* (the hole #54 left open), and an undeclared node is torn down normally. The interactive case is the one that would silently pass again if this regressed.