### PR TITLE
fix: contract diagnostics no longer depend on map iteration order

### DIFF
--- a/internal/blueprint/contract.go
+++ b/internal/blueprint/contract.go
@@ -44,7 +44,9 @@ type canonicalEntry struct {
 	Port canonicalPort `json:"port"`
 }
 
-// Digest is the contract set's identity: sha256 hex over a canonical JSON form covering exactly the checked claims — scope, role, port, type, nullable, sensitive — with every port sorted by (scope, role, name). Map iteration order must never leak into identity — anything binding to a contract set binds to this value — which is why the entries are collected and sorted rather than marshalled straight from the maps.
+// Digest is the contract set's identity: sha256 hex over a canonical JSON form covering exactly the checked claims — scope, role, port, type, nullable, sensitive — with every port sorted by (scope, role, name). Entries are collected and sorted rather than marshalled straight from the maps so iteration order can never leak into identity.
+//
+// Nothing calls this yet. It is kept, rather than deleted and rewritten later, because the resume condition the run journal needs — "does this incomplete run's contract set still match?" — is exactly this value, and because the property its tests pin (reordering blocks must not change identity, changing any claim must) is easier to keep true continuously than to re-establish. Delete it if that consumer is abandoned.
 func (c *Contracts) Digest() (string, error) {
 	entries := make([]canonicalEntry, 0)
 	for _, dc := range c.ByDir {

--- a/internal/graph/build.go
+++ b/internal/graph/build.go
@@ -35,7 +35,7 @@ type Graph struct {
 	Lock *blueprint.Lock
 	// Contracts is the blueprint's contract set, merged by Build: the root blueprint's own producer/consumer blocks plus every instantiated group's (see mergeContracts). Keying is hybrid (see blueprint.DirContracts): local scopes by resolved source directory, remote scopes by the declared source string, so two vendored instances of one remote module share one record. Nil is the ordinary, uncontracted graph, and every contract-aware consumer must treat nil as "no claims, no checks".
 	Contracts *blueprint.Contracts
-	// ContractMode is the blueprint's `contracts { mode = ... }` value, set by engine load after Build; graph reads it only to pick contract-problem severity (enforce escalates C001-C006 to errors), never to change what is checked.
+	// ContractMode is the blueprint's `contracts { mode = ... }` value, set by engine load after Build; graph reads it only to pick contract-problem severity (enforce escalates every C0xx to an error), never to change what is checked.
 	ContractMode string
 }
 

--- a/internal/graph/contracts_test.go
+++ b/internal/graph/contracts_test.go
@@ -576,3 +576,49 @@ producer "github.com/org/repo//modules/vpc" {
 		t.Fatalf("got = %v, want exactly one C001 naming the shared source", problems)
 	}
 }
+
+// Two nodes sharing one remote source are inspected separately — their Dir is vendor/<node-name> — so re-vendoring one of them (vendor --node) can leave the copies disagreeing about what the module declares. Which copy the contract is judged against must be a decision, not whatever the node map yields.
+//
+// The fixture makes the choice observable: only "b" declares vpc_id, so reading "a" reports C001 and reading "b" reports nothing. Asserting the lowest-named node wins pins the rule. Note that a loop here would prove nothing — Go randomises map iteration between processes but held one order within a single run, so the map-ordered version passed a twelve-iteration stability check and only varied from one `go test` to the next.
+func TestContractProblems_RemoteSourceSchemaIsTheLowestNamedNode(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "vendor/a/main.tf"), `output "other" { value = "x" }`)
+	writeFixtureFile(t, filepath.Join(root, "vendor/b/main.tf"), `output "vpc_id" { value = "x" }`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "a" { source = "github.com/acme/vpc" }
+node "b" { source = "github.com/acme/vpc" }
+
+producer "github.com/acme/vpc" {
+  output "vpc_id" { type = "string" }
+}
+`)
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	g, err := Build(bp, root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	problems := contractProblems(g)
+	if len(problems) != 1 || !strings.Contains(problems[0].Message, "[C001]") {
+		t.Fatalf("got = %v, want one C001 from reading node a's copy", problems)
+	}
+}
+
+// sortedContracts orders by Scope, but entries are keyed by Dir, and the root blueprint and a group can each write "./modules/vpc" relative to their own file — same spelling, different module. The tie has to break on something stable; leaving it to sort stability hands the order back to map iteration, which is what this function exists to remove.
+func TestSortedContracts_BreaksScopeTiesOnDir(t *testing.T) {
+	c := &blueprint.Contracts{ByDir: map[string]*blueprint.DirContracts{
+		"/z/modules/vpc": {Scope: "./modules/vpc", Dir: "/z/modules/vpc"},
+		"/a/modules/vpc": {Scope: "./modules/vpc", Dir: "/a/modules/vpc"},
+		"/m/modules/vpc": {Scope: "./modules/vpc", Dir: "/m/modules/vpc"},
+	}}
+
+	want := []string{"/a/modules/vpc", "/m/modules/vpc", "/z/modules/vpc"}
+	for k, dc := range sortedContracts(c) {
+		if dc.Dir != want[k] {
+			t.Fatalf("position %d = %q, want %q", k, dc.Dir, want[k])
+		}
+	}
+}

--- a/internal/graph/validate_contracts.go
+++ b/internal/graph/validate_contracts.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
@@ -25,9 +26,14 @@ func contractProblems(g *Graph) []Problem {
 	if g.Contracts == nil {
 		return nil
 	}
-	used := map[string]bool{}
+	// Nodes are grouped by contract key and sorted by name so the schema a contract is judged against never depends on map iteration order. It matters only for remote sources: nodes sharing a local directory share one cached *module.Schema, but two instances of one remote module live in vendor/<node-name> and are inspected separately, so re-vendoring a single node (vendor --node) can leave the two copies disagreeing. Picking by name makes the answer stable; the second copy still goes uninspected, which is a gap worth its own diagnostic rather than a silent tiebreak.
+	byKey := map[string][]*Node{}
 	for _, n := range g.Nodes {
-		used[contractKey(n)] = true
+		key := contractKey(n)
+		byKey[key] = append(byKey[key], n)
+	}
+	for _, nodes := range byKey {
+		sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 	}
 
 	// Enforce is the only mode that blocks, and it exists only as reviewed blueprint configuration — never as a default or a CLI flag someone passes once.
@@ -43,17 +49,12 @@ func contractProblems(g *Graph) []Problem {
 
 	// C001/C002/C006: contracts against reality, independent of edges — a promise about a port the module never declared, or a scope nothing instantiates, is wrong whether or not anything consumes it yet.
 	for _, dc := range sortedContracts(g.Contracts) {
-		if !used[dc.Dir] {
+		owners := byKey[dc.Dir]
+		if len(owners) == 0 {
 			report("contract.[C006] %s: no node in this graph uses source %q; update the scope path or remove the contract", dc.Scope, dc.Scope)
 			continue
 		}
-		var schemaOwner *Node
-		for _, n := range g.Nodes {
-			if contractKey(n) == dc.Dir {
-				schemaOwner = n
-				break
-			}
-		}
+		schemaOwner := owners[0]
 		for _, name := range sortedPorts(dc.Producer) {
 			if !schemaOwner.Schema.HasOutput(name) {
 				report("contract.[C001] producer %s.output.%s: module declares no such output; remove the promise or add the output", dc.Scope, name)
@@ -150,16 +151,19 @@ func parseCtyType(s string) (cty.Type, error) {
 }
 
 // sortedContracts / sortedPorts exist so problem order — and therefore test output and JSON — never depends on map iteration.
+//
+// Scope alone does not order the set: entries are keyed by Dir, and two of them can share a Scope spelling while resolving to different directories (the root blueprint and a group each writing "./modules/vpc" relative to their own file). Dir breaks that tie, because leaving it to the sort's stability hands the order straight back to the map this function exists to sort away from.
 func sortedContracts(c *blueprint.Contracts) []*blueprint.DirContracts {
 	out := make([]*blueprint.DirContracts, 0, len(c.ByDir))
 	for _, dc := range c.ByDir {
 		out = append(out, dc)
 	}
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j].Scope < out[j-1].Scope; j-- {
-			out[j], out[j-1] = out[j-1], out[j]
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Scope != out[j].Scope {
+			return out[i].Scope < out[j].Scope
 		}
-	}
+		return out[i].Dir < out[j].Dir
+	})
 	return out
 }
 
@@ -168,10 +172,6 @@ func sortedPorts(m map[string]blueprint.PortContract) []string {
 	for name := range m {
 		out = append(out, name)
 	}
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j] < out[j-1]; j-- {
-			out[j], out[j-1] = out[j-1], out[j]
-		}
-	}
+	sort.Strings(out)
 	return out
 }


### PR DESCRIPTION
Two places in `contractProblems` let Go's map ordering decide what `validate` reports.

## The schema a contract is judged against

`schemaOwner` was whichever node the node map yielded first. That is harmless for local sources — every node sharing a directory holds the same cached `*module.Schema` — but two instances of one *remote* module live in `vendor/<node-name>` and are inspected separately. `terragraph vendor --node a` re-fetches only that node, so the copies can drift, and then C001 / C002 / C007 / C008 / C009 report differently from one run to the next.

Nodes are now grouped by contract key once and sorted by name.

The second copy still goes uninspected. That is a real gap, but it wants its own diagnostic — "two vendored realizations of one contracted source disagree" — rather than being buried in a tiebreak, so the comment names it instead of pretending it is closed.

## Problem ordering

`sortedContracts` compared `Scope` alone while entries are keyed by `Dir`. The root blueprint and a group can each write `"./modules/vpc"` relative to their own file: same spelling, different module. The tie fell through to insertion order — the map order this function exists to remove. It now breaks on `Dir`.

Both helpers use `sort.Slice` / `sort.Strings` instead of hand-rolled insertion sorts. That is not only style: the single-key loop is what left nowhere obvious to put a second key, which is how the tie was missed.

## Also

- `Digest()` has had no caller since the evidence layer was removed. Its comment claimed *"anything binding to a contract set binds to this value"*. It is kept — the run journal's resume condition is exactly this value, and the property its tests pin is cheaper to hold continuously than to re-establish — but the comment now says that rather than implying a consumer exists.
- A comment naming the `C001-C006` range predates C007-C009.

## Verification

```
$ make check
EXIT=0
```

Worth flagging how the first test was arrived at. A twelve-iteration stability loop **passed against the buggy code**: Go randomises map iteration between processes but held one order within a single `go test` run. The test now asserts *which* node wins, with a fixture where the two vendored copies disagree so the choice is observable. Against the pre-fix code that fails in 6 of 8 runs; with the fix it passes every time.