### PR TITLE
docs: add active development warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Release](https://img.shields.io/github/v/release/cloudfluent/terragraph)](https://github.com/cloudfluent/terragraph/releases) [![CI](https://github.com/cloudfluent/terragraph/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfluent/terragraph/actions/workflows/ci.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/cloudfluent/terragraph.svg)](https://pkg.go.dev/github.com/cloudfluent/terragraph) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
+> [!WARNING]
+> terragraph is under active development and is not yet production-ready. Use it at your own risk. Breaking changes may occur frequently until the first stable release.
+
 Split infrastructure into independent Terraform modules and you lose the one thing a single workspace gives you for free: one module's outputs feeding straight into another's inputs. That gap gets closed one of three ways. By hand: `apply`, copy a value, paste it into the next module's tfvars, repeat. With `terraform_remote_state`, which trades the copying for a dependency written into the consumer's code: it names the producer's backend and needs read access to its entire state file, so the module no longer stands on its own. Or by giving up the isolation and merging everything back into one giant workspace.
 
 terragraph closes that gap without any of the three tradeoffs. Every root module stays completely standalone, with its own backend, providers, and resources, and no reference to any other module. A separate file declares the **wiring**: which output feeds which input. terragraph reads that file, works out the dependency order, and passes the real values through automatically as it applies each module, with no generated code and no shared state.


### PR DESCRIPTION
Add a warning at the top of the README explaining that terragraph is under active development, is not yet production-ready, and may introduce frequent breaking changes before its first stable release.

I reviewed the full diff; this sets expectations for users before they install or run terragraph.

Validation:
```
make check
```
Passed formatting, lint (0 issues), generated documentation checks, build, the Go test suite with the race detector, and VS Code type, lint, and formatting checks.
