### PR TITLE
fix: force-unlock works on an unvendored checkout and names the lock holder

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -57,7 +57,9 @@ The mechanism is an S3 lock **object** via conditional writes (the same idea as 
 
 If the object already exists, the command **fails immediately** (it does not wait the way flock does).
 
-Ctrl-C / SIGTERM / SIGKILL leave the S3 object (the process exits without running `defer`; flock still drops with the fd). A failed `DeleteObject` after a successful run does the same: the command prints the error to stderr and still reports success. Recover with `terragraph force-unlock --yes`: it deletes the configured lock object and prints `released <bucket>/<key>`. `--yes` is required — and the command refuses to say more than bucket/key without it — because releasing is unconditional and could break a lock that is genuinely held.
+Ctrl-C / SIGTERM / SIGKILL leave the S3 object (the process exits without running `defer`; flock still drops with the fd). A failed `DeleteObject` after a successful run does the same: the command prints the error to stderr and still reports success. Recover with `terragraph force-unlock --yes`: it deletes the configured lock object. `--yes` is required because releasing is unconditional and could break a lock that is genuinely held; without it the command names the object and, when the object can still be read, who wrote it and when — the one thing you need to decide whether breaking it is safe.
+
+It only parses the blueprint, so it works on a checkout with nothing vendored yet, which is the usual shape of a recovery. It does refuse while another `terragraph` process on the same checkout is running, since that process is the likeliest legitimate holder; it cannot see processes on other machines, which is what `--yes` is for.
 
 IAM on the lock key needs `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject`. Conditional delete uses `If-Match`, which AWS evaluates as a Get; `s3:DeleteObject` alone is not enough.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,9 +2,12 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -60,7 +63,7 @@ func NewRootCmd(version string) *cobra.Command {
 	root.AddCommand(newPlanCmd(&blueprintPath, binaryOf, loggerOf))
 	root.AddCommand(newApplyCmd(&blueprintPath, binaryOf, loggerOf))
 	root.AddCommand(newDestroyCmd(&blueprintPath, binaryOf, loggerOf))
-	root.AddCommand(newForceUnlockCmd(&blueprintPath, binaryOf, loggerOf))
+	root.AddCommand(newForceUnlockCmd(&blueprintPath))
 	root.AddCommand(newVendorCmd(&blueprintPath, loggerOf))
 	root.AddCommand(newLanguageServerCmd())
 
@@ -309,28 +312,52 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 	return cmd
 }
 
-func newForceUnlockCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
+func newForceUnlockCmd(blueprintPath *string) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
 		Use:   "force-unlock",
 		Short: "Release a leftover graph lock object left by an interrupted run",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// loadEngine, not loadLockedEngine: the stuck lock is exactly why this command exists, and it never reads module files, so there is nothing to protect with the process lock.
-			e, err := loadEngine(cmd, blueprintPath, binaryOf, loggerOf)
+			// The blueprint is parsed, not built into a graph: all this needs is the lock block, and graph.Build stats every node source — so a checkout with nothing vendored yet would abort the one command that exists to recover from an interrupted run. Same reason newVendorCmd parses directly.
+			bp, dir, err := blueprint.LoadPath(*blueprintPath)
 			if err != nil {
 				return err
 			}
-			lock := e.Graph.Lock
-			if lock == nil {
-				return fmt.Errorf("this blueprint declares no graph lock")
+			if bp.Lock == nil {
+				return fmt.Errorf("this blueprint declares no graph lock; there is nothing for force-unlock to release")
 			}
+			baseDir, err := filepath.Abs(dir)
+			if err != nil {
+				return fmt.Errorf("resolving blueprint directory: %w", err)
+			}
+
+			// A live process on this checkout is the likeliest legitimate holder of the graph lock about to be deleted, and flock drops with the fd on exit, so a held one means someone is genuinely running rather than that a crash left it behind. It says nothing about other machines — that is what --yes is for — but the same-machine mistake is free to catch.
+			lock, err := runlock.TryAcquire(baseDir)
+			if err != nil {
+				if errors.Is(err, runlock.ErrHeld) {
+					return fmt.Errorf("another terragraph process is using this blueprint and may hold the graph lock legitimately; wait for it to finish")
+				}
+				return fmt.Errorf("locking blueprint: %w", err)
+			}
+			defer func() { _ = lock.Close() }()
+
+			s3 := bp.Lock.S3
+			// Who holds the lock is worth showing but never worth waiting on: this is the command someone reaches for when a backend is already misbehaving, so an unreachable one degrades to "unknown" on a short deadline rather than stalling the refusal it exists to explain.
+			holderCtx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+			who, created := graphlock.Holder(holderCtx, bp.Lock)
+			cancel()
+			held := ""
+			if who != "" {
+				held = fmt.Sprintf(", held by %s since %s", who, created)
+			}
+
 			if !yes {
-				return fmt.Errorf("refusing to release %s/%s without --yes; run terragraph force-unlock --yes", lock.S3.Bucket, lock.S3.Key)
+				return fmt.Errorf("refusing to release s3://%s/%s%s without --yes; the holder may still be running, and releasing is unconditional", s3.Bucket, s3.Key, held)
 			}
-			if err := graphlock.Release(cmd.Context(), lock); err != nil {
+			if err := graphlock.Release(cmd.Context(), bp.Lock); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "released %s/%s\n", lock.S3.Bucket, lock.S3.Key)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "released s3://%s/%s%s\n", s3.Bucket, s3.Key, held)
 			return nil
 		},
 	}

--- a/internal/cli/force_unlock_test.go
+++ b/internal/cli/force_unlock_test.go
@@ -54,3 +54,36 @@ func TestForceUnlock_RefusesWithoutYes(t *testing.T) {
 		}
 	}
 }
+
+// The command this reaches for exists because a run was interrupted, and the natural next step is a fresh checkout — which has nothing vendored. Building the graph stats every node source, so it aborted before ever looking at the lock block. Parsing the blueprint is enough: the refusal below proves it got as far as the lock.
+func TestForceUnlock_WorksOnAnUnvendoredCheckout(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "blueprint.hcl"), `
+node "eks" { source = "github.com/acme/eks" }
+
+lock {
+  s3 {
+    bucket = "acme-tfstate"
+    key    = "terragraph/prod.lock"
+    region = "ap-northeast-2"
+  }
+}
+`)
+
+	root := NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"--blueprint", filepath.Join(dir, "blueprint.hcl"), "force-unlock"})
+	err := root.Execute()
+
+	if err == nil {
+		t.Fatal("expected the --yes refusal")
+	}
+	if strings.Contains(err.Error(), "not vendored") {
+		t.Fatalf("force-unlock should not need vendored modules, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--yes") || !strings.Contains(err.Error(), "terragraph/prod.lock") {
+		t.Fatalf("expected a refusal naming the lock object, got: %v", err)
+	}
+}

--- a/internal/graphlock/graphlock.go
+++ b/internal/graphlock/graphlock.go
@@ -18,6 +18,8 @@ type Backend interface {
 	Matches(lock *blueprint.Lock) bool
 	Acquire(ctx context.Context, lock *blueprint.Lock) (Held, error)
 	Release(ctx context.Context, lock *blueprint.Lock) error
+	// Holder reports who holds the lock and since when, for force-unlock to show before it breaks one. Empty strings mean unknown, which is not an error: the object may already be gone.
+	Holder(ctx context.Context, lock *blueprint.Lock) (who, created string)
 }
 
 // Held is a held graph lock. Close releases it. Close on a nil or already-released Held is a no-op.
@@ -45,6 +47,19 @@ func Acquire(ctx context.Context, lock *blueprint.Lock) (Held, error) {
 		}
 	}
 	return nil, fmt.Errorf("no graph lock backend matches this lock block")
+}
+
+// Holder reports who currently holds the lock described by lock, and since when, so force-unlock can show what it is about to break. Empty strings mean unknown — an unreadable or already-deleted object is not an error here.
+func Holder(ctx context.Context, lock *blueprint.Lock) (who, created string) {
+	if lock == nil {
+		return "", ""
+	}
+	for _, b := range backends {
+		if b.Matches(lock) {
+			return b.Holder(ctx, lock)
+		}
+	}
+	return "", ""
 }
 
 // Release deletes a leftover graph lock object (force-unlock). Held.Close refuses a lock whose etag moved; Release skips that guard on purpose — the holder is gone, so no If-Match could ever match — leaving the --yes confirmation at the CLI as the only safety. A nil lock is a no-op.

--- a/internal/graphlock/graphlock_test.go
+++ b/internal/graphlock/graphlock_test.go
@@ -16,6 +16,11 @@ type fakeBackend struct {
 
 func (f fakeBackend) Matches(lock *blueprint.Lock) bool { return f.matches }
 
+// The fake reports no holder: every test here is about dispatch and error paths, not about what a real object says, and "unknown" is the shape a caller must already handle.
+func (f fakeBackend) Holder(ctx context.Context, lock *blueprint.Lock) (string, string) {
+	return "", ""
+}
+
 func (f fakeBackend) Acquire(ctx context.Context, lock *blueprint.Lock) (Held, error) {
 	if f.calls != nil {
 		*f.calls++

--- a/internal/graphlock/s3.go
+++ b/internal/graphlock/s3.go
@@ -82,6 +82,16 @@ func (b s3Backend) Acquire(ctx context.Context, lock *blueprint.Lock) (Held, err
 }
 
 // Release deletes the lock object unconditionally (force-unlock path). Unlike Close there is no If-Match: the etag belongs to a run that no longer exists, and gating on it would make recovery impossible.
+// Holder reports who wrote the lock object and when, from the payload Acquire stored. Empty strings mean the object is gone or unreadable — force-unlock still has to work when the answer cannot be had, so this reports absence rather than failing.
+func (b s3Backend) Holder(ctx context.Context, lock *blueprint.Lock) (who, created string) {
+	cfg := lock.S3
+	client, err := b.client(ctx, cfg.Region)
+	if err != nil {
+		return "", ""
+	}
+	return readLockHolder(ctx, client, cfg)
+}
+
 func (b s3Backend) Release(ctx context.Context, lock *blueprint.Lock) error {
 	cfg := lock.S3
 	client, err := b.client(ctx, cfg.Region)


### PR DESCRIPTION
Three things about the command that exists to recover from an interrupted run.

## It could not run on the checkout you would recover from

`loadEngine` builds the graph, which stats every node source:

```
$ terragraph force-unlock --yes
Error: node "eks": source "github.com/acme/eks" is not vendored yet; run "terragraph vendor --node eks"
```

An interrupted CI run leaves the object; the natural next step is a fresh checkout, which by definition has nothing vendored. Deleting an S3 object should not require fetching modules. It parses the blueprint now — the way `newVendorCmd` already does, for the same reason.

## It didn't say who holds the lock

`--yes` asks the operator one question: *is this lock dead, or is someone running right now?* The answer is in the object, and `Acquire`'s failure message already prints it. The refusal now does too:

```
Error: refusing to release s3://acme-tfstate/terragraph/prod.lock, held by seungmun@ci-runner-3
since 2026-09-04T05:12:00Z without --yes; the holder may still be running, and releasing is
unconditional
```

Bounded at three seconds. This is the command someone reaches for when a backend is already misbehaving, so an unreachable one degrades to "unknown" instead of stalling the refusal it exists to explain.

## The comment justified it with the wrong lock

> loadEngine, not loadLockedEngine: the stuck lock is exactly why this command exists, and it never reads module files

Both halves were wrong. The stuck lock is the **S3 object**; `loadLockedEngine` takes the **local flock**, which a leftover object does not block. And `graph.Build` runs `module.Inspect` over every node directory.

It now takes the flock via `TryAcquire`. A live process on this checkout is the likeliest legitimate holder of the lock about to be deleted, and flock drops with the fd on exit — so a held one means someone is genuinely running, not that a crash left it behind. It says nothing about other machines; that is what `--yes` is for.

## Verification

```
$ make check
EXIT=0
```

The new test asserts the unvendored checkout reaches the `--yes` refusal rather than the vendor error. I confirmed the premise separately — a graph-building command on that same fixture does fail with `is not vendored yet` — so the negative assertion has teeth.

`Backend` gained a `Holder` method, so the test fake implements it too.