### PR TITLE
fix: accept Terraform-compatible input values

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -12,7 +12,7 @@
 
 Cycle detection reports every independent cyclic cluster in one pass (Tarjan's SCC algorithm), not just the first one found.
 
-Type checking is a runtime check, not static inference: a standard root module's `output` blocks don't declare a type, so there's nothing to infer statically. Instead, by the time an edge is about to be wired the concrete value is already known: it's decoded directly against the target variable's declared type (the same mechanism Terraform itself uses to load `*.tfvars.json`), which is exact rather than a guess.
+Type checking runs when inputs are resolved for execution. terragraph decodes each concrete value and uses cty's type conversion and optional attribute defaults to check whether the target variable's declared type can accept it. This accepts `any`, convertible `map(any)` values, optional object attributes with defaults, and additional object attributes. The original input is passed unchanged in the tfvars file: Terraform/OpenTofu performs the final conversion, applies variable defaults and nullability rules, and evaluates variable validation blocks.
 
 ## How values are passed
 

--- a/internal/cli/sensitive_inputs_unix_test.go
+++ b/internal/cli/sensitive_inputs_unix_test.go
@@ -169,7 +169,7 @@ func TestRunCommands_SensitiveInputErrorsStayRedacted(t *testing.T) {
 func TestPlan_NonSensitiveInputRetainsDetailedError(t *testing.T) {
 	bp := writeSensitiveInputFixture(t, false)
 	_, _, err := runCmdAt(t, bp, "plan", "--output", "json")
-	if err == nil || !strings.Contains(err.Error(), "unsupported attribute") || !strings.Contains(err.Error(), "PRIVATE_PAYLOAD_KEY") {
+	if err == nil || !strings.Contains(err.Error(), `attribute "count"`) || !strings.Contains(err.Error(), "number required") {
 		t.Fatalf("error = %v, want detailed non-sensitive type error", err)
 	}
 	if errors.Unwrap(err) == nil {

--- a/internal/engine/inputs.go
+++ b/internal/engine/inputs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty/convert"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
@@ -86,7 +87,7 @@ func (e *Engine) checkType(edge blueprint.Edge, val any) error {
 	return nil
 }
 
-// checkVarType verifies val against the type constraint node.varName declares, if any. This is an exact runtime check, not static inference: by the time either a data edge or a literal Vars entry supplies a value it's already concrete, so it's decoded straight against the target's cty.Type using the same mechanism Terraform itself uses to load *.tfvars.json. A variable with no declared type constraint is skipped (nothing to check against).
+// checkVarType checks concrete input convertibility with cty and optional attribute defaults; the original value is still passed to Terraform so its variable handling owns the final conversion.
 func (e *Engine) checkVarType(nodeName, varName string, val any, sourceSensitive bool) (err error) {
 	v, ok := e.Graph.Nodes[nodeName].Schema.Variables[varName]
 	if !ok || v.Type == "" {
@@ -97,7 +98,7 @@ func (e *Engine) checkVarType(nodeName, varName string, val any, sourceSensitive
 	if diags.HasErrors() {
 		return fmt.Errorf("node.%s.input.%s: internal error parsing declared type %q: %s", nodeName, varName, v.Type, diags.Error())
 	}
-	ctyType, diags := typeexpr.TypeConstraint(typeExpr)
+	ctyType, defaults, diags := typeexpr.TypeConstraintWithDefaults(typeExpr)
 	if diags.HasErrors() {
 		return fmt.Errorf("node.%s.input.%s: internal error resolving declared type %q: %s", nodeName, varName, v.Type, diags.Error())
 	}
@@ -115,7 +116,16 @@ func (e *Engine) checkVarType(nodeName, varName string, val any, sourceSensitive
 	if err != nil {
 		return fmt.Errorf("node.%s.input.%s: encoding value for type check: %w", nodeName, varName, err)
 	}
-	if _, err := ctyjson.Unmarshal(data, ctyType); err != nil {
+	// Decode the JSON's actual shape first: decoding against the constraint mistakes any for cty's typed JSON wrapper and rejects extra object attributes before conversion can discard them.
+	var concrete ctyjson.SimpleJSONValue
+	if err := json.Unmarshal(data, &concrete); err != nil {
+		return fmt.Errorf("node.%s.input.%s: decoding value for type check: %w", nodeName, varName, err)
+	}
+	value := concrete.Value
+	if defaults != nil {
+		value = defaults.Apply(value)
+	}
+	if _, err := convert.Convert(value, ctyType); err != nil {
 		return fmt.Errorf("node.%s.input.%s: does not match declared type %s: %w", nodeName, varName, v.Type, err)
 	}
 	return nil

--- a/internal/engine/type_compatibility_unix_test.go
+++ b/internal/engine/type_compatibility_unix_test.go
@@ -1,0 +1,117 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+// loadInputTypeEngine uses a real declaration and captures the subprocess's tfvars so accepting a value cannot silently rewrite it.
+func loadInputTypeEngine(t *testing.T, constraint, literal string) *Engine {
+	t.Helper()
+	dir := t.TempDir()
+	if err := osWriteFile(filepath.Join(dir, "module", "main.tf"), []byte(fmt.Sprintf("variable \"value\" { type = %s }\n", constraint))); err != nil {
+		t.Fatal(err)
+	}
+	bp := writeBlueprint(t, dir, fmt.Sprintf("node \"a\" {\n source = \"./module\"\n vars = { value = %s }\n}\n", literal))
+	binary := filepath.Join(dir, "terraform-fake")
+	if err := os.WriteFile(binary, []byte(`#!/bin/sh
+case "$1" in
+  init) mkdir -p "$TF_DATA_DIR" ;;
+  plan)
+    for arg in "$@"; do
+      case "$arg" in
+        -var-file=*) cp "${arg#-var-file=}" "$TF_DATA_DIR/varfile-seen" || exit 1 ;;
+      esac
+    done
+    ;;
+  *) exit 1 ;;
+esac
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	e, err := Load(bp, exec.Binary(binary), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return e
+}
+
+// assertInputTypeAccepted checks the exact encoded input, leaving Terraform responsible for applying defaults, coercions, and object projection.
+func assertInputTypeAccepted(t *testing.T, e *Engine) {
+	t.Helper()
+	want, err := json.Marshal(e.Graph.Nodes["a"].Vars["value"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Plan(Options{}); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	var vars map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(varfileSeen(t, e, "a")), &vars); err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	if err := json.Compact(&got, vars["value"]); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("passed value = %s, want original %s", got.Bytes(), want)
+	}
+}
+
+func TestPlan_AnyInputAcceptsScalar(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, "any", `"fixture"`))
+}
+
+func TestPlan_AnyInputAcceptsHeterogeneousValues(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, "any", `[9007199254740993, "fixture", { enabled = true }, null]`))
+}
+
+func TestPlan_MapAnyInputAcceptsConvertibleValues(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, "map(any)", `{ count = 9007199254740993, label = "fixture", empty = null }`))
+}
+
+func TestPlan_OptionalInputDefaultsAcceptMissingAndNullAttributes(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, `object({ missing = optional(string, "default"), empty = optional(number, 2) })`, `{ empty = null }`))
+}
+
+func TestPlan_OptionalInputDefaultsAcceptNestedCollections(t *testing.T) {
+	constraint := `object({ items = list(object({ name = string, settings = optional(object({ enabled = optional(bool, true) }), {}) })) })`
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, constraint, `{ items = [{ name = "fixture" }] }`))
+}
+
+func TestPlan_OptionalInputDefaultsPreserveTopLevelNull(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, `object({ name = optional(string, "default") })`, `null`))
+}
+
+func TestPlan_ObjectInputAcceptsAdditionalAttributes(t *testing.T) {
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, `object({ name = string })`, `{ name = "fixture", extra = true }`))
+}
+
+func TestPlan_InputAcceptsPrimitiveCoercion(t *testing.T) {
+	constraint := `object({ count = number, label = string, enabled = bool })`
+	assertInputTypeAccepted(t, loadInputTypeEngine(t, constraint, `{ count = "9007199254740993", label = 12, enabled = "true" }`))
+}
+
+func TestPlan_MapAnyInputRejectsIncompatibleValues(t *testing.T) {
+	e := loadInputTypeEngine(t, "map(any)", `{ count = 1, details = { enabled = true } }`)
+	if _, err := e.Plan(Options{}); err == nil || !strings.Contains(err.Error(), "node.a.input.value") {
+		t.Fatalf("error = %v, want incompatible map input rejected", err)
+	}
+}
+
+func TestPlan_ObjectInputRejectsMissingRequiredAttribute(t *testing.T) {
+	e := loadInputTypeEngine(t, `object({ name = string })`, `{}`)
+	if _, err := e.Plan(Options{}); err == nil || !strings.Contains(err.Error(), "node.a.input.value") {
+		t.Fatalf("error = %v, want missing required attribute rejected", err)
+	}
+}


### PR DESCRIPTION
Related to #69 (input compatibility).

Terraform accepts values such as an ordinary string for `any`, optional object attributes, and convertible `map(any)` entries, but terragraph rejected them before execution. This uses cty's existing defaults and conversion APIs to check acceptance while forwarding the original JSON payload unchanged; Terraform/OpenTofu still owns final variable conversion and validation.

The change preserves exact numbers and sensitive-error redaction. Invalid required attributes and incompatible values still fail. The execution model documentation explains this boundary.

Validation:

```text
go test -race ./internal/engine -run '^TestPlan_(AnyInput|MapAnyInput|OptionalInput|ObjectInput|InputAccepts)' -count=1 -v
Before: valid any/map(any)/optional/extra-attribute cases rejected
After: PASS

Direct Terraform 1.5.7 / OpenTofu 1.11.0 vs terragraph plan --output json
40 local provider-free cases: before 18 disagreements, after 0

make check
PASS (including full race suite and VS Code checks)
```

The runtime comparison ran on macOS arm64. It also covered nested optional defaults, invalid values, null, and exact large/fractional numbers. This does not implement Terraform variable-level defaults, nullable rules, validation blocks, or provider validation.
