### PR TITLE
fix: a node's explicit backend path no longer claims a same-named orphan

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -352,11 +352,21 @@ func (e *Engine) stateOrphans() []graph.Problem {
 	if err != nil {
 		return nil // No state directory yet (fresh or never-applied project): nothing can be orphaned.
 	}
+	// Claims are whole resolved paths, not basenames, so a node that owns some other directory's live.tfstate cannot vouch for the one in here and silence a real orphan.
+	//
+	// A relative explicit path is claimed under both bases it could resolve to. Terraform resolves -backend-config=path against the subprocess's working directory, which is the node's module directory, while docs/blueprint.md's example (".terragraph/state/<node>.tfstate") reads as blueprint-relative — and which one a real terraform produces is not settled here. Claiming both keeps this warning conservative in the direction that matters: it can only ever stay silent about a file some node might own, never accuse one that is live.
 	claimed := make(map[string]bool)
 	for _, n := range e.Graph.Nodes {
-		if p, ok := n.BackendConfig["path"]; ok {
-			claimed[filepath.Base(p)] = true
+		p, ok := n.BackendConfig["path"]
+		if !ok {
+			continue
 		}
+		if filepath.IsAbs(p) {
+			claimed[filepath.Clean(p)] = true
+			continue
+		}
+		claimed[filepath.Clean(filepath.Join(n.Dir, p))] = true
+		claimed[filepath.Clean(filepath.Join(e.BaseDir, p))] = true
 	}
 	var stale []string
 	for _, entry := range entries {
@@ -367,7 +377,7 @@ func (e *Engine) stateOrphans() []graph.Problem {
 		if !strings.HasSuffix(fname, ".tfstate") {
 			continue
 		}
-		if !claimed[fname] {
+		if !claimed[filepath.Join(dir, fname)] {
 			stale = append(stale, fname)
 		}
 	}
@@ -376,7 +386,8 @@ func (e *Engine) stateOrphans() []graph.Problem {
 	for _, fname := range stale {
 		problems = append(problems, graph.Problem{
 			Severity: graph.SeverityWarning,
-			Message:  fmt.Sprintf("%s: state for a node that no longer exists in this blueprint; if the node was renamed, rename it back (or remove/import the state file if abandoned)", filepath.Join(dir, fname)),
+			// The .backup sibling the local backend writes is named here rather than reported on its own: it is not a state file anyone can adopt, but "remove the file" that leaves it behind is incomplete advice.
+			Message: fmt.Sprintf("%s: state for a node that no longer exists in this blueprint; if the node was renamed, rename it back (or remove/import the state file, and its .tfstate.backup sibling if present, when abandoned)", filepath.Join(dir, fname)),
 		})
 	}
 	return problems

--- a/internal/engine/state_orphans_test.go
+++ b/internal/engine/state_orphans_test.go
@@ -92,3 +92,38 @@ node "vpc" {
 		t.Fatalf("expected no warnings while the explicit path's node exists, got: %+v", problems)
 	}
 }
+
+// A node whose explicit path points somewhere else entirely must not vouch for a same-named file in the state directory. Matching on the basename alone did exactly that: "live.tfstate" owned by a node writing into its own module directory silenced the orphan sitting under .terragraph/state.
+func TestStateOrphans_ExplicitPathElsewhereDoesNotClaimTheStateDir(t *testing.T) {
+	baseDir := t.TempDir()
+	writeModule(t, filepath.Join(baseDir, "stacks", "vpc"))
+	path := writeBlueprint(t, baseDir, `
+node "vpc" {
+  source         = "./stacks/vpc"
+  backend_config = { path = "/somewhere/else/live.tfstate" }
+}
+`)
+
+	e, err := Load(path, exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	orphan := filepath.Join(e.BaseDir, ".terragraph", "state", "live.tfstate")
+	if err := os.MkdirAll(filepath.Dir(orphan), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(orphan, []byte(`{"version":4}`), 0o644); err != nil {
+		t.Fatalf("writing orphan fixture: %v", err)
+	}
+
+	var got []string
+	for _, p := range e.Validate() {
+		got = append(got, p.Message)
+	}
+	if len(got) != 1 || !strings.Contains(got[0], "live.tfstate") {
+		t.Fatalf("got = %v, want one warning naming the stray live.tfstate", got)
+	}
+	if !strings.Contains(got[0], ".tfstate.backup") {
+		t.Fatalf("remedy should mention the backup sibling, got: %q", got[0])
+	}
+}


### PR DESCRIPTION
`stateOrphans` matched by basename, so a node writing its state somewhere else entirely still vouched for an identically named file under `.terragraph/state` — silencing exactly the warning #55 added.

```hcl
node "vpc" {
  source         = "./stacks/vpc"
  backend_config = { path = "/somewhere/else/live.tfstate" }
}
```

A stray `.terragraph/state/live.tfstate` went unreported. Claims are whole resolved paths now.

## One thing I could not settle

A relative explicit `path` is claimed under **both** bases it could resolve to.

Terraform resolves `-backend-config=path` against the subprocess's working directory, which here is the node's module directory. But `docs/blueprint.md`'s own example reads as blueprint-relative:

```hcl
backend_config = {
  path = ".terragraph/state/data-apne2-dev-vpc.tfstate"
}
```

…and it sits next to the default-fill, which *is* `<blueprint dir>/.terragraph/state/<node>.tfstate`. Which one a real `terraform init` produces is not something the test suite can answer — the fake binary never touches a backend — and I did not want to encode a guess in a warning.

Claiming both keeps this conservative in the direction that matters: it can stay silent about a file some node might own, but it can never accuse one that is live.

**Worth settling separately**, since it is a user-facing question, not a diagnostics one: if the doc's example resolves against the module directory, then two nodes sharing a `source` and both setting that path collide on one state file — which is the exact failure `backend_config` exists to prevent.

## Also

The remedy names the `.tfstate.backup` sibling the local backend writes. "Remove the state file" alone leaves it behind.

## Verification

```
$ make check
EXIT=0
```

The new test fails against basename matching (`got = []`, no warning) and passes with the fix.