### PR TITLE
fix: redact sensitive input validation errors

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -16,6 +16,8 @@ Type checking is a runtime check, not static inference: a standard root module's
 
 ## How values are passed
 
+Input validation errors omit value-derived details, including object and map keys, when the destination variable or the inspected upstream output is declared `sensitive`. The error still names the node, input, and declared type so you can check the value against the module's variable declaration. This applies to terragraph's encoding and type-checking errors, including their JSON run reports; it does not redact arbitrary Terraform/OpenTofu subprocess output.
+
 terragraph never writes or modifies `.tf` files. Before running a node, it writes the values resolved from its incoming data edges (and its own `vars`, including literals a `use.vars` rewrote onto that node; see [blueprint.md](blueprint.md#literal-input-values-vars)) to an ephemeral, engine-managed tfvars file, then passes it to Terraform explicitly via `-var-file`. Terraform's own `*.auto.tfvars.json` auto-loading is never relied on: two nodes can share a module directory (see `backend_config` in [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), and auto-loading by a fixed filename would let them clobber each other's values.
 
 Where that file is written is controlled by an optional `tfvars` block:

--- a/internal/cli/sensitive_inputs_unix_test.go
+++ b/internal/cli/sensitive_inputs_unix_test.go
@@ -1,0 +1,220 @@
+//go:build !windows
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSensitiveInputFixture includes an invalid required field so the failure remains valid even if extra object attributes become accepted later.
+func writeSensitiveInputFixture(t *testing.T, sensitive bool) string {
+	t.Helper()
+	bp := writeRunFixture(t)
+	dir := filepath.Dir(bp)
+	writeFixtureFile(t, filepath.Join(dir, "module", "main.tf"), fmt.Sprintf(`variable "credentials" {
+  type = object({ count = number })
+  sensitive = %t
+}
+`, sensitive))
+	writeFixtureFile(t, bp, fmt.Sprintf(`runtime "fake" { binary = %q }
+node "a" {
+  source = "./module"
+  runtime = runtime.fake
+  vars = {
+    credentials = {
+      PRIVATE_PAYLOAD_KEY = "PRIVATE_PAYLOAD_VALUE"
+      count = []
+    }
+  }
+}
+`, filepath.Join(dir, "terraform-fake")))
+	return bp
+}
+
+func TestPlan_SensitiveInputErrorRedactsPayload(t *testing.T) {
+	bp := writeSensitiveInputFixture(t, true)
+	stdout, stderr, err := runCmdAt(t, bp, "plan", "--output", "json", "--log-level", "debug")
+	if err == nil {
+		t.Fatal("expected invalid sensitive input to fail")
+	}
+	for _, output := range []string{stdout, stderr, err.Error()} {
+		if strings.Contains(output, "PRIVATE_PAYLOAD") {
+			t.Fatal("sensitive payload appears in CLI output or error")
+		}
+	}
+	for cause := err; cause != nil; cause = errors.Unwrap(cause) {
+		if strings.Contains(cause.Error(), "PRIVATE_PAYLOAD") {
+			t.Fatal("sensitive payload remains in the error chain")
+		}
+	}
+	for _, context := range []string{"node.a.input.credentials", "object({ count = number })", "sensitive", "check"} {
+		if !strings.Contains(err.Error(), context) {
+			t.Fatalf("error = %v, want context %q", err, context)
+		}
+	}
+	var report runResult
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("invalid JSON report: %v", err)
+	}
+	if len(report.Nodes) != 1 || report.Nodes[0].Node != "a" || report.Nodes[0].Status != "failed" || report.Nodes[0].Error == "" {
+		t.Fatalf("nodes = %+v, want node a failed with a safe error", report.Nodes)
+	}
+	if strings.Contains(stderr, "terraform init") || strings.Contains(stderr, "terraform plan") {
+		t.Fatal("invalid input reached the runtime")
+	}
+}
+
+// writeSensitiveEdgeFixture makes source-only sensitivity observable even when the destination variable is not marked sensitive.
+func writeSensitiveEdgeFixture(t *testing.T, inputSensitive, outputSensitive bool) string {
+	t.Helper()
+	bp := writeSensitiveInputFixture(t, inputSensitive)
+	dir := filepath.Dir(bp)
+	writeFixtureFile(t, filepath.Join(dir, "producer", "main.tf"), fmt.Sprintf(`output "credentials" {
+  value = {}
+  sensitive = %t
+}
+`, outputSensitive))
+	writeFixtureFile(t, filepath.Join(dir, "terraform-fake"), `#!/bin/sh
+case "$1" in
+  output) printf '{"credentials":{"value":{"PRIVATE_PAYLOAD_KEY":"PRIVATE_PAYLOAD_VALUE","count":[]}}}'; exit 0 ;;
+  *) printf 'unexpected runtime command\n' >&2; exit 1 ;;
+esac
+`)
+	writeFixtureFile(t, bp, fmt.Sprintf(`runtime "fake" { binary = %q }
+node "producer" {
+  source = "./producer"
+  runtime = runtime.fake
+}
+node "a" {
+  source = "./module"
+  runtime = runtime.fake
+}
+edge {
+  from = node.producer.output.credentials
+  to = node.a.input.credentials
+}
+`, filepath.Join(dir, "terraform-fake")))
+	return bp
+}
+
+func TestPlan_SensitiveUpstreamErrorRedactsPayload(t *testing.T) {
+	bp := writeSensitiveEdgeFixture(t, false, true)
+	stdout, stderr, err := runCmdAt(t, bp, "plan", "--node", "a", "--output", "json", "--log-level", "debug")
+	if err == nil {
+		t.Fatal("expected invalid upstream value to fail")
+	}
+	for _, output := range []string{stdout, stderr, err.Error()} {
+		if strings.Contains(output, "PRIVATE_PAYLOAD") {
+			t.Fatal("sensitive upstream payload appears in CLI output or error")
+		}
+	}
+	if !strings.Contains(err.Error(), "node.producer.output.credentials") || !strings.Contains(err.Error(), "node.a.input.credentials") {
+		t.Fatalf("error = %v, want both source and destination context", err)
+	}
+}
+
+func TestRunCommands_SensitiveInputErrorsStayRedacted(t *testing.T) {
+	for _, command := range []string{"plan", "apply", "destroy"} {
+		for _, output := range []string{"text", "json"} {
+			for _, source := range []string{"literal", "sensitive-input", "sensitive-output"} {
+				t.Run(command+"/"+output+"/"+source, func(t *testing.T) {
+					var bp string
+					if source == "literal" {
+						bp = writeSensitiveInputFixture(t, true)
+					} else {
+						bp = writeSensitiveEdgeFixture(t, source == "sensitive-input", source == "sensitive-output")
+					}
+					args := []string{command, "--node", "a", "--output", output, "--parallelism", "2", "--log-level", "debug"}
+					if command != "plan" {
+						args = append(args, "--auto-approve")
+					}
+					stdout, stderr, err := runCmdAt(t, bp, args...)
+					if err == nil || !strings.Contains(err.Error(), "node.a.input.credentials") || !strings.Contains(err.Error(), "value details withheld") {
+						t.Fatalf("error = %v, want safe input error with node context", err)
+					}
+					for _, stream := range []string{stdout, stderr} {
+						if strings.Contains(stream, "PRIVATE_PAYLOAD") {
+							t.Fatal("sensitive payload appears in a CLI stream")
+						}
+					}
+					for cause := err; cause != nil; cause = errors.Unwrap(cause) {
+						if strings.Contains(cause.Error(), "PRIVATE_PAYLOAD") {
+							t.Fatal("sensitive payload remains in the error chain")
+						}
+					}
+					if output == "json" {
+						var report runResult
+						if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+							t.Fatalf("invalid JSON report: %v", err)
+						}
+						if len(report.Nodes) != 1 || report.Nodes[0].Status != "failed" || !strings.Contains(report.Nodes[0].Error, "value details withheld") {
+							t.Fatalf("nodes = %+v, want failed with redacted error", report.Nodes)
+						}
+					}
+					if strings.Contains(stderr, "unexpected runtime command") || strings.Contains(stderr, "terraform init") || strings.Contains(stderr, "terraform plan") {
+						t.Fatal("invalid input reached the consumer runtime")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestPlan_NonSensitiveInputRetainsDetailedError(t *testing.T) {
+	bp := writeSensitiveInputFixture(t, false)
+	_, _, err := runCmdAt(t, bp, "plan", "--output", "json")
+	if err == nil || !strings.Contains(err.Error(), "unsupported attribute") || !strings.Contains(err.Error(), "PRIVATE_PAYLOAD_KEY") {
+		t.Fatalf("error = %v, want detailed non-sensitive type error", err)
+	}
+	if errors.Unwrap(err) == nil {
+		t.Fatal("non-sensitive error chain was lost")
+	}
+}
+
+func TestPlan_ValidSensitiveInputStillReachesRuntime(t *testing.T) {
+	bp := writeSensitiveInputFixture(t, true)
+	dir := filepath.Dir(bp)
+	contents, err := os.ReadFile(bp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := strings.Replace(string(contents), `PRIVATE_PAYLOAD_KEY = "PRIVATE_PAYLOAD_VALUE"`, "", 1)
+	valid = strings.Replace(valid, "count = []", "count = 3", 1)
+	writeFixtureFile(t, bp, valid)
+	writeFixtureFile(t, filepath.Join(dir, "terraform-fake"), `#!/bin/sh
+case "$1" in
+  init) mkdir -p "$TF_DATA_DIR"; exit 0 ;;
+  plan)
+    for arg in "$@"; do
+      case "$arg" in -var-file=*) cp "${arg#-var-file=}" "$TF_DATA_DIR/received.json"; exit $? ;; esac
+    done
+    ;;
+esac
+exit 1
+`)
+	stdout, _, err := runCmdAt(t, bp, "plan", "--output", "json")
+	if err != nil {
+		t.Fatalf("valid sensitive input failed: %v", err)
+	}
+	var report runResult
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Nodes) != 1 || report.Nodes[0].Status != "planned" {
+		t.Fatalf("nodes = %+v, want planned", report.Nodes)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".terragraph", "tfdata", "a", "received.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct{ Credentials struct{ Count int } }
+	if err := json.Unmarshal(data, &got); err != nil || got.Credentials.Count != 3 {
+		t.Fatalf("received count = %d, error = %v, want 3", got.Credentials.Count, err)
+	}
+}

--- a/internal/engine/inputs.go
+++ b/internal/engine/inputs.go
@@ -68,7 +68,7 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 		if _, conflict := vars[varName]; conflict {
 			return nil, fmt.Errorf("node.%s.input.%s: set by both a data edge and vars; remove one", name, varName)
 		}
-		if err := e.checkVarType(name, varName, val); err != nil {
+		if err := e.checkVarType(name, varName, val, false); err != nil {
 			return nil, err
 		}
 		vars[varName] = val
@@ -79,14 +79,15 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 
 // checkType verifies a concrete value resolved from a data edge against the target variable's declared type constraint. See checkVarType, which does the actual check and is shared with a node's own literal Vars.
 func (e *Engine) checkType(edge blueprint.Edge, val any) error {
-	if err := e.checkVarType(edge.To.Node, edge.To.Name, val); err != nil {
+	sourceSensitive := e.Graph.Nodes[edge.From.Node].Schema.OutputDetails[edge.From.Name].Sensitive
+	if err := e.checkVarType(edge.To.Node, edge.To.Name, val, sourceSensitive); err != nil {
 		return fmt.Errorf("value from %s: %w", edge.From, err)
 	}
 	return nil
 }
 
 // checkVarType verifies val against the type constraint node.varName declares, if any. This is an exact runtime check, not static inference: by the time either a data edge or a literal Vars entry supplies a value it's already concrete, so it's decoded straight against the target's cty.Type using the same mechanism Terraform itself uses to load *.tfvars.json. A variable with no declared type constraint is skipped (nothing to check against).
-func (e *Engine) checkVarType(nodeName, varName string, val any) error {
+func (e *Engine) checkVarType(nodeName, varName string, val any, sourceSensitive bool) (err error) {
 	v, ok := e.Graph.Nodes[nodeName].Schema.Variables[varName]
 	if !ok || v.Type == "" {
 		return nil
@@ -99,6 +100,15 @@ func (e *Engine) checkVarType(nodeName, varName string, val any) error {
 	ctyType, diags := typeexpr.TypeConstraint(typeExpr)
 	if diags.HasErrors() {
 		return fmt.Errorf("node.%s.input.%s: internal error resolving declared type %q: %s", nodeName, varName, v.Type, diags.Error())
+	}
+
+	// Encoding and conversion errors can contain payload keys; replace the error rather than wrapping it so callers cannot recover sensitive details from the chain.
+	if v.Sensitive || sourceSensitive {
+		defer func() {
+			if err != nil {
+				err = fmt.Errorf("node.%s.input.%s: cannot validate sensitive value against declared type %s; value details withheld; check the input value against the module variable declaration", nodeName, varName, v.Type)
+			}
+		}()
 	}
 
 	data, err := json.Marshal(val)

--- a/internal/engine/sensitive_inputs_test.go
+++ b/internal/engine/sensitive_inputs_test.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+func TestPlan_SensitiveInputErrorDoesNotRetainPayload(t *testing.T) {
+	dir := t.TempDir()
+	if err := osWriteFile(filepath.Join(dir, "module", "main.tf"), []byte(`variable "credentials" {
+  type = object({ count = number })
+  sensitive = true
+}`)); err != nil {
+		t.Fatal(err)
+	}
+	bp := writeBlueprint(t, dir, `node "a" {
+  source = "./module"
+  vars = { credentials = { PRIVATE_PAYLOAD_KEY = "PRIVATE_PAYLOAD_VALUE", count = [] } }
+}`)
+	var stdout, stderr bytes.Buffer
+	e, err := Load(bp, exec.Binary(filepath.Join(dir, "must-not-run")), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	runs, err := e.Plan(Options{})
+	if err == nil || !strings.Contains(err.Error(), "node.a.input.credentials") || !strings.Contains(err.Error(), "value details withheld") {
+		t.Fatalf("error = %v, want redacted input validation error", err)
+	}
+	if len(runs) != 1 || runs[0].Status != StatusFailed || runs[0].Err == nil {
+		t.Fatalf("runs = %+v, want a failed run with a safe error", runs)
+	}
+	for _, reported := range []error{err, runs[0].Err} {
+		for cause := reported; cause != nil; cause = errors.Unwrap(cause) {
+			if strings.Contains(cause.Error(), "PRIVATE_PAYLOAD") {
+				t.Fatal("sensitive payload remains in an error chain")
+			}
+		}
+	}
+	if strings.Contains(stdout.String()+stderr.String(), "PRIVATE_PAYLOAD") {
+		t.Fatal("sensitive payload appears in engine streams")
+	}
+}


### PR DESCRIPTION
## Summary

Input validation could expose object/map keys from a sensitive value in errors, including JSON run reports. I reviewed the full diff; this change replaces value-derived error details when either the destination variable or the inspected upstream output is declared sensitive, while keeping the node, input, declared type, and a remedy.

The original error is discarded rather than wrapped so its payload cannot be recovered through the error chain. Non-sensitive diagnostics, valid input values, exit codes, and JSON structure remain unchanged.

Refs #69 (E-06, the error-redaction part of R03). Type-conversion compatibility, runtime output sensitivity metadata, snapshots, and saved-plan permissions remain separate work. This does not redact arbitrary Terraform/OpenTofu subprocess output.

## Verification

On macOS with Go 1.27.1 and Node 22.14.0:

```text
go test -race ./internal/cli -run 'Sensitive(Input|Upstream)|SensitiveInputErrors' -count=1
ok  github.com/cloudfluent/terragraph/internal/cli

go test -race ./internal/engine ./internal/cli
ok  github.com/cloudfluent/terragraph/internal/engine
ok  github.com/cloudfluent/terragraph/internal/cli

make check
lint: 0 issues; all Go race tests and VS Code checks passed
```

Actual before/after CLI acceptance used race-enabled binaries at `2fc9543` and this change, with on-disk fixtures and a fake Terraform subprocess boundary. All 40 executions passed: 18 sensitive-error scenarios on each version, plus ordinary-error and valid-sensitive-input controls on each version. The matrix covers plan/apply/destroy, text/JSON, literal inputs, sensitive destinations, and sensitive upstream outputs. Invalid inputs never execute the consumer runtime; valid input values were checked in the generated tfvars.

Minimal reproduction: declare a module variable `credentials` with `type = object({ count = number })` and `sensitive = true`, then pass `vars = { credentials = { PRIVATE_PAYLOAD_KEY = "PRIVATE_PAYLOAD_VALUE", count = [] } }` from node `a`.

```text
terragraph plan --blueprint blueprint.hcl --node a --output json --parallelism 2 --log-level debug

Before (exit 1, stderr and JSON error):
node.a.input.credentials: does not match declared type object({ count = number }): unsupported attribute "PRIVATE_PAYLOAD_KEY"

After (exit 1, stderr and JSON error):
node.a.input.credentials: cannot validate sensitive value against declared type object({ count = number }); value details withheld; check the input value against the module variable declaration
```

The required `count` field is independently invalid, so the regression does not rely on continuing to reject extra object attributes. Repository tests preserve the reproduction; CLI shell tests run on Unix, and the public Engine.Plan regression has no platform restriction. Linux and Windows execution results are pending CI.

- [x] `make check` passes locally

## Checklist

- [x] Tests cover redacted streams and error chains, failure reports, ordinary diagnostics, and valid input delivery
- [x] `docs/execution-model.md` documents the protection and its boundary
