### PR TITLE
fix: preserve output sensitivity and consistent input reads

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -18,7 +18,9 @@ terragraph decodes each concrete value and uses cty's type conversion and option
 
 ## How values are passed
 
-Input validation errors omit value-derived details, including object and map keys, when the destination variable or the inspected upstream output is declared `sensitive`. The error still names the node, input, and declared type so you can check the value against the module's variable declaration. This applies to terragraph's encoding and type-checking errors, including their JSON run reports; it does not redact arbitrary Terraform/OpenTofu subprocess output.
+A node resolving multiple inputs from the same upstream reuses one successful live output read for those inputs, so they cannot mix different state revisions. A subsequent input resolution reads live outputs again.
+
+Input validation errors omit value-derived details, including object and map keys, when the destination variable or the inspected upstream output is declared `sensitive`, or when the runtime output is sensitive or omits sensitivity metadata. Runtime sensitivity is preserved both for live reads and for outputs produced earlier in the same run. The error still names the node, input, and declared type so you can check the value against the module's variable declaration. This applies to terragraph's encoding and type-checking errors, including their JSON run reports; it does not redact arbitrary Terraform/OpenTofu subprocess output.
 
 terragraph never writes or modifies `.tf` files. Before running a node, it writes the values resolved from its incoming data edges (and its own `vars`, including literals a `use.vars` rewrote onto that node; see [blueprint.md](blueprint.md#literal-input-values-vars)) to an ephemeral, engine-managed tfvars file, then passes it to Terraform explicitly via `-var-file`. Terraform's own `*.auto.tfvars.json` auto-loading is never relied on: two nodes can share a module directory (see `backend_config` in [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), and auto-loading by a fixed filename would let them clobber each other's values.
 

--- a/internal/engine/apply.go
+++ b/internal/engine/apply.go
@@ -37,7 +37,7 @@ func (e *Engine) Apply(opts Options) ([]NodeRun, error) {
 
 	e.logger().Info("apply starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
 
-	return e.runLevels(opts, false, func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	return e.runLevels(opts, false, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		vars, err := e.resolveInputs(name, applied)
 		if err != nil {
 			return nil, "", err
@@ -83,7 +83,7 @@ func (e *Engine) Apply(opts Options) ([]NodeRun, error) {
 			if err := e.writeSnapshot(name, outputs); err != nil {
 				return nil, "", err
 			}
-			return outputs.Values(), StatusUnchanged, nil
+			return outputs, StatusUnchanged, nil
 		}
 
 		// What the plan actually does, read back from the file before any of it happens. Local only: no state is refreshed and no provider is called.
@@ -121,7 +121,7 @@ func (e *Engine) Apply(opts Options) ([]NodeRun, error) {
 		if err := e.writeSnapshot(name, outputs); err != nil {
 			return nil, "", err
 		}
-		return outputs.Values(), StatusApplied, nil
+		return outputs, StatusApplied, nil
 	}, nil)
 }
 

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -49,7 +49,7 @@ func (e *Engine) Destroy(opts Options) ([]NodeRun, error) {
 
 	e.logger().Info("destroy starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
 
-	return e.runLevels(opts, true, func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	return e.runLevels(opts, true, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		// A destroy plan needs the same resolved input values an apply would have used (e.g. a variable feeding a resource's count or for_each), so it's evaluated identically here: every upstream dependency is still standing at this point, since destroy walks the graph in reverse topological order (downstream first).
 		vars, err := e.resolveInputs(name, applied)
 		if err != nil {

--- a/internal/engine/inputs.go
+++ b/internal/engine/inputs.go
@@ -12,11 +12,14 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 )
 
 // resolveInputs gathers the values for name's inputs (every data edge pointing at it, plus its own literal Vars), checking each one against the target variable's declared type. Sources are tried in a fixed order — outputs already captured earlier in the current run (keyed by node name), then that upstream node's own existing state read live — and only when the graph opted into snapshots and the live read failed, the node's published output snapshot as a last resort (see snapshot.go): never ahead of the live read, so stale snapshots cannot displace a successful live read.
-func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (map[string]any, error) {
+func (e *Engine) resolveInputs(name string, applied map[string]exec.Outputs) (map[string]any, error) {
 	vars := map[string]any{}
+	// Multiple edges from one upstream must share one live read so a state change cannot mix revisions within a node's inputs.
+	liveOutputs := make(map[string]exec.Outputs)
 
 	for _, edge := range e.Graph.Edges {
 		if !edge.IsDataEdge() || edge.To.Node != name {
@@ -25,8 +28,14 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 
 		outputs, ok := applied[edge.From.Node]
 		if !ok {
+			outputs, ok = liveOutputs[edge.From.Node]
+		}
+		if !ok {
 			live, err := e.runner(edge.From.Node).Outputs()
-			outputs = live.Values()
+			outputs = live
+			if err == nil {
+				liveOutputs[edge.From.Node] = live
+			}
 			if err != nil {
 				// Cancellation must not fall back to disk, where stale values can obscure the cause or block a run that is already stopping.
 				if cancelled := e.context().Err(); cancelled != nil {
@@ -41,7 +50,12 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 						if !e.snapshotOutputAllowed(edge.From.Node, edge.From.Name) || slices.Contains(snapshot.Withheld, edge.From.Name) {
 							return nil, fmt.Errorf("resolving %s: %s was withheld from output snapshots; sensitive outputs and outputs without verified sensitivity metadata cannot be reused; restore live upstream outputs or apply the upstream in this run: %w", edge.To, edge.From, err)
 						}
-						outputs = snapshot.Outputs
+						outputs = make(exec.Outputs, len(snapshot.Outputs))
+						// readSnapshot has already removed values without verified public metadata.
+						public := false
+						for name, value := range snapshot.Outputs {
+							outputs[name] = exec.Output{Value: value, Sensitive: &public}
+						}
 					}
 				}
 				if !found {
@@ -65,7 +79,7 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 			return nil, err
 		}
 
-		vars[edge.To.Name] = val
+		vars[edge.To.Name] = val.Value
 	}
 
 	// graph.Validate already rejects a variable set by both an edge and Vars as a structural error, but resolveInputs runs on whatever graph it's handed (e.g. in a future --node-scoped run that skips Validate), so it re-checks rather than trusting that pass ran first.
@@ -83,9 +97,11 @@ func (e *Engine) resolveInputs(name string, applied map[string]map[string]any) (
 }
 
 // checkType verifies a concrete value resolved from a data edge against the target variable's declared type constraint. See checkVarType, which does the actual check and is shared with a node's own literal Vars.
-func (e *Engine) checkType(edge blueprint.Edge, val any) error {
+func (e *Engine) checkType(edge blueprint.Edge, output exec.Output) error {
 	sourceSensitive := e.Graph.Nodes[edge.From.Node].Schema.OutputDetails[edge.From.Name].Sensitive
-	if err := e.checkVarType(edge.To.Node, edge.To.Name, val, sourceSensitive); err != nil {
+	// Runtime metadata survives live reads and level boundaries so static declarations cannot expose sensitive payloads through conversion errors.
+	sourceSensitive = sourceSensitive || output.Sensitive == nil || *output.Sensitive
+	if err := e.checkVarType(edge.To.Node, edge.To.Name, output.Value, sourceSensitive); err != nil {
 		return fmt.Errorf("value from %s: %w", edge.From, err)
 	}
 	return nil

--- a/internal/engine/levels_test.go
+++ b/internal/engine/levels_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 	"github.com/cloudfluent/terragraph/internal/graph"
 	"github.com/cloudfluent/terragraph/internal/module"
 )
@@ -48,7 +49,7 @@ func TestRunLevels_RespectsParallelismCap(t *testing.T) {
 	e := newTestEngine([]string{"a", "b", "c", "d"}, nil)
 
 	var current, max int64
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		n := atomic.AddInt64(&current, 1)
 		for {
 			m := atomic.LoadInt64(&max)
@@ -77,7 +78,7 @@ func TestRunLevels_LevelIsABarrier(t *testing.T) {
 	e := newTestEngine([]string{"a", "b"}, []blueprint.Edge{orderEdge("a", "b")})
 
 	var aFinished atomic.Bool
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		if name == "a" {
 			time.Sleep(30 * time.Millisecond)
 			aFinished.Store(true)
@@ -99,7 +100,7 @@ func TestRunLevels_ErrorInLevelStopsNextLevel(t *testing.T) {
 	e := newTestEngine([]string{"a", "b", "c"}, []blueprint.Edge{orderEdge("a", "b")})
 
 	var bRan atomic.Bool
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		switch name {
 		case "c":
 			return nil, "", fmt.Errorf("boom")
@@ -121,11 +122,11 @@ func TestRunLevels_ErrorInLevelStopsNextLevel(t *testing.T) {
 func TestRunLevels_AppliedSnapshotPropagatesAcrossLevels(t *testing.T) {
 	e := newTestEngine([]string{"a", "b"}, []blueprint.Edge{orderEdge("a", "b")})
 
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		if name == "a" {
-			return map[string]any{"x": "from-a"}, "", nil
+			return exec.Outputs{"x": {Value: "from-a"}}, "", nil
 		}
-		if applied["a"]["x"] != "from-a" {
+		if applied["a"]["x"].Value != "from-a" {
 			return nil, "", fmt.Errorf("expected b to see a's output, got %v", applied["a"])
 		}
 		return nil, "", nil
@@ -141,7 +142,7 @@ func TestRunLevels_AfterLevelRunsOncePerLevel(t *testing.T) {
 	// levels: [a, c], [b] -> afterLevel should fire twice.
 
 	var calls int64
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		return nil, "", nil
 	}
 	afterLevel := func() error {
@@ -161,7 +162,7 @@ func TestRunLevels_AfterLevelErrorAbortsRun(t *testing.T) {
 	e := newTestEngine([]string{"a", "b"}, []blueprint.Edge{orderEdge("a", "b")})
 
 	var bRan atomic.Bool
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		if name == "b" {
 			bRan.Store(true)
 		}

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -27,7 +27,7 @@ func (e *Engine) Plan(opts Options) ([]NodeRun, error) {
 	defer unlockGraph()
 
 	e.logger().Info("plan starting", "node", opts.Node, "parallelism", opts.parallelism())
-	return e.runLevels(opts, false, func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	return e.runLevels(opts, false, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		vars, err := e.resolveInputs(name, applied)
 		if err != nil {
 			return nil, "", err

--- a/internal/engine/resolve_inputs_test.go
+++ b/internal/engine/resolve_inputs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 	"github.com/cloudfluent/terragraph/internal/module"
 )
 
@@ -31,7 +32,7 @@ func TestResolveInputs_EdgeAndVarsTogether(t *testing.T) {
 	e.Graph.Nodes["b"].Schema.Variables["cidr"] = module.Variable{Name: "cidr", Type: "string"}
 	e.Graph.Nodes["b"].Vars = map[string]any{"cidr": "10.16.0.0/20"}
 
-	applied := map[string]map[string]any{"a": {"id": "vpc-123"}}
+	applied := map[string]exec.Outputs{"a": {"id": {Value: "vpc-123"}}}
 	vars, err := e.resolveInputs("b", applied)
 	if err != nil {
 		t.Fatalf("resolveInputs: %v", err)
@@ -49,7 +50,7 @@ func TestResolveInputs_ConflictBetweenEdgeAndVarsErrors(t *testing.T) {
 	e.Graph.Nodes["b"].Schema.Variables["x"] = module.Variable{Name: "x", Type: "string"}
 	e.Graph.Nodes["b"].Vars = map[string]any{"x": "literal-value"}
 
-	applied := map[string]map[string]any{"a": {"id": "vpc-123"}}
+	applied := map[string]exec.Outputs{"a": {"id": {Value: "vpc-123"}}}
 	if _, err := e.resolveInputs("b", applied); err == nil {
 		t.Fatalf("expected an error: %q is set by both an edge and vars", "x")
 	}

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 	"github.com/cloudfluent/terragraph/internal/graph"
 )
 
@@ -69,7 +70,7 @@ type NodeRun struct {
 }
 
 // nodeAction runs one node's step of a plan/apply/destroy: given the outputs applied so far this run and a writer for this node's terraform output, it returns the outputs to feed downstream (nil if the node produced none worth propagating, e.g. Destroy), the success status to record for the node, and an error.
-type nodeAction func(name string, applied map[string]map[string]any, out io.Writer) (outputs map[string]any, status string, err error)
+type nodeAction func(name string, applied map[string]exec.Outputs, out io.Writer) (outputs exec.Outputs, status string, err error)
 
 // runLevels is the shared execution loop behind Plan/Apply/Destroy: it walks the graph (or a single node) level by level, running up to opts.Parallelism nodes within a level concurrently. Nodes in the same level are guaranteed to have no edge between them, so a read-only snapshot of outputs applied so far is safe to share across the level's goroutines, and results are merged back only once the whole level completes (no data races). If any node in a level errors, already-started siblings finish but the next level never starts; the returned runs record those unreached nodes as StatusNotRun so a report covers the whole selection rather than stopping where execution did. afterLevel, if non-nil, runs once each level completes successfully; an error from it aborts the run the same way.
 func (e *Engine) runLevels(opts Options, reverse bool, action nodeAction, afterLevel func() error) (runs []NodeRun, err error) {
@@ -78,7 +79,7 @@ func (e *Engine) runLevels(opts Options, reverse bool, action nodeAction, afterL
 		return nil, err
 	}
 
-	applied := map[string]map[string]any{}
+	applied := map[string]exec.Outputs{}
 	var mu sync.Mutex
 	var outMu sync.Mutex
 	buffered := opts.parallelism() > 1
@@ -98,7 +99,7 @@ func (e *Engine) runLevels(opts Options, reverse bool, action nodeAction, afterL
 			return markNotRun(runs, levels, li), err
 		}
 		mu.Lock()
-		snapshot := make(map[string]map[string]any, len(applied))
+		snapshot := make(map[string]exec.Outputs, len(applied))
 		for k, v := range applied {
 			snapshot[k] = v
 		}
@@ -123,7 +124,7 @@ func (e *Engine) runLevels(opts Options, reverse bool, action nodeAction, afterL
 				}
 
 				e.logger().Debug("running node", "node", name)
-				var outputs map[string]any
+				var outputs exec.Outputs
 				var status string
 				err := e.context().Err()
 				if err == nil {

--- a/internal/engine/run_report_test.go
+++ b/internal/engine/run_report_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 )
 
 // TestRunLevels_ReportsFailedAndNotRun proves the report covers the whole selection: the failing node is recorded as failed at its level, and every node the aborted run never reached is recorded as not run rather than simply missing.
 func TestRunLevels_ReportsFailedAndNotRun(t *testing.T) {
 	e := newTestEngine([]string{"a", "b"}, []blueprint.Edge{orderEdge("a", "b")})
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		if name == "a" {
 			return nil, "", fmt.Errorf("boom")
 		}
@@ -38,7 +39,7 @@ func TestRunLevels_ReportsFailedAndNotRun(t *testing.T) {
 // TestRunLevels_ReportsSuccessStatuses proves the status an action returns is what the report carries, level numbers follow execution order, and a successful run reports every selected node.
 func TestRunLevels_ReportsSuccessStatuses(t *testing.T) {
 	e := newTestEngine([]string{"a", "b"}, []blueprint.Edge{orderEdge("a", "b")})
-	action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+	action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		return nil, StatusPlanned, nil
 	}
 
@@ -80,7 +81,7 @@ func TestRunLevels_ReportsInExecutionOrder(t *testing.T) {
 
 			failure := errors.New("boom")
 			lastStarted := make(chan struct{})
-			action := func(name string, applied map[string]map[string]any, out io.Writer) (map[string]any, string, error) {
+			action := func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 				// At parallelism 2, the middle node must be recorded before the last can start and release the first, forcing completion order away from name order without sleeps.
 				if name == first[0] {
 					<-lastStarted

--- a/internal/engine/sensitive_runtime_unix_test.go
+++ b/internal/engine/sensitive_runtime_unix_test.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApply_RuntimeSensitiveInputErrorsWithholdPayload(t *testing.T) {
+	for _, metadata := range []string{`"sensitive":true,`, `"sensitive":null,`, "", `"sensitive":false,`} {
+		t.Run(metadata, func(t *testing.T) {
+			for _, node := range []string{"b", ""} {
+				t.Run("node="+node, func(t *testing.T) {
+					e := loadFallbackEngine(t, false)
+					modulePath := filepath.Join(e.BaseDir, "module", "main.tf")
+					src, err := os.ReadFile(modulePath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					src = bytes.Replace(src, []byte(`default = ""`), []byte(`type = map(object({ count = number }))
+  default = {}`), 1)
+					if err := os.WriteFile(modulePath, src, 0o600); err != nil {
+						t.Fatal(err)
+					}
+					scriptPath := filepath.Join(e.BaseDir, "terraform-fake")
+					script, err := os.ReadFile(scriptPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					script = bytes.ReplaceAll(script, []byte(`"sensitive":false,`), []byte(metadata))
+					script = bytes.ReplaceAll(script, []byte(`"value":"%s"`), []byte(`"value":{"PRIVATE_PAYLOAD_KEY":"%s"}`))
+					if err := os.WriteFile(scriptPath, script, 0o755); err != nil {
+						t.Fatal(err)
+					}
+					e, err = Load(filepath.Join(e.BaseDir, "blueprint.hcl"), e.Binary, e.Stdout, e.Stderr)
+					if err != nil {
+						t.Fatal(err)
+					}
+					runs, err := e.Apply(Options{Node: node, AutoApprove: true, Parallelism: 2})
+					if metadata == `"sensitive":false,` {
+						if err == nil || !strings.Contains(err.Error(), "PRIVATE_PAYLOAD_KEY") || strings.Contains(err.Error(), "value details withheld") {
+							t.Fatalf("error = %v, want detailed public input error", err)
+						}
+						return
+					}
+					if err == nil || !strings.Contains(err.Error(), "value details withheld") {
+						t.Fatalf("error = %v, want redacted runtime-sensitive input error", err)
+					}
+					if strings.Contains(e.Stdout.(*bytes.Buffer).String()+e.Stderr.(*bytes.Buffer).String(), "PRIVATE_PAYLOAD") {
+						t.Fatal("sensitive payload appears in engine streams")
+					}
+					reported := []error{err}
+					for _, run := range runs {
+						reported = append(reported, run.Err)
+					}
+					for _, report := range reported {
+						for cause := report; cause != nil; cause = errors.Unwrap(cause) {
+							if strings.Contains(cause.Error(), "PRIVATE_PAYLOAD") {
+								t.Fatal("sensitive payload remains in error chain")
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/engine/snapshot_fallback_unix_test.go
+++ b/internal/engine/snapshot_fallback_unix_test.go
@@ -247,3 +247,55 @@ func TestResolveInputs_CancellationDoesNotUseSnapshot(t *testing.T) {
 		t.Fatalf("inputs = %v, error = %v, want cancellation without snapshot values", vars, err)
 	}
 }
+
+func TestResolveInputs_ReadsUpstreamOnceForMultipleInputs(t *testing.T) {
+	t.Setenv("TG_OUTPUT_LATER", "later")
+	e := loadFallbackEngine(t, false)
+	modulePath := filepath.Join(e.BaseDir, "module", "main.tf")
+	src, err := os.ReadFile(modulePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src = append(src, []byte("\nvariable \"second\" { default = \"\" }\n")...)
+	if err := os.WriteFile(modulePath, src, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	blueprintPath := filepath.Join(e.BaseDir, "blueprint.hcl")
+	src, err = os.ReadFile(blueprintPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src = append(src, []byte(`
+edge {
+ from = node.a.output.consumed
+ to = node.b.input.second
+}
+`)...)
+	if err := os.WriteFile(blueprintPath, src, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	e, err = Load(blueprintPath, e.Binary, e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		vars, err := e.resolveInputs("b", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "first"
+		if i == 1 {
+			want = "later"
+		}
+		if vars["consumed"] != want || vars["second"] != want {
+			t.Fatalf("inputs = %v, want both inputs from the same %q read", vars, want)
+		}
+	}
+	calls, err := os.ReadFile(filepath.Join(e.dataDir("a"), "output-calls"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(calls)) != "2" {
+		t.Fatalf("output calls = %q, want one per input resolution", calls)
+	}
+}

--- a/internal/engine/type_check_test.go
+++ b/internal/engine/type_check_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/exec"
 	"github.com/cloudfluent/terragraph/internal/module"
 )
 
@@ -19,7 +20,7 @@ func TestCheckType_MatchingTypePasses(t *testing.T) {
 	e.Graph.Nodes["b"].Schema.Variables["vpc_id"] = module.Variable{Name: "vpc_id", Type: "string"}
 
 	edge := dataEdge("a", "id", "b", "vpc_id")
-	if err := e.checkType(edge, "vpc-123"); err != nil {
+	if err := e.checkType(edge, exec.Output{Value: "vpc-123"}); err != nil {
 		t.Fatalf("expected no error for a matching string value, got %v", err)
 	}
 }
@@ -29,7 +30,7 @@ func TestCheckType_MismatchedTypeFails(t *testing.T) {
 	e.Graph.Nodes["b"].Schema.Variables["subnet_ids"] = module.Variable{Name: "subnet_ids", Type: "list(string)"}
 
 	edge := dataEdge("a", "id", "b", "subnet_ids")
-	if err := e.checkType(edge, "vpc-123"); err == nil {
+	if err := e.checkType(edge, exec.Output{Value: "vpc-123"}); err == nil {
 		t.Fatalf("expected an error feeding a string into a list(string) variable")
 	}
 }
@@ -40,7 +41,7 @@ func TestCheckType_ListValueIntoListTypePasses(t *testing.T) {
 
 	edge := dataEdge("a", "ids", "b", "subnet_ids")
 	val := []any{"subnet-1", "subnet-2"}
-	if err := e.checkType(edge, val); err != nil {
+	if err := e.checkType(edge, exec.Output{Value: val}); err != nil {
 		t.Fatalf("expected no error for a matching list value, got %v", err)
 	}
 }
@@ -50,7 +51,7 @@ func TestCheckType_UntypedVariableAlwaysPasses(t *testing.T) {
 	e.Graph.Nodes["b"].Schema.Variables["anything"] = module.Variable{Name: "anything", Type: ""}
 
 	edge := dataEdge("a", "id", "b", "anything")
-	if err := e.checkType(edge, map[string]any{"nested": true}); err != nil {
+	if err := e.checkType(edge, exec.Output{Value: map[string]any{"nested": true}}); err != nil {
 		t.Fatalf("expected no error for an untyped variable, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Keep runtime output sensitivity attached until downstream input validation so a sensitive map key cannot leak through a conversion error. This covers live upstream reads and outputs produced earlier in the same apply, including unchanged nodes; missing or null sensitivity metadata also withholds error details, while explicitly public values retain detailed diagnostics.

When several inputs consume the same upstream, reuse one successful live read within that input resolution. Previously, a changing upstream could supply different state revisions to the same downstream node. Subsequent input resolutions still read fresh outputs. Update the execution-model documentation and add regression coverage for both fixes.

## Verification

Before the fixes, the regression tests failed (failure excerpts):

```text
$ go test -race ./internal/engine -run TestApply_RuntimeSensitiveInputErrorsWithholdPayload
--- FAIL: TestApply_RuntimeSensitiveInputErrorsWithholdPayload
error = node "b": value from node.a.output.consumed: node.b.input.consumed: does not match declared type map(object({ count = number })): element "PRIVATE_PAYLOAD_KEY": object required, but have string, want redacted runtime-sensitive input error
FAIL

$ go test -race ./internal/engine -run TestResolveInputs_ReadsUpstreamOnceForMultipleInputs
--- FAIL: TestResolveInputs_ReadsUpstreamOnceForMultipleInputs
inputs = map[consumed:first second:second], want both inputs from the same "first" read
FAIL
```

After the fixes:

```text
$ go test -race ./internal/engine -run 'TestResolveInputs_ReadsUpstreamOnceForMultipleInputs|TestApply_RuntimeSensitiveInputErrorsWithholdPayload'
ok  github.com/cloudfluent/terragraph/internal/engine  3.353s

$ make check
0 issues.
ok  github.com/cloudfluent/terragraph/internal/engine  26.893s
All matched files use Prettier code style!
```

The full gate completed successfully on macOS with the pinned Go 1.27.1: formatting, lint, generated CLI docs, build, all Go tests with the race detector, and VS Code type/lint/format checks. Regression coverage checks error chains and engine streams, sensitive/missing/null/public metadata, live and same-run inputs, and a fresh read on the next resolution. Subprocess tests use executable fixtures; this does not claim a deployment against real infrastructure.

- [x] `make check` passes locally (fmt, lint, docs, build, test, vscode-check)

## Checklist

- [x] Tests added or updated for the behavior change
- [x] `docs/*.md` updated for the changed behavior
