### PR TITLE
fix: warn about relative local backend paths

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -90,7 +90,9 @@ Either endpoint may be a group instance (`use.<name>`), and each expanded edge t
 
 ## Reusing the same module across instances
 
-A node can reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding. If the module declares `backend "local"` (an empty block is enough) and the node does not set `path`, terragraph fills `path` to `<blueprint dir>/.terragraph/state/<node>.tfstate` (absolute) and passes it as `terraform init -backend-config=path=...`. An explicit `path` wins.
+A node can reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding. If the module declares `backend "local"` (an empty block is enough) and the node does not set `path`, terragraph fills `path` to `<blueprint dir>/.terragraph/state/<node>.tfstate` (absolute) and passes it as `terraform init -backend-config=path=...`. An explicit `backend_config.path` wins.
+
+An explicit relative local-backend `backend_config.path` is passed through unchanged: Terraform/OpenTofu resolves it for the default workspace from the node's module directory, **not** the blueprint directory. For example, with `source = "./modules/vpc"`, `path = ".terragraph/state/vpc.tfstate"` places state under `modules/vpc/.terragraph/state/`. `terragraph validate` warns about this relative path. Omit `backend_config.path` to use the automatic absolute path above, or supply an absolute path outside the module directory when choosing a custom location. Changing a path does not move existing state; migrate existing state before running against the new location.
 
 ```hcl
 node "vpc_prod" {
@@ -185,9 +187,6 @@ An edge wires one node's real output into another node's input, but not every in
 ```hcl
 node "data-apne2-dev-vpc" {
   source = "./modules/vpc"
-  backend_config = {
-    path = ".terragraph/state/data-apne2-dev-vpc.tfstate"
-  }
   vars = {
     name            = "dpl-apne2-vpc-dev"
     cidr            = "10.16.0.0/20"

--- a/internal/engine/state_orphans_test.go
+++ b/internal/engine/state_orphans_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,12 +70,12 @@ func TestStateOrphans_NoStrayFileNoNewProblems(t *testing.T) {
 func TestStateOrphans_ExplicitBackendPathClaimsItsFile(t *testing.T) {
 	baseDir := t.TempDir()
 	writeModule(t, filepath.Join(baseDir, "stacks", "vpc"))
-	path := writeBlueprint(t, baseDir, `
+	path := writeBlueprint(t, baseDir, fmt.Sprintf(`
 node "vpc" {
   source = "./stacks/vpc"
-  backend_config = { path = ".terragraph/state/prod.tfstate" }
+  backend_config = { path = %q }
 }
-`)
+`, filepath.Join(baseDir, ".terragraph", "state", "prod.tfstate")))
 
 	e, err := Load(path, exec.Terraform, io.Discard, io.Discard)
 	if err != nil {

--- a/internal/engine/state_orphans_test.go
+++ b/internal/engine/state_orphans_test.go
@@ -98,12 +98,12 @@ node "vpc" {
 func TestStateOrphans_ExplicitPathElsewhereDoesNotClaimTheStateDir(t *testing.T) {
 	baseDir := t.TempDir()
 	writeModule(t, filepath.Join(baseDir, "stacks", "vpc"))
-	path := writeBlueprint(t, baseDir, `
+	path := writeBlueprint(t, baseDir, fmt.Sprintf(`
 node "vpc" {
   source         = "./stacks/vpc"
-  backend_config = { path = "/somewhere/else/live.tfstate" }
+  backend_config = { path = %q }
 }
-`)
+`, filepath.Join(baseDir, "elsewhere", "live.tfstate")))
 
 	e, err := Load(path, exec.Terraform, io.Discard, io.Discard)
 	if err != nil {

--- a/internal/graph/backend_test.go
+++ b/internal/graph/backend_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -357,6 +358,9 @@ node "c" {
 	if err != nil {
 		t.Fatalf("LoadPath: %v", err)
 	}
+	for i := range bp.Nodes {
+		bp.Nodes[i].BackendConfig["path"] = filepath.Join(root, bp.Nodes[i].BackendConfig["path"])
+	}
 	g, err := Build(bp, dir)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -466,6 +470,9 @@ node "b" {
 	bp, dir, err := blueprint.LoadPath(filepath.Join(root, "blueprint.hcl"))
 	if err != nil {
 		t.Fatalf("LoadPath: %v", err)
+	}
+	for i := range bp.Nodes {
+		bp.Nodes[i].BackendConfig["path"] = filepath.Join(root, bp.Nodes[i].BackendConfig["path"])
 	}
 	g, err := Build(bp, dir)
 	if err != nil {
@@ -655,11 +662,71 @@ node "b" {
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
+	for i := range bp.Nodes {
+		bp.Nodes[i].BackendConfig["path"] = filepath.Join(root, bp.Nodes[i].BackendConfig["path"])
+	}
 	g, err := Build(bp, root)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
 	if problems := Validate(g); len(problems) != 0 {
 		t.Fatalf("got = %v, want separate workspace states", problems)
+	}
+}
+
+func TestValidate_RelativeLocalBackendPathWarns(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "modules", "vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+ source = "./modules/vpc"
+ backend_config = { path = ".terragraph/state/vpc.tfstate" }
+}
+`)
+	g := parseAndBuild(t, root)
+	problems := Validate(g)
+	if len(problems) != 1 {
+		t.Fatalf("got = %v, want one relative-path warning", problems)
+	}
+	if problems[0].Severity != SeverityWarning {
+		t.Fatalf("got = %v, want warning", problems[0])
+	}
+	for _, want := range []string{"node.vpc.backend_config.path", "relative", g.Nodes["vpc"].Dir, "absolute path", "omit"} {
+		if !strings.Contains(problems[0].Message, want) {
+			t.Fatalf("got = %q, want substring %q", problems[0].Message, want)
+		}
+	}
+	if got := g.Nodes["vpc"].BackendConfig["path"]; got != ".terragraph/state/vpc.tfstate" {
+		t.Fatalf("got = %q, want original relative path", got)
+	}
+}
+
+func TestValidate_AbsoluteLocalBackendPathDoesNotWarn(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "modules", "vpc"), localBackend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), fmt.Sprintf(`
+node "vpc" {
+ source = "./modules/vpc"
+ backend_config = { path = %q }
+}
+`, filepath.Join(root, "state", "vpc.tfstate")))
+	if problems := Validate(parseAndBuild(t, root)); len(problems) != 0 {
+		t.Fatalf("got = %v, want no problems", problems)
+	}
+}
+
+func TestValidate_RemoteBackendRelativePathDoesNotWarn(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "modules", "vpc"), `terraform {
+ backend "http" {}
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+node "vpc" {
+ source = "./modules/vpc"
+ backend_config = { path = "state/vpc" }
+}
+`)
+	if problems := Validate(parseAndBuild(t, root)); len(problems) != 0 {
+		t.Fatalf("got = %v, want no problems", problems)
 	}
 }

--- a/internal/graph/backend_test.go
+++ b/internal/graph/backend_test.go
@@ -691,7 +691,7 @@ node "vpc" {
 	if problems[0].Severity != SeverityWarning {
 		t.Fatalf("got = %v, want warning", problems[0])
 	}
-	for _, want := range []string{"node.vpc.backend_config.path", "relative", g.Nodes["vpc"].Dir, "absolute path", "omit"} {
+	for _, want := range []string{"node.vpc.backend_config.path", "relative", fmt.Sprintf("%q", g.Nodes["vpc"].Dir), "absolute path", "omit"} {
 		if !strings.Contains(problems[0].Message, want) {
 			t.Fatalf("got = %q, want substring %q", problems[0].Message, want)
 		}

--- a/internal/graph/group_build_test.go
+++ b/internal/graph/group_build_test.go
@@ -158,8 +158,8 @@ func TestBuild_SameGroupDirectoryUsedTwice_InstancesDontShareState(t *testing.T)
 		t.Fatalf("expected distinct filled backend paths, got %+v / %+v", first.BackendConfig, second.BackendConfig)
 	}
 	if first.BackendConfig != nil {
-		first.BackendConfig["path"] = "mutated"
-		if second.BackendConfig["path"] == "mutated" {
+		first.BackendConfig["path"] = filepath.Join(root, "mutated.tfstate")
+		if second.BackendConfig["path"] == first.BackendConfig["path"] {
 			t.Fatalf("mutating the first instance's BackendConfig affected the second: %+v", second.BackendConfig)
 		}
 	}

--- a/internal/graph/validate.go
+++ b/internal/graph/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -219,6 +220,13 @@ func backendProblems(g *Graph) []Problem {
 					Message:  fmt.Sprintf("node.%s: backend_config is set but the module declares no backend block", name),
 				})
 			}
+		}
+		// Terraform resolves explicit relative paths from the module directory, which can put state inside a vendored source tree.
+		if statePath := node.BackendConfig["path"]; node.Schema != nil && node.Schema.Backend == "local" && statePath != "" && !filepath.IsAbs(statePath) {
+			problems = append(problems, Problem{
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("node.%s.backend_config.path: relative path %q for the default workspace is resolved from module directory %q, not the blueprint directory; use an absolute path outside the module or omit backend_config.path to use the managed state path", name, statePath, node.Dir),
+			})
 		}
 		if node.Dir != "" {
 			byDir[node.Dir] = append(byDir[node.Dir], name)


### PR DESCRIPTION
The local-backend example used a relative path that Terraform resolves inside the module directory. This change removes that override from the vars example and warns when an explicit local `backend_config.path` is relative, with the module directory and remedies in the diagnostic. The path remains unchanged and the diagnostic is advisory.

This takes up the concrete backend-path follow-up suggested in https://github.com/cloudfluent/terragraph/pull/66#issuecomment-5567163325.

Regression coverage checks the relative-path warning, preservation of the configured path, and absence of the warning for absolute paths and non-local backends. Existing collision and orphan-state fixtures now use portable absolute paths where they intend to refer to state outside the module. The warning assertion matches the quoted directory on Windows as well as Unix.

Validation:

```text
# Before the validator change, with the new regression test:
$ mise x go@1.27.1 -- go test -race ./internal/graph -run 'TestValidate_(RelativeLocalBackendPathWarns|AbsoluteLocalBackendPathDoesNotWarn|RemoteBackendRelativePathDoesNotWarn)' -count=1
--- FAIL: TestValidate_RelativeLocalBackendPathWarns (0.00s)
    backend_test.go:680: got = [], want one relative-path warning
FAIL

# After the change:
$ mise x go@1.27.1 -- go test -race ./internal/graph -run 'TestValidate_(RelativeLocalBackendPathWarns|AbsoluteLocalBackendPathDoesNotWarn|RemoteBackendRelativePathDoesNotWarn)' -count=1 -v
=== RUN   TestValidate_RelativeLocalBackendPathWarns
--- PASS: TestValidate_RelativeLocalBackendPathWarns (0.00s)
=== RUN   TestValidate_AbsoluteLocalBackendPathDoesNotWarn
--- PASS: TestValidate_AbsoluteLocalBackendPathDoesNotWarn (0.00s)
=== RUN   TestValidate_RemoteBackendRelativePathDoesNotWarn
--- PASS: TestValidate_RemoteBackendRelativePathDoesNotWarn (0.00s)
PASS
```

Full gate also passed:

```text
$ mise x go@1.27.1 -- make check
# fmt-check: clean
0 issues.
# docs-check: clean; build: passed
# go test -race: all packages passed
# VS Code: tsc and eslint passed
All matched files use Prettier code style!

$ git diff --check
(no output)
```

Prepared with Codex.

