### PR TITLE
fix: support arbitrary HCL filenames in VS Code and clarify docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: editors/vscode/package-lock.json
 
       # Runs the exact same Go and VS Code extension checks a contributor runs locally via `make check`, so CI never drifts from the local dev loop.
-      - run: make check
+      - run: xvfb-run -a make check
 
   cross-platform:
     name: build & test (${{ matrix.os }})

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 editors/vscode/out/
 editors/vscode/bin/
 editors/vscode/*.vsix
+editors/vscode/.vscode-test/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ External contributors: fork the repo and branch from `main`. Maintainers: branch
 
 Before opening a PR: `make check` (fmt, lint, docs, build, test, the same thing CI runs) should pass locally. If the change touches blueprint semantics, a CLI flag, or an example's expected output, update the relevant `docs/*.md` or example `README.md` in the same PR.
 
+On headless Linux, install Xvfb and run `xvfb-run -a make check`, as CI does.
+
 ## What the PR body needs
 
 Two things, and neither one is long.

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,12 @@ docs-check: docs ## Fail if docs/cli/*.md is stale (what CI runs)
 	  (echo "docs/cli/*.md is stale, run 'make docs' and commit the result" >&2; exit 1)
 
 .PHONY: vscode-check
-vscode-check: ## Type-check, lint, and format-check the VS Code extension
+vscode-check: build ## Type-check, lint, format-check, and integration-test the VS Code extension
 	cd editors/vscode && npm ci
 	cd editors/vscode && npm run check
 	cd editors/vscode && npm run lint
 	cd editors/vscode && npm run format:check
+	cd editors/vscode && npm test
 
 .PHONY: check
 check: fmt-check lint docs-check build test vscode-check ## Everything CI runs, in the same order

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Requires Go 1.27.1+ to build, and `terraform` or `tofu` on `PATH` to run.
 
 ## VS Code
 
-Install **Terragraph Blueprint** from the VS Code Marketplace to get completion, definition navigation, hover metadata, and validation for `blueprint.hcl` and `group.hcl`. The extension contains a matching language server, so editor features do not require a separate CLI installation. See [`editors/vscode`](editors/vscode) for source-development and override details.
+Install **Terragraph Blueprint** from the VS Code Marketplace to get completion with port metadata, definition navigation, and validation for Terragraph `.hcl` files opened as HCL, whatever their filenames. The extension contains a matching language server, so editor features do not require a separate CLI installation. See [`editors/vscode`](editors/vscode) for source-development and override details.
 
 ## Quick look
 
-A blueprint (`blueprint.hcl`) is a flat list of `node` and `edge` facts:
+A blueprint is a flat list of `node` and `edge` facts. Save this example as `blueprint.hcl`, the CLI's default path:
 
 ```hcl
 node "vpc" { source = "./stacks/vpc" }
@@ -48,6 +48,8 @@ terragraph apply --parallelism 2 --auto-approve
 ```
 
 `terragraph` resolves the graph, runs `terraform`/`tofu` for each node in dependency order, and passes `vpc`'s real `vpc_id` output into `eks`'s input at runtime. See [`examples/basic`](examples/basic) for this exact setup running end to end.
+
+Filenames are flexible: `--blueprint topology.hcl` reads that file alone, while `--blueprint .` merges every `.hcl` file directly in the current directory. Without the flag, only `blueprint.hcl` is read. A group's `group.hcl` filename is also a convention; groups are selected by their block names. See [file loading and a split blueprint example](docs/blueprint.md#files-and-loading) and [group source directories](docs/groups.md#source-directories-and-filenames).
 
 ## Documentation
 

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -1,6 +1,6 @@
 # Blueprint
 
-A blueprint (`blueprint.hcl` by default) is a flat list of `node` and `edge` facts, not nested configuration. `--blueprint` can also point at a directory instead of a single file: every `.hcl` file directly inside it (not recursively) is merged into one blueprint, exactly the way a [group](groups.md)'s source directory already merges its own `.hcl` files. This is useful for splitting a large blueprint across several files (e.g. `nodes.hcl`, `edges.hcl`) without any of them needing a specific name.
+A blueprint describes nodes and the edges between them in HCL. The CLI reads `blueprint.hcl` by default; other filenames and directories can be selected with `--blueprint`.
 
 ```hcl
 node "vpc" {
@@ -28,6 +28,40 @@ An input is a single slot: two data edges targeting the same input are a validat
 Node canvas layout (for the future visual editor) lives in a separate `blueprint.layout.json`, so moving a box never shows up in a `blueprint.hcl` diff.
 
 Edges wire values; contracts review them. See [`docs/contracts.md`](contracts.md) to declare producer guarantees and consumer requirements as top-level `producer`/`consumer` blocks keyed by module source.
+
+## Files and loading
+
+| Invocation | Files read |
+|---|---|
+| `terragraph graph` | `blueprint.hcl` only |
+| `terragraph graph --blueprint topology.hcl` | `topology.hcl` only |
+| `terragraph graph --blueprint .` | Every `.hcl` file directly in the current directory, non-recursively |
+
+Single-file loading does not merge neighboring files. For example, adding `contracts.hcl` next to `blueprint.hcl` only includes those contracts when you select the directory. Directory loading includes hidden `.hcl` files too, including `.terraform.lock.hcl`; keep another tool's HCL configuration in its own directory. `.tf`, `.HCL`, and `.hcl.json` files are not collected by directory loading.
+
+You can split a blueprint without creating either `blueprint.hcl` or `group.hcl`. In a new directory, copy the `stacks` directory from [`examples/basic`](../examples/basic) and create these two files:
+
+```hcl
+# nodes.hcl
+node "vpc" { source = "./stacks/vpc" }
+node "eks" { source = "./stacks/eks" }
+```
+
+```hcl
+# edges.hcl
+edge {
+  from = node.vpc.output.vpc_id
+  to   = node.eks.input.vpc_id
+}
+```
+
+```sh
+terragraph graph --blueprint .
+# level 1: vpc
+# level 2: eks
+```
+
+Names and singleton settings must be unique across the merged files; later files do not override earlier declarations. The files may contain any supported top-level blocks regardless of their names. Block nesting still matters: `export` belongs inside a `group`, while settings such as `runtime`, `vendor`, and `lock` belong at the top level. Repeating the same `group` name in multiple files is a duplicate definition, not a way to extend its body. See [group source directories](groups.md#source-directories-and-filenames) for how a `use` selects a group.
 
 ## Graph remote lock (`lock`)
 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -43,6 +43,8 @@ edge {
 
 This expands purely in memory when the graph is built (no files are generated) into real nodes namespaced under the instance name (`checkout.cluster`, `checkout.nodegroup`), which every command (`plan`, `apply`, `--node`, `graph`) treats exactly like any other node.
 
+The filenames above are examples: `blueprint.hcl` is the CLI's default path, and `group.hcl` is a convention. Other `.hcl` filenames work too.
+
 A few rules fall out of that expansion:
 - **Only `export`-declared ports are visible from outside the instance.** `use.checkout.output.cluster_id` works; `use.checkout.cluster.output.cluster_id` doesn't even parse. This is deliberate: a group is only safely reusable if its author can change internals without an unbounded set of external edges depending on them, the same reason Terraform modules, Go's unexported identifiers, and private class members all work this way. If a consumer needs something not currently exported, the fix is adding it to the group's `export` block, not reaching around it. Plain nodes (not inside a group) have no such restriction.
 - **A data edge into a group's exposed input can fan out** (`to = [node.a.input.x, node.b.input.x]`) because "which internal nodes need this value" is a fact about the group's own design that its author must state; it isn't inferable from graph structure. An exposed output is always a 1:1 passthrough, so it never needs this.
@@ -50,6 +52,14 @@ A few rules fall out of that expansion:
 - **A bare, ordering-only edge into or out of a group needs no such declaration**: an edge with `from = node.x` and `to = use.checkout` (no port) expands automatically to every node inside the group with no internal predecessor (its "roots"); the symmetric case on the `from` side expands to every node with no internal successor (its "sinks"). Between two groups, every downstream root waits for every upstream sink, including when both sides have multiple leaves. Unlike fan-out, this is inferable directly from the group's internal graph shape.
 - **An edge into or out of an instance can carry nested `input` blocks** (see [blueprint.md](blueprint.md#several-values-between-the-same-two-nodes-input)), wiring several of the instance's exposed inputs in one block. For example, an edge with `from = node.vpc` and `to = use.checkout` can contain `input "vpc_id" { from = output.vpc_id }`. Each block expands into an ordinary data edge before any of the above applies, so an expanded edge fans out through `export` and collides on a leaf exactly as a separately written one would.
 - **`node`↔`group` and `group`↔`group` edges use identical syntax** to `node`↔`node`. A group instance is indistinguishable from a node both in edge references and in schema: internal nodes are inspected exactly as today (`module.Inspect` against their real `.tf` files), the `export` block is validated against those real schemas, and once valid it's synthesized into the same schema shape a real module has. Groups can nest (a group's own `use` blocks resolve recursively), and a group that directly or transitively uses itself is a validation error.
+
+## Source directories and filenames
+
+`use.source` names a directory, not an individual file. Terragraph reads every `.hcl` file directly inside that directory, non-recursively, then selects the `group` whose label matches the `use` label. In the example above, it looks for `group "eks-service"` anywhere in `./groups/eks-service`. Renaming `group.hcl` to `components.hcl` needs no change to the `use` block; the directory name also need not match the group name.
+
+All files use the same syntax rules. You can define a group in any `.hcl` file, but its nodes, edges, nested uses, and `export` must be inside that group's body to belong to it. A top-level node in another file is not automatically included in the group. A `runtime` declaration goes outside the group body, either in the same file or another `.hcl` file in its source directory. Defining the same `group` name in two files is rejected rather than merging their bodies.
+
+The calling blueprint can also span arbitrary filenames such as `nodes.hcl` and `edges.hcl`; run it with `--blueprint .` to include both. See [files and loading](blueprint.md#files-and-loading) for a complete split example. This directory mode is explicit for the calling blueprint and always used for group sources.
 
 ## Choosing a runtime for an instance
 

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -1,8 +1,10 @@
 # VS Code IntelliSense
 
-The Terragraph Blueprint extension gives `blueprint.hcl` and `group.hcl` language-server-backed editing. Install **Terragraph Blueprint** from the VS Code Marketplace and it works immediately.
+The Terragraph Blueprint extension gives Terragraph `.hcl` files language-server-backed editing, whatever their filenames. This includes split files such as `nodes.hcl`, `edges.hcl`, and `contracts.hcl`, as well as arbitrarily named files in group source directories. Open them with the **HCL** language mode. Install **Terragraph Blueprint** from the VS Code Marketplace to use these features.
 
 The extension bundles a compatible language server, so nothing here requires installing the `terragraph` CLI separately.
+
+The editor uses other `.hcl` files in the same directory as context, including unsaved changes in open files. To run a split blueprint through the CLI, use `--blueprint .`: the CLI's default still reads only `blueprint.hcl`. Editor support does not change [which files the CLI loads](blueprint.md#files-and-loading).
 
 ## Completion
 
@@ -69,7 +71,7 @@ Clearing the path goes back to the language server bundled with the extension.
 
 ## When completion doesn't appear
 
-1. Check the file is named `blueprint.hcl` or `group.hcl`.
+1. Check the file has a `.hcl` extension and the language mode in the status bar is **HCL**; its basename can be anything.
 2. Reload the window with the `Developer: Reload Window` command.
 3. Under **View: Output**, select the `Terragraph Blueprint` channel and look for a language server startup error.
 4. If you're developing, run `make build` in the repository root and restart the Extension Development Host.

--- a/editors/vscode/.prettierignore
+++ b/editors/vscode/.prettierignore
@@ -1,4 +1,5 @@
 bin/
 node_modules/
 out/
+.vscode-test/
 *.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,6 +1,9 @@
 .github/
 .vscode/
 src/
+test/
+out/test/
+.vscode-test/
 node_modules/
 eslint.config.mjs
 .prettierignore

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,8 @@
 # Terragraph Blueprint for VS Code
 
-This extension starts `terragraph language-server` and supplies Blueprint-aware completion for `blueprint.hcl` and `group.hcl` files opened as HCL.
+This extension starts `terragraph language-server` and supplies completion with port metadata, definition navigation, and diagnostics for Terragraph `.hcl` files opened as HCL. Filenames are flexible: `nodes.hcl`, `edges.hcl`, `contracts.hcl`, and files in group source directories receive the same editing support as the conventional `blueprint.hcl` and `group.hcl` names.
+
+Open-file edits are sent to the server without saving. It also reads neighboring `.hcl` files for context. When running a split blueprint in the CLI, use `--blueprint .`; omitting the flag still loads only `blueprint.hcl`. See [files and loading](../../docs/blueprint.md#files-and-loading).
 
 Marketplace releases contain a matching `terragraph language-server` binary, so no separate CLI installation is required for editor features. Set `terragraph.languageServer.path` only to override that bundled binary.
 
@@ -19,3 +21,11 @@ For a source checkout, the extension automatically uses the executable built at 
 ```
 
 Use VS Code's **Run Extension** launch configuration, then open a Terragraph workspace. The server currently completes local Terraform module inputs and outputs, node/use traversals, and direct group `export` ports. It deliberately continues providing completion while the HCL document is syntactically incomplete.
+
+## Integration tests
+
+From the repository root, `make vscode-check` builds the language server and runs the extension checks, including tests in a real VS Code Extension Host. `make check` includes the same tests. For a narrower loop after building the server, run `npm test` in this directory.
+
+The runner downloads VS Code on its first run and caches it under `.vscode-test/`. To use an existing installation, set `TERRAGRAPH_VSCODE_EXECUTABLE` to its executable path. Each run uses a temporary workspace, profile, and extensions directory. A fixture extension registers the HCL language; the real Terragraph extension and language server provide completion metadata, definition navigation, and diagnostics, including edits that have not been saved.
+
+On Linux without a display, run `xvfb-run -a make check` from the repository root, as CI does (requires Xvfb).

--- a/editors/vscode/eslint.config.mjs
+++ b/editors/vscode/eslint.config.mjs
@@ -5,7 +5,13 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig(
   {
-    ignores: ["bin/**", "node_modules/**", "out/**", "*.vsix"],
+    ignores: [
+      "bin/**",
+      "node_modules/**",
+      "out/**",
+      ".vscode-test/**",
+      "*.vsix",
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -15,6 +15,7 @@
         "@eslint/js": "^9.0.0",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.1",
         "eslint": "^9.0.0",
@@ -1635,6 +1636,23 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@vscode/vsce": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
@@ -2258,6 +2276,35 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cockatiel": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
@@ -2315,6 +2362,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3165,6 +3219,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3517,6 +3584,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3562,8 +3636,7 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3641,6 +3714,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3649,6 +3735,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -3666,6 +3765,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3799,6 +3905,52 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -3867,6 +4019,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/linkify-it": {
@@ -3974,6 +4136,49 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4091,6 +4296,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -4285,6 +4503,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -4320,6 +4554,68 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -4366,6 +4662,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4623,6 +4926,13 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4816,6 +5126,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4936,6 +5263,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5033,6 +5367,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-concat": {
@@ -5150,6 +5497,19 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5648,8 +6008,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "compile": "tsc -p .",
     "check": "tsc -p . --noEmit",
+    "test": "npm run compile && node out/test/runTest.js",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write .",
@@ -53,6 +54,7 @@
     "@eslint/js": "^9.0.0",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.1",
     "eslint": "^9.0.0",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -39,10 +39,7 @@ export async function activate(
     args: ["language-server"],
   };
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { scheme: "file", pattern: "**/blueprint.hcl" },
-      { scheme: "file", pattern: "**/group.hcl" },
-    ],
+    documentSelector: [{ scheme: "file", pattern: "**/*.hcl" }],
     outputChannel: output,
     traceOutputChannel: output,
   };

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -1,0 +1,128 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import * as vscode from "vscode";
+
+// Provider registration and diagnostics cross the extension-host/LSP boundary asynchronously.
+async function eventually(
+  description: string,
+  check: () => Promise<boolean> | boolean,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await setTimeout(50);
+  }
+  assert.fail(description);
+}
+
+async function replace(
+  document: vscode.TextDocument,
+  text: string,
+): Promise<void> {
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(
+    document.uri,
+    new vscode.Range(
+      document.positionAt(0),
+      document.positionAt(document.getText().length),
+    ),
+    text,
+  );
+  assert.equal(await vscode.workspace.applyEdit(edit), true);
+}
+
+async function checkEditingFeatures(
+  root: string,
+  filename: string,
+  group: boolean,
+): Promise<void> {
+  const dir = path.join(root, filename.replace(".hcl", ""));
+  await fs.mkdir(path.join(dir, "module"), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "module", "main.tf"),
+    'variable "vpc_id" { type = string }\noutput "vpc_id" {\n  value = "vpc-123"\n  description = "Network identifier"\n}\n',
+  );
+  const uri = vscode.Uri.file(path.join(dir, filename));
+  const body =
+    'node "vpc" { source = "./module" }\nedge {\n  from = node.vpc.output.v\n  to = node.vpc.input.vpc_id\n}\n';
+  const initial = group ? 'group "network" {\n' + body + "}\n" : body;
+  await fs.writeFile(uri.fsPath, initial);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+  assert.equal(document.languageId, "hcl");
+  const outputEnd =
+    initial.indexOf("node.vpc.output.v") + "node.vpc.output.v".length;
+  await eventually(`${filename}: missing vpc_id completion`, async () => {
+    const completions =
+      await vscode.commands.executeCommand<vscode.CompletionList>(
+        "vscode.executeCompletionItemProvider",
+        uri,
+        document.positionAt(outputEnd),
+      );
+    return (
+      completions?.items.some(
+        (item) =>
+          item.label === "vpc_id" &&
+          (typeof item.documentation === "string"
+            ? item.documentation
+            : item.documentation?.value
+          )?.includes("Network identifier"),
+      ) ?? false
+    );
+  });
+
+  const complete = initial.replace(
+    "node.vpc.output.v",
+    "node.vpc.output.vpc_id",
+  );
+  await replace(document, complete);
+  assert.equal(document.isDirty, true);
+  const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+    "vscode.executeDefinitionProvider",
+    uri,
+    document.positionAt(complete.indexOf("node.vpc.output") + "node.".length),
+  );
+  assert.equal(
+    definitions?.[0]?.uri.toString(),
+    uri.toString(),
+    `${filename}: definition`,
+  );
+  assert.equal(definitions[0].range.start.line, group ? 1 : 0);
+
+  await replace(document, complete.replace("output.vpc_id", "output.missing"));
+  await eventually(`${filename}: missing diagnostic after unsaved edit`, () =>
+    vscode.languages
+      .getDiagnostics(uri)
+      .some(
+        (diagnostic) =>
+          diagnostic.source === "terragraph" &&
+          diagnostic.message.includes("missing"),
+      ),
+  );
+  await replace(document, complete);
+  await eventually(
+    `${filename}: stale diagnostic after repair`,
+    () => vscode.languages.getDiagnostics(uri).length === 0,
+  );
+  assert.equal(await fs.readFile(uri.fsPath, "utf8"), initial);
+  console.log(
+    `PASS ${filename}: completion metadata, definition, unsaved diagnostics`,
+  );
+}
+
+export async function run(): Promise<void> {
+  const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  assert.ok(root, "test workspace is required");
+  for (const [filename, group] of [
+    ["blueprint.hcl", false],
+    ["group.hcl", true],
+    ["nodes.hcl", false],
+    ["edges.hcl", false],
+    ["contracts.hcl", false],
+    ["components.hcl", true],
+  ] as const) {
+    await checkEditingFeatures(root, filename, group);
+  }
+}

--- a/editors/vscode/src/test/runTest.ts
+++ b/editors/vscode/src/test/runTest.ts
@@ -1,0 +1,47 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runTests } from "@vscode/test-electron";
+
+async function main(): Promise<void> {
+  const temporary = await fs.mkdtemp(
+    path.join(os.tmpdir(), "terragraph-vscode-"),
+  );
+  const workspace = path.join(temporary, "workspace");
+  const extension = path.resolve(__dirname, "..", "..");
+  try {
+    await fs.mkdir(path.join(workspace, ".vscode"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace, ".vscode", "settings.json"),
+      JSON.stringify({
+        "terragraph.languageServer.path": path.resolve(
+          extension,
+          "..",
+          "..",
+          "terragraph",
+        ),
+      }),
+    );
+    await runTests({
+      vscodeExecutablePath: process.env.TERRAGRAPH_VSCODE_EXECUTABLE,
+      extensionDevelopmentPath: [
+        extension,
+        path.join(extension, "test", "fixtures", "hcl-language"),
+      ],
+      extensionTestsPath: path.join(__dirname, "index"),
+      launchArgs: [
+        workspace,
+        "--disable-extensions",
+        "--user-data-dir=" + path.join(temporary, "user-data"),
+        "--extensions-dir=" + path.join(temporary, "extensions"),
+      ],
+    });
+  } finally {
+    await fs.rm(temporary, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/editors/vscode/test/fixtures/hcl-language/package.json
+++ b/editors/vscode/test/fixtures/hcl-language/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hcl-test-language",
+  "publisher": "terragraph-tests",
+  "version": "0.0.0",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "hcl",
+        "extensions": [
+          ".hcl"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

A blueprint split into `nodes.hcl` and `edges.hcl` already works with `--blueprint .`, but the VS Code extension only connected to `blueprint.hcl` and `group.hcl`. This change gives arbitrary `.hcl` filenames the same editing support and makes the documentation distinguish CLI defaults from naming conventions.

- Match all file-backed `*.hcl` documents in the language-client selector.
- Explain single-file loading, directory merging, group selection, and block placement; include a runnable split-file example without either conventional filename.
- Add real VS Code Extension Host regression tests for completion metadata, definition navigation, and diagnostics after unsaved edits. Run them through `make check`, using Xvfb in Linux CI, and exclude test artifacts from the extension package.
- Correct the README's hover claim: the existing server provides port metadata in completion items.

Fixes #84.

## Verification

Actual VS Code 1.135.0 on macOS, using an isolated temporary workspace and profile:

```sh
cd editors/vscode
TERRAGRAPH_VSCODE_EXECUTABLE='/Applications/Visual Studio Code.app/Contents/MacOS/Code' npm test
```

Before changing the selector:

```text
PASS blueprint.hcl: completion metadata, definition, unsaved diagnostics
PASS group.hcl: completion metadata, definition, unsaved diagnostics
AssertionError [ERR_ASSERTION]: nodes.hcl: missing vpc_id completion
Exit code:   1
```

After changing the selector:

```text
PASS blueprint.hcl: completion metadata, definition, unsaved diagnostics
PASS group.hcl: completion metadata, definition, unsaved diagnostics
PASS nodes.hcl: completion metadata, definition, unsaved diagnostics
PASS edges.hcl: completion metadata, definition, unsaved diagnostics
PASS contracts.hcl: completion metadata, definition, unsaved diagnostics
PASS components.hcl: completion metadata, definition, unsaved diagnostics
Exit code:   0
```

From the repository root:

```sh
TERRAGRAPH_VSCODE_EXECUTABLE='/Applications/Visual Studio Code.app/Contents/MacOS/Code' make check
```

Passed formatting, lint (`0 issues.`), generated-doc checks, build, all Go tests with `-race`, extension type/lint/format checks, and the six Extension Host scenarios above.

The documented `nodes.hcl` / `edges.hcl` example was extracted into a temporary directory with the example modules and no `blueprint.hcl` or `group.hcl`:

```text
terragraph graph --blueprint .
level 1: vpc
level 2: eks
```

`npx vsce ls --no-dependencies` also confirmed the package excludes the test runner and fixture extension.

- [x] `make check` passes locally (fmt, lint, docs, build, test)

## Checklist

- [x] Tests added or updated for the behavior change
- [x] Documentation updated for filename conventions and editor support
