### PR TITLE
docs: align the user guide with supported behavior

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,32 @@
 # Documentation
 
-- [blueprint.md](blueprint.md): nodes, edges, reusing a module across instances, literal `vars`, per-node `runtime` and `env`
-- [groups.md](groups.md): bundling nodes into a reusable sub-blueprint
-- [contracts.md](contracts.md): producer guarantees, consumer requirements, and advisory or enforced declaration checks
-- [vendoring.md](vendoring.md): pointing a node at a remote git module
-- [execution-model.md](execution-model.md): validation, how values are passed, parallelism, concurrent CLI processes, the graph remote lock, how apply decides what needs applying, the one known limitation
-- [intellisense.md](intellisense.md): VS Code completion, go to definition, error reporting
-- [cli/terragraph.md](cli/terragraph.md): full command/flag reference, generated from the CLI itself (see `make docs` in the repo root)
+terragraph connects independent Terraform/OpenTofu root modules. A blueprint names the modules and connects their outputs to inputs; terragraph runs them in dependency order while each module keeps its own state.
+
+## Start with a working example
+
+[Install the CLI](../README.md#install) and put `terraform` or `tofu` on `PATH`. From a checkout of this repository, try the [basic example](../examples/basic), which uses local files and random values without cloud credentials:
+
+```sh
+cd examples/basic
+terragraph validate
+terragraph graph
+terragraph apply
+```
+
+`validate` checks the blueprint against its modules, `graph` shows execution order, and `apply` plans and asks for confirmation as it reaches each changed node. Add `--tofu` to use OpenTofu. The example may download providers during initialization.
+
+For a new graph, `apply` can create upstream resources and pass their outputs to downstream nodes in the same run. `plan` reads existing upstream outputs, so it cannot preview a consumer whose required output is unavailable, or propagate upstream's newly planned values. Read the [planning limitation](execution-model.md#known-limitation) before using a whole-graph plan as a change preview.
+
+For your own modules, start with [nodes, edges, and literal inputs](blueprint.md). If a node uses a remote source, run [vendoring](vendoring.md) before validation or execution. For a blueprint split across files, select its directory with `--blueprint .`; see [files and loading](blueprint.md#files-and-loading).
+
+## Find the next task
+
+| You want to | Read |
+|---|---|
+| Connect modules, supply inputs, or choose runtimes and environments | [Blueprint](blueprint.md) |
+| Reuse a set of connected modules | [Groups](groups.md) and the [group example](../examples/group) |
+| Check producer and consumer declarations | [Contracts](contracts.md) |
+| Bring Git sources into version control and update them | [Vendoring](vendoring.md) |
+| Preview a graph, control changes, run in CI, or recover from failure | [Execution model](execution-model.md) |
+| Use completion, definition navigation, and editor diagnostics | [VS Code IntelliSense](intellisense.md) |
+| Look up a command or flag | [CLI reference](cli/terragraph.md), generated from the CLI |

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -1,6 +1,6 @@
 # Blueprint
 
-A blueprint describes nodes and the edges between them in HCL. The CLI reads `blueprint.hcl` by default; other filenames and directories can be selected with `--blueprint`.
+A blueprint describes independent Terraform/OpenTofu root modules (`node` blocks) and the connections between them (`edge` blocks). The CLI reads `blueprint.hcl` by default; select another file or a directory with `--blueprint`.
 
 ```hcl
 node "vpc" {
@@ -17,17 +17,63 @@ edge {
 }
 ```
 
-An edge can be:
-- **Explicit (data edge)**: both sides reference a specific port (`node.<name>.output.<attr>` / `node.<name>.input.<attr>`). The engine passes the value at runtime.
-- **Implicit (ordering-only edge)**: both sides reference a bare node (`node.<name>`). No value is passed; it only constrains execution order.
+Each `source` points to a module with its own Terraform configuration, variables, and outputs. Local node sources start with `./` or `../` and resolve relative to the blueprint file's directory, or to the directory selected by `--blueprint`. Other source strings require [vendoring](vendoring.md). Node, group, runtime, and `use` instance names may contain only letters, digits, underscores, and hyphens.
 
-Mixing the two on the same edge (a port on one side, a bare node on the other) is rejected at parse time.
+An edge can carry a value or only control execution order:
 
-An input is a single slot: two data edges targeting the same input are a validation Error, whether their `from` sides differ or match (exact duplicates). The same rule covers a data edge colliding with `vars` (see [Literal input values (`vars`)](#literal-input-values-vars)). It is checked after group expansion, so two outer edges, or an outer edge plus an internal one, that only meet on the same leaf once a `use` export has rewritten them are caught too. A `use.vars` key is rewritten onto those same leaves and collides the same way as `node.vars`; see [groups.md](groups.md#setting-literal-inputs-for-an-instance). Ordering-only edges are not this rule; they carry no value.
+- **Data edge:** `node.<name>.output.<attr>` feeds `node.<name>.input.<attr>`. Both ports must exist in their modules. The downstream node waits for the upstream node, then receives its real output value.
+- **Ordering-only edge:** `from = node.vpc` and `to = node.eks` makes `eks` wait for `vpc` without passing a value.
 
-Node canvas layout (for the future visual editor) lives in a separate `blueprint.layout.json`, so moving a box never shows up in a `blueprint.hcl` diff.
+Both endpoints must use the same form; mixing a bare node and a port is an error. A destination input may have only one data source, including after [group expansion](groups.md). Duplicate data edges and a data edge combined with `vars` on the same input are errors. Ordering-only edges do not occupy an input.
 
-Edges wire values; contracts review them. See [`docs/contracts.md`](contracts.md) to declare producer guarantees and consumer requirements as top-level `producer`/`consumer` blocks keyed by module source.
+See [`examples/basic`](../examples/basic) for runnable modules and [the execution model](execution-model.md) for how `plan`, `apply`, and `destroy` use these connections.
+
+## Literal input values (`vars`)
+
+Use `vars` for values specific to a node, such as an environment name or CIDR. Keys are the module's declared variable names:
+
+```hcl
+node "data-apne2-dev-vpc" {
+  source = "./modules/vpc"
+  vars = {
+    name            = "dpl-apne2-vpc-dev"
+    cidr            = "10.16.0.0/20"
+    private_subnets = ["10.16.0.0/23", "10.16.2.0/23"]
+    tags            = { tenant = "data-platform" }
+  }
+}
+```
+
+Values can be strings, numbers, booleans, nulls, lists, or nested objects. Numeric precision is preserved when values are passed to Terraform. If you control the module interface, related settings can share an `object`-typed variable instead of many separate variables.
+
+`vars` accepts literal data with no variables or functions in scope. Another node's output needs an `edge`; putting `node.other.output.x` inside `vars` is an error and would not record the dependency. A `vars` key must name a real input and must not also be supplied by a data edge.
+
+Resolved `vars` and edge values share the same temporary tfvars file and type checks. Terraform/OpenTofu performs the final conversion and variable validation. See [how values are passed](execution-model.md#how-values-are-passed) for the optional `tfvars` setting and cleanup behavior, and [group instance inputs](groups.md#setting-literal-inputs-for-an-instance) for `use.vars`.
+
+## Several values between the same two nodes (`input`)
+
+When two modules exchange several values, nested `input` blocks let you name the nodes once:
+
+```hcl
+edge {
+  from = node.vpc
+  to   = node.eks
+
+  input "vpc_id" {
+    from = output.vpc_id
+  }
+
+  input "subnet_ids" {
+    from = output.private_subnet_ids
+  }
+}
+```
+
+Each block label names an input on the destination, and `from = output.<attr>` names an output on the source. Use this relative spelling inside the block; an absolute `node.vpc.output.vpc_id` is rejected. Labels must be unique within an edge.
+
+Each `input` becomes an ordinary data edge, so the same port checks, input collision rules, and execution order apply. The enclosing `from` and `to` must be bare node or `use` references. With no `input` blocks, the edge is ordering-only; it cannot combine nested inputs with port endpoints.
+
+Either endpoint may be a group instance, such as `use.checkout`. Its values resolve through the group's [exported ports](groups.md), including input fan-out.
 
 ## Files and loading
 
@@ -63,68 +109,11 @@ terragraph graph --blueprint .
 
 Names and singleton settings must be unique across the merged files; later files do not override earlier declarations. The files may contain any supported top-level blocks regardless of their names. Block nesting still matters: `export` belongs inside a `group`, while settings such as `runtime`, `vendor`, and `lock` belong at the top level. Repeating the same `group` name in multiple files is a duplicate definition, not a way to extend its body. See [group source directories](groups.md#source-directories-and-filenames) for how a `use` selects a group.
 
-## Graph remote lock (`lock`)
-
-An optional top-level `lock` block serializes `plan` / `apply` / `destroy` across machines (a laptop and CI, or two clones). Terraform still locks each node's state; this lock is the graph run. Activation is the block itself, not a CLI flag. At most one `lock` per blueprint. See [execution-model.md](execution-model.md#graph-remote-lock) for acquire order and crash behavior.
-
-```hcl
-lock {
-  s3 {
-    bucket = "acme-tfstate"
-    key    = "terragraph/prod.lock"
-    region = "ap-northeast-2"
-  }
-}
-```
-
-`s3` is the only nested type in this release (`dynamodb` / `gcs` later). Parse errors: empty `lock {}`; two nested backends; an unknown nested type (including `dynamodb` today); a second `lock` block. `bucket`, `key`, and `region` are required non-empty literal strings.
-
-When `lock` is present, every node must use a remote backend (`s3` / `gcs` / `azurerm` / `http` / `remote` / `cloud`). `backend "local"` or no backend block is a validate **Error**. An S3 graph lock must not share an object with a node (same `key` and same bucket, or same `key` when `backend_config.bucket` is omitted). Known literal S3 backend settings from the module are combined with `backend_config` overrides for this check. Matching literal bucket/key candidates whose AWS partition cannot be determined produce a warning that lock/state separation is unverified; the existing explicit partial-key error remains an error. No `lock` block leaves current behavior (including local state) unchanged.
-
-## Output snapshots (`snapshots`)
-
-An optional empty `snapshots { }` block opts the graph into local output
-snapshots. Activation is the block itself, not a CLI flag; at most one
-`snapshots` per blueprint; the body accepts nothing in this release. With
-it, `apply` records the non-sensitive outputs a data edge consumes from each
-node into the gitignored `.terragraph/outputs/`. Sensitive outputs and outputs
-without sensitivity metadata are withheld; only their port names are recorded.
-Input resolution gains a source of **last** resort — after this run's applied
-outputs and after live `terraform output`, never ahead of either. Without the block, nothing is
-written and resolution is unchanged. See
-[execution-model.md](execution-model.md#output-snapshots) for the ordering
-rationale.
-
-## Several values between the same two nodes (`input`)
-
-One `edge` block is one pair, which is faithful to "a flat list of facts" but noisy when two modules that already expose many flat variables need ten of them wired. An edge whose `from` and `to` are bare references may instead carry nested `input` blocks, the same shape as a group's [`export` input](groups.md):
-
-```hcl
-edge {
-  from = node.vpc
-  to   = node.eks
-
-  input "vpc_id" {
-    from = output.vpc_id
-  }
-
-  input "subnet_ids" {
-    from = output.private_subnet_ids
-  }
-}
-```
-
-The block label is the destination input on the `to` node, and `from` is a relative `output.<attr>` on the `from` node: the enclosing edge already names the source, so it is never repeated (an absolute `node.vpc.output.vpc_id` inside the block is rejected rather than accepted-if-it-matches). Duplicate labels on one edge are an error, the same as in an `export` block.
-
-This is shorthand and nothing more. With no `input` blocks the edge is the ordering-only edge above; with one or more, it expands at parse time into exactly that many ordinary data edges (`node.vpc.output.vpc_id` → `node.eks.input.vpc_id`, and so on), and everything downstream — the one-source-per-input rule below, `use` export resolution, cycle detection — treats them as if they had been written out one block each. An edge that already names a specific port on either side has exactly one value to carry, so combining that with `input` blocks is rejected.
-
-When you own both modules, the better reduction is still one `object`-typed output wired into one `object`-typed input by one ordinary edge (see [`vars`](#literal-input-values-vars) for the same argument applied to literal values). This shorthand is for the modules you don't get to reshape.
-
-Either endpoint may be a group instance (`use.<name>`), and each expanded edge then resolves through that instance's `export` exactly as a separately written one would, fan-out included: see [groups.md](groups.md).
-
 ## Reusing the same module across instances
 
-A node can reuse one module `source` across multiple instances (e.g. the same `./stacks/vpc` for both `dev` and `prod`) without their state colliding. If the module declares `backend "local"` (an empty block is enough) and the node does not set `path`, terragraph fills `path` to `<blueprint dir>/.terragraph/state/<node>.tfstate` (absolute) and passes it as `terraform init -backend-config=path=...`. An explicit `path` wins.
+Multiple nodes can share one `source` while supplying different `vars`, environments, and backend settings. Each instance needs its own state address.
+
+For a module declaring `backend "local"` (an empty block is enough), terragraph supplies an absolute `path` of `<blueprint dir>/.terragraph/state/<node>.tfstate` when the node has no explicit `backend_config.path`:
 
 ```hcl
 node "vpc_prod" {
@@ -136,65 +125,52 @@ node "vpc_dev" {
 }
 ```
 
-`backend_config` is still available for remote backends (`bucket`, `profile`, `region`, `key`, ...) or an explicit local `path`. It requires a `backend` block in the module; a missing block or a `cloud` block plus a non-empty `backend_config` is a validate **Error**. Two nodes that share a module directory and resolve to the same `backend_config` map (including both empty) are also a validate **Error**. Validation also rejects known shared local state paths (including symlink aliases and differing backup options) and known shared S3 bucket/key addresses across module directories. Explicit `TF_WORKSPACE` values are included in these address checks. Confirmed S3 collisions require a known partition as well as matching bucket, effective workspace key, and endpoint. If the literal bucket/key candidates match, their endpoints are not explicitly distinct, and either partition is unknown, validation warns of a possible collision instead of inferring equality from missing regions or matching custom endpoints. Set explicit backend region and endpoint settings where applicable and verify the resolved namespaces: AWS profiles can select different partitions, and custom services can select namespaces by credentials. Only statically known scalar settings are compared; backend expressions, compound settings, and external configuration are not resolved by these checks, which do not discover or manage remote state. Names that resolve to the same managed path on the actual filesystem are a validate **Error**, including letter-case variants on a case-insensitive volume; validation never renames nodes or moves state. If missing paths have parent directories whose case rules cannot be established, validation warns that separation is unverified. Every node also gets its own isolated `.terraform/` metadata directory (`TF_DATA_DIR`, managed automatically) regardless of whether its `source` is shared with another node. Otherwise two instances of the same module would also fight over which backend they were last configured with.
+This gives the default workspace a different state file for each node. A module with no backend block uses Terraform's implicit local state and does not receive this generated path. An explicit `backend_config.path` wins; a path written only in the module's backend block is overridden. A relative path is resolved from the **module's directory**, not the blueprint directory. Non-default Terraform workspaces use their backend's workspace paths, so verify those separately. Terragraph never migrates existing state; see [state paths and migration](execution-model.md#how-values-are-passed) before adopting this layout for an existing deployment.
 
-Sharing a `source` directory does *not* isolate `.terraform.lock.hcl`, though: unlike `.terraform/`, that file lives in the module directory itself. If those instances also resolve to different runtimes (see below), Terraform and OpenTofu will each keep rewriting it to their own provider registry host on every `init`, and `terragraph validate` warns about exactly this. Give each instance its own `source` copy (or wait until they're all on the same runtime) rather than ignoring that warning.
+Use `backend_config` for remote backend fields such as `bucket`, `key`, `region`, and `profile`, or for an explicit local path. Entries are passed to `terraform init` as `-backend-config` options. A non-empty map requires a `backend` block in the module; it is invalid with no backend block or with a `cloud` block. A group's [`use.backend_config`](groups.md#isolating-state-for-an-instance) can supply shared defaults.
+
+Validation rejects identical backend configuration maps on a shared source, known shared local state paths, and known shared S3 state addresses. It also rejects node names that collide on the filesystem, including case differences on a case-insensitive volume. These checks use statically known settings, including explicit `TF_WORKSPACE` values; they cannot resolve all backend expressions, external configuration, or credential-dependent namespaces. Warnings about unverified separation require checking the paths or backend namespaces yourself. Set distinct addresses and explicit region/endpoint settings where needed; a different profile alone does not establish a different state address.
+
+Every node receives a separate `TF_DATA_DIR` for Terraform's backend metadata, even when sources are not shared. The module's `.terraform.lock.hcl` is still shared by nodes using the same directory. Validation warns when those nodes select different runtime binaries; use separate source copies or the same runtime to avoid provider lock file conflicts.
 
 ## Choosing a runtime per node (`runtime`)
 
-Every node runs against whichever binary a plain `--tofu`/no-flag choice on the CLI selects, by default. A node (or a whole blueprint) can override that by declaring one or more named `runtime` blocks and referencing one:
+Use named runtimes to select Terraform or OpenTofu per node, or to pin a binary while migrating stacks independently:
 
 ```hcl
 runtime "tofu" {
-  binary  = "tofu"          # a PATH-resolved command, or an absolute path to pin an exact install
-  version = ">= 1.8.0"      # optional, free-form; documentation only, see below
+  binary  = "tofu"
+  version = ">= 1.8.0"  # documentation only; not an enforced constraint
 }
 
 runtime "legacy" {
-  binary  = "/opt/terraform_1.5.7"
+  binary = "/opt/terraform_1.5.7"
 }
 
 node "eks" {
   source  = "./stacks/eks"
-  runtime = runtime.tofu     # this node always runs on tofu, regardless of --tofu
+  runtime = runtime.tofu
 }
 
 node "legacy_dns" {
   source  = "./stacks/dns"
-  runtime = runtime.legacy   # pinned to an exact binary, for a stack that isn't ready to move yet
+  runtime = runtime.legacy
 }
 ```
 
-A node that names no `runtime` falls back, in order: the blueprint's own `default = true` runtime, if it declared one; otherwise the CLI's `--tofu` flag or its built-in `terraform` default. Since every node has its own isolated state (see [execution-model.md](execution-model.md)), this can be applied node by node: migrate one stack to a new runtime while everything else keeps running exactly as before, with no shared workspace to force an all-or-nothing cutover. There's no way back down, though: Terraform/OpenTofu record the version that last wrote a state file, and an older binary will refuse to read it, so treat this as a one-way door per node, not something to toggle back and forth.
+Runtime selection uses the node's explicit choice, then the nearest enclosing [`use.runtime`](groups.md#choosing-a-runtime-for-an-instance), then the root blueprint's runtime marked `default = true`, then the CLI's `--tofu` flag or built-in `terraform` default. At most one runtime in the root blueprint may declare `default = true`. A group's default-marked runtime does not become an instance default.
 
-Static module inspection follows the same runtime choice before validating ports, types, backend configuration, or contracts. Terraform reads `.tf` and `.tf.json`; OpenTofu also reads `.tofu` and `.tofu.json`, replacing a `.tf` file only with its same-name `.tofu` counterpart (and likewise for `.tf.json` / `.tofu.json`). Different formats coexist. Inspection never creates or edits module files.
+`binary` may name a command on PATH or an absolute executable path. `version` records intent; terragraph does not enforce that constraint. Before switching runtimes, back up state and check compatibility: new state formats or runtime features can prevent a rollback. See [Terraform's compatibility guidance](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises) and the [OpenTofu migration guide](https://opentofu.org/docs/intro/migration/migration-guide/).
 
-The canonical commands `terraform` and `tofu` identify the file-selection mode. An absolute binary path also identifies it when it resolves to the same file as exactly one of those commands on the current PATH. A different installation or arbitrary wrapper is accepted when both modes expose identical static declarations, including defaults, sensitivity, and backend attributes. If they differ, inspection fails before execution: use the intended canonical command on PATH, point to that same installation, or make the declarations agree. A filename such as `/opt/custom/tofu` alone does not prove which runtime a wrapper runs. No runtime is executed to make this decision.
+Validation and editor inspection follow the same runtime choice. Terraform reads `.tf` and `.tf.json`; OpenTofu also reads `.tofu` and `.tofu.json`. An OpenTofu file replaces only its same-name, same-format Terraform counterpart, so `main.tofu` replaces `main.tf`, while `main.tofu.json` and `main.tf` coexist. Inspection does not execute a runtime or edit module files.
 
-For a recognized OpenTofu runtime, static validation and editor inspection assume support for `.tofu` files (OpenTofu 1.8 or newer). They never execute the runtime. Before `plan`, `apply`, or `destroy` consumes inputs or snapshots, nodes selecting `.tofu` / `.tofu.json` files must report an actual version of at least 1.8.0 through `version -json`; an old, failed, or unparseable response stops the run with an upgrade remedy. A node-scoped run also checks direct upstream nodes whose outputs it can read. Modules selecting only `.tf` / `.tf.json` need no version probe and continue to work with older OpenTofu.
+The canonical `terraform` and `tofu` commands identify the inspection mode. An absolute binary path does too if it resolves to the same file as exactly one of those commands on PATH. Other binaries and wrappers are accepted only when both modes expose identical static declarations, including defaults, sensitivity, and backend settings. If inspection reports a mismatch, select the intended canonical command on PATH, point to that installation, or make the declarations agree; a wrapper's filename alone does not identify its runtime.
 
-An unknown wrapper whose static schemas agree remains allowed without a version probe: terragraph cannot prove what it executes from its name or version response. This preserves the wrapper contract without claiming support for runtime-specific behavior outside the inspected declarations.
-
-`version` in a runtime declaration remains documentation only and has no effect on execution; the `.tofu` compatibility check uses the selected binary's actual response. It is there to record what a node is expected to run against, next to the `binary` that actually selects it. (It once fed the incremental-apply cache key. That cache is gone: whether a node needs applying is now decided by asking Terraform for a refreshed plan, every run — see [execution-model.md](execution-model.md#deciding-whether-a-node-needs-applying).)
-
-### How much a node may change without being asked (`approve`)
-
-```hcl
-node "db" {
-  source  = "./stacks/db"
-  approve = "all"
-}
-```
-
-`approve` declares how much of this node's plan may be applied unattended: `none`, `safe` (create/update, the default), or `all` (adds replace and delete). Set it on the specific node whose plan is destructive by design, rather than reaching for `--approve=all`, which grants the same thing to every node in the graph at once and tends to end up pasted into CI.
-
-Like `runtime`, it replaces rather than merges, and a `use` block can set it for every node an instance expands to. Full resolution order and what happens when a plan exceeds its level are in [execution-model.md](execution-model.md#what-a-node-may-do-approve).
-
-A `use` block can also set `runtime`, which becomes the default for every node the group instance expands to (unless one of those nodes names its own): see [groups.md](groups.md#choosing-a-runtime-for-an-instance). A group's own definition has no equivalent: which toolchain deploys a reusable group is a fact about where it's instantiated, not about the group itself.
+Recognized OpenTofu runtimes selecting `.tofu` files must report version 1.8.0 or newer before `plan`, `apply`, or `destroy` can consume inputs. An old, failed, or unparseable version response stops execution. A `--node` run also checks direct upstream nodes whose outputs it may read. Modules selecting only `.tf` files need no probe; unknown wrappers with matching declarations remain allowed without a probe.
 
 ## Extra environment variables per node (`env`)
 
-Different nodes sometimes need to run against different cloud accounts, regions, or roles: the same module deployed once per tenant, each into its own AWS account, say. That's ordinarily expressed through whatever a provider block reads from its environment (`AWS_PROFILE`, `AWS_REGION`, `ARM_SUBSCRIPTION_ID`, and so on), so a node can set `env` to add exactly those, keyed by variable name:
+Use `env` when nodes need different provider accounts, regions, or roles:
 
 ```hcl
 node "prod_vpc" {
@@ -206,35 +182,67 @@ node "prod_vpc" {
 }
 ```
 
-Each entry is added to (and, on a name collision, overrides) the terragraph process's own environment before the node's `terraform`/`tofu` subprocess starts. `TF_DATA_DIR` is reserved: declaring it in any node or `use` `env`, even with an empty value, is a parse error. The restriction ignores case on every platform so the same blueprint remains safe on Windows, where environment variable names are case-insensitive. Remove that entry; terragraph always supplies a separate data directory for each node, replacing any `TF_DATA_DIR` inherited from the host process. This rule also applies to custom runtime binaries and wrappers.
+Entries override the terragraph process's environment for that node's Terraform/OpenTofu subprocesses. An enclosing [`use.env`](groups.md#setting-the-environment-for-an-instance) contributes defaults; the node overrides only the keys it sets. Nested instances merge in the same way, with the nearest declaration winning.
 
-This is deliberately the *only* mechanism terragraph offers for provider environment configuration: it never generates or edits a `provider` block (see [execution-model.md](execution-model.md#how-values-are-passed) for the same "no generated `.tf`" rule applied to values), so a provider that needs something `env` can't express (a literal value baked into the config, say) should instead read it as a variable and take that through an edge or `vars`, the same as any other input.
+`TF_DATA_DIR` is reserved for per-node backend isolation. Declaring it in node or `use` `env` is an error, regardless of case or an empty value. Remove that entry; terragraph supplies its own value, including when the host environment or a custom runtime is used.
 
-Unlike `runtime` (a single choice that replaces whatever it inherits), `env` merges: a `use` block's own `env` (see [groups.md](groups.md#choosing-a-runtime-for-an-instance)) contributes defaults to every node the instance expands to, and a node's own `env` only overrides the specific keys it names, leaving everything else it inherited in place. `env` is part of what a node actually runs against, so changing which account or region it targets changes the plan Terraform produces for it — see [execution-model.md](execution-model.md#deciding-whether-a-node-needs-applying).
+Terragraph never generates provider configuration. If a provider setting needs a module variable instead of an environment variable, supply it through `vars` or an edge.
 
-## Literal input values (`vars`)
+<a id="how-much-a-node-may-change-without-being-asked-approve"></a>
 
-An edge wires one node's real output into another node's input, but not every input is another node's data. Sometimes a value is just this node's own: "this tenant's CIDR is 10.16.0.0/20." A node can set `vars` to supply such values directly, keyed by variable name:
+## Allowed plan changes (`approve`)
+
+Set `approve` to control which resource changes a node may apply:
 
 ```hcl
-node "data-apne2-dev-vpc" {
-  source = "./modules/vpc"
-  backend_config = {
-    path = ".terragraph/state/data-apne2-dev-vpc.tfstate"
-  }
-  vars = {
-    name            = "dpl-apne2-vpc-dev"
-    cidr            = "10.16.0.0/20"
-    private_subnets = ["10.16.0.0/23", "10.16.2.0/23"]
-    tags            = { tenant = "data-platform" }
+node "db" {
+  source  = "./stacks/db"
+  approve = "safe"
+}
+```
+
+| Level | Allowed resource changes |
+|---|---|
+| `none` | No resource mutations |
+| `safe` (default) | Create and update |
+| `all` | Create, update, replace, and delete |
+
+The policy is checked before applying, including in interactive runs. `--auto-approve` skips confirmation prompts; it does not bypass this policy. A plan that exceeds the policy fails before that node applies, and later levels do not run.
+
+`none` can still apply plans containing only output changes or reads, which may write state. Use `terragraph plan` for a preview without apply.
+
+The node's setting wins over the nearest enclosing [`use.approve`](groups.md#setting-an-approval-policy-for-an-instance), then `--approve`, then `safe`. Thus `--approve=all` only changes the fallback for nodes with no declared policy; it cannot override the explicit `safe` above. See [approval behavior](execution-model.md#what-a-node-may-do-approve) for execution details and how this applies to `destroy`.
+
+## Graph remote lock (`lock`)
+
+Add a top-level `lock` block when laptops, CI jobs, or separate clones may run the same graph concurrently. It serializes `plan`, `apply`, and `destroy` across machines while Terraform continues to lock each node's state:
+
+```hcl
+lock {
+  s3 {
+    bucket = "acme-tfstate"
+    key    = "terragraph/prod.lock"
+    region = "ap-northeast-2"
   }
 }
 ```
 
-This is the same mechanism an edge uses to feed a value in: both end up merged into the same engine-managed tfvars file (see [execution-model.md](execution-model.md#how-values-are-passed)) and type-checked against the target variable's declared type the same way, so a `vars` value is exactly as safe as a wired one. An input is a single slot: it's an error for it to be set by more than one source at once, whether that's two data edges targeting the same input (including exact duplicates, and including after group expansion, where two outer edges or an outer edge plus an internal one can converge on the same leaf only once a `use` export has rewritten them) or a data edge and `vars` together. Since a variable's value can itself be any JSON-compatible shape a Terraform variable can hold (string, number, bool, list, or a nested object like `tags` above), a module needing many inputs still only needs one `vars` entry per node, not one edge per variable: give it a single variable typed `object({ ... })`, or several logically-grouped ones, rather than dozens of flat variables, and reuse across many nearly-identical stacks (the same module, one per tenant, differing only in `vars`) stays as small as adding one `node` block each.
+The block itself enables locking. A blueprint may declare one lock, containing one `s3` block; other lock backends are not supported. `bucket`, `key`, and `region` must be non-empty literal strings.
 
-Numbers are passed to tfvars without conversion to floating-point Go values: for example, `9007199254740993` remains that number rather than being rounded to `9007199254740992`. This also applies to numbers inside lists and objects, live upstream outputs, and output snapshots. Previously rounded values cannot be recovered from an existing snapshot; apply the upstream again to publish its current outputs.
+Every node must then use a supported remote backend (`s3`, `gcs`, `azurerm`, `http`, `remote`, or `cloud`); implicit or explicit local state is rejected. Choose a lock object separate from every node's state. Validation checks known S3 addresses and reports collisions or unverified separation; resolve these before sharing the graph across machines. Without the block, local state remains allowed.
 
-`vars` is for literal data, not another node's output: the attribute is evaluated with no variables or functions in scope, so writing `node.other.output.x` inside it fails to parse. That value needs a real edge, which is what actually records the dependency and makes the engine wait for it to exist.
+See [graph remote locking](execution-model.md#graph-remote-lock) for credentials, permissions, contention, and recovering a stale lock, and [backend limitations](execution-model.md#known-limitation) for `apply` support.
 
-See also: [groups.md](groups.md) for bundling several nodes into one reusable unit, [vendoring.md](vendoring.md) for pointing `node.source` at a remote module, and [execution-model.md](execution-model.md#how-values-are-passed) for the optional `tfvars` block controlling where a node's resolved values are written.
+## Output snapshots (`snapshots`)
+
+Add an empty top-level block to retain local output values for fallback when live upstream outputs are unavailable:
+
+```hcl
+snapshots {}
+```
+
+A blueprint may contain one `snapshots` block; it accepts no settings. During `apply`, including a no-change apply, terragraph records outputs consumed by data edges under `.terragraph/outputs/`. Sensitive outputs and outputs without sensitivity metadata are withheld; only their names are recorded. Keep `.terragraph/` out of version control.
+
+Snapshots are a last resort after this run's applied outputs and live `terraform output`. They may be stale and do not replace a refreshed plan or automatically apply upstream nodes. Without the block, snapshots are neither written nor used. See [output snapshots](execution-model.md#output-snapshots) for fallback conditions and refreshing existing snapshots.
+
+For additional checks on values exchanged between modules, see [producer and consumer contracts](contracts.md).

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,155 +1,155 @@
 # Contracts
 
-Contracts turn graph edges into reviewed, two-sided promises: a producer
-declares what one of its outputs guarantees; a consumer declares what one of
-its inputs requires. Contracts are advisory by default: violations surface as
-warnings in `terragraph validate`, and the blueprint's `contracts { mode =
-"enforce" }` block (see [Modes](#modes)) is the only way to make them block;
-it is never enabled silently.
+Contracts help review whether connected modules agree on the values they
+exchange. A producer declares an output's promised type, nullability, or
+sensitivity; a consumer declares what its input expects. They are useful when
+reusing modules or reviewing an interface change before execution.
 
-## Where contracts live
-
-`producer` and `consumer` are ordinary top-level blueprint blocks. They parse
-from any `.hcl` file a blueprint parses: a single-file blueprint, every file
-of a directory blueprint (which merge like every other block kind), and a
-group body — so a group's own `group.hcl` carries the contracts for its
-internal modules, resolved against the group file's own directory. There is
-no reserved filename: `contracts.hcl` is a convention, not a mechanism — a
-file by that name is just another blueprint file whose blocks merge with the
-rest.
+Contracts check **declarations**, not actual output values. Even in `enforce`
+mode, terragraph does not verify that a returned value satisfies a producer's
+type or non-null promise. Runtime input type checks use the module's variable
+declaration, not a narrower consumer contract.
 
 ## Grammar
 
+For modules that expose an output and input named `vpc_id`, add contracts to
+the blueprint alongside their data edge:
+
 ```hcl
+node "vpc" { source = "./modules/vpc" }
+node "app" { source = "./modules/app" }
+
+edge {
+  from = node.vpc.output.vpc_id
+  to   = node.app.input.vpc_id
+}
+
 producer "./modules/vpc" {
   output "vpc_id" {
-    type      = "string"        # Terraform type constraint syntax
-    nullable  = false           # this output is never null
-    sensitive = false           # not a secret
+    type      = "string"
+    nullable  = false  # promises a non-null output
+    sensitive = false
   }
 }
 
 consumer "./modules/app" {
   input "vpc_id" {
     type      = "string"
-    nullable  = false           # this input must never receive null
-    sensitive = false           # refuses values marked sensitive upstream
+    nullable  = false  # requires the producer's non-null promise
+    sensitive = false
   }
 }
 ```
 
-The block label is the module source, spelled exactly as a node's `source`:
-a relative path (`./modules/vpc`, `../shared/vpc`) or a remote module source
-(`github.com/org/repo//modules/vpc`). Absolute paths are rejected at parse
-time.
+The module's input must accept `string`, and its input and output sensitivity
+declarations must agree with the explicit `sensitive = false` claims above.
+See the [contracts example](../examples/contracts) for a complete blueprint
+and modules.
 
-A port carries at most three attributes — `type` (a Terraform type
-constraint, parse-checked where the file and port are known), `nullable`, and
-`sensitive` — and the grammar carries nothing `validate` does not check:
-there is no predicate syntax and no `stability`.
+Each port accepts three optional attributes. `type` is a quoted Terraform
+type constraint, such as `"string"` or `"list(string)"`.
 
-Attribute absence is the *lenient* claim: an omitted `nullable` on a producer
-means "may be null" (a weak promise), an omitted `nullable` on a consumer
-means "accepts null", and an omitted `sensitive` claims nothing. Checks only
-fire on explicit strictness the other side does not meet.
-
-## Keying: one contract per source, not per node
-
-Contracts are keyed by module source, not by node name. A local scope keys by
-the directory it resolves to against the declaring file's directory — the
-same base a node source in that file resolves against. A remote scope keys
-by the declared source string itself, because a remote node's vendored
-directory is per-instance (`vendor/<node-name>`) while the contract belongs
-to the source everything was vendored from. Every node sharing a source
-shares its contract: a group instantiated twice, one module reused through
-`backend_config`, or two vendored instances of the same remote module inherit
-the same contract everywhere they appear. Every actual module copy is checked against that contract, so updating only one vendored instance cannot hide a contradiction behind another copy. Repeated identical findings are grouped and name all affected nodes.
-
-## Facts, and who declares them
-
-Terraform modules already declare most contract facts in their own `variable`
-and `output` blocks. `validate` reconciles every explicit contract claim
-against the module's schema:
-
-| Fact | Declared by the module | Reconciled |
+| Omitted attribute | Producer | Consumer |
 |---|---|---|
-| Consumer `type` | `variable` type constraint | yes — C007 |
-| Consumer `sensitive` | `variable` `sensitive` | yes — C008 |
-| Producer `sensitive` | `output` `sensitive` | yes — C009 |
-| Producer `type` | nothing — a root-module output cannot declare a type | no — the contract's reason to exist |
+| `type` | No type promise | No type requirement |
+| `nullable` | May return null | Accepts null |
+| `sensitive` | No sensitivity claim | Does not declare acceptance of sensitive values |
 
-Producer output type is the one fact no `.tf` file can declare, which is
-exactly why the producer side of a contract exists: the contract is the only
-place that promise can be written down, and the compatibility checks (C003)
-are the only thing that reviews it.
+If the producer contract declares `sensitive = true`, the consumer contract
+must explicitly declare `sensitive = true` too. The corresponding module
+output and variable must also declare that sensitivity.
 
-## Error classes and codes
+## Modes
 
-`terragraph validate` reports three classes. C001/C002/C006 are existence and
-scope: a promise about a port the module never declared, or a scope nothing
-instantiates, is wrong whether or not anything consumes it yet. C003–C005 are
-side-vs-side compatibility, checked for every data edge whose endpoints both
-carry contracts on that port — producer and consumer each keep their word and
-still cannot be wired together. C007–C009 are contract-vs-module
-contradiction: the module's `variable` and `output` blocks are the
-declaration of record, and a contract claiming a different type or
-sensitivity is simply wrong about the module it describes — fix the contract,
-not the wiring. Reconciliation fires only on explicit claims (an absent
-attribute is no claim, and a variable with no type constraint has nothing to
-contradict), in both directions. Uncontracted endpoints check nothing — that
-is the migration path.
+Start by checking the blueprint:
 
-C007 asks whether the module's type could accept the contract's, not whether
-the two are identical. A contract **narrower** than the variable it describes
-is a stricter promise rather than a contradiction:
+```sh
+terragraph validate
+```
+
+The default mode, `warn`, reports contract findings without failing the
+command. Once the declarations agree, make findings block commands by adding
+this top-level block:
 
 ```hcl
-# a vendored module, not yours to edit
-variable "tags" { type = map(any) }
-
-consumer "./vendor/thing" {
-  input "tags" { type = "map(string)" }   # allowed: we only ever pass strings
+contracts {
+  mode = "enforce"
 }
 ```
 
-Requiring equality would have left C007 able to say nothing beyond "restate
-the module's type", and would have made a narrowing promise impossible for
-exactly the modules that cannot be changed. A genuine mismatch — `string`
-against a `number` variable — still fires. The distinction is Terraform's own
-safe conversion: narrowing is safe, `string` to `number` is not.
+`enforce` makes every C001–C009 finding an error for `validate`, `graph`,
+`plan`, `apply`, and `destroy`. Set `mode = "warn"` or remove the mode block
+to return to warnings. There is no per-code severity setting. Invalid syntax
+and conflicting contract declarations remain errors in either mode.
 
-| Code | Severity | Fires when |
-|---|---|---|
-| C001 | warning | producer contract names an output the module does not declare |
-| C002 | warning | consumer contract names an input variable the module does not declare |
-| C003 | warning | producer type is not convertible to the consumer's required type (cty `ConvertibleTo`) |
-| C004 | warning | consumer requires non-null (`nullable = false`) but the producer allows null |
-| C005 | warning | producer is `sensitive = true` but the consumer does not accept sensitive values |
-| C006 | warning | contract scope matches no node in the graph (stale path after a move or rename) |
-| C007 | warning | consumer's claimed `type` is one the module's declared variable type could never accept |
-| C008 | warning | consumer's explicit `sensitive` claim contradicts the module's declared variable sensitivity |
-| C009 | warning | producer's explicit `sensitive` claim contradicts the module's declared output sensitivity |
+## Where contracts live
 
-Every code is a warning under the default mode; the mode block below is the
-one severity dial, and it moves all of them together — there is no per-code
-severity.
+`producer` and `consumer` are top-level blueprint blocks or blocks inside a
+`group` body. In a directory blueprint, they can live in any parsed `.hcl`
+file. `contracts.hcl` is only a naming convention: when loading a single
+blueprint file, sibling files are not loaded automatically.
 
-### Modes
+The label is a module source: a relative path such as `./modules/vpc` or
+`../shared/vpc`, or a remote source such as
+`github.com/org/repo//modules/vpc`. Absolute paths are rejected.
 
-`contracts { mode = "..." }` in the blueprint is reviewed configuration and
-the only severity dial: `warn` (the default when the block is absent) reports
-every C001–C009 as a warning; `enforce` escalates them to errors, which
-blocks `validate`, `plan`, `apply`, and `destroy` the same way structural
-errors already do. An upgrade never selects a stricter mode on its own.
+## Keying: one contract per source, not per node
 
-## Contract identity
+All nodes using the same source share its contract. Local paths resolve
+against the declaring file's directory, including contracts inside a group.
+Remote sources must match the node's declared source string, rather than its
+per-node vendored path. Every actual module copy is checked, including copies
+used by different group instances.
 
-An internal contract digest helper exists for possible future consumers.
-No CLI command reports a contract digest, and execution, approval, and
-output snapshots do not use it.
+There is no per-node override. If a group and its enclosing blueprint declare
+the same source, role, and port, identical claims are shared; different claims
+are an error. Within one blueprint's files, declaring the same source, role,
+and port twice is an error even when the claims agree.
 
-## Deferred
+## Facts, and who declares them
 
-- The evidence layer (`terragraph.lock`, `observe`, `propose`) — removed per review; runtime evidence may return once the declarative layer settles.
-- Predicate syntax (`assert` blocks) — no check evaluates it today.
-- LSP/VS Code support for contract blocks — returns once the grammar settles.
+Contracts check that named ports exist. When both ends of a data edge have
+contracts for those ports, terragraph also compares their type, nullability,
+and sensitivity claims. A port without a contract skips this comparison, so
+contracts can be adopted one connection at a time. Type compatibility is
+checked only when both contracts specify a type; a possible conversion does
+not guarantee that every actual value will convert successfully.
+
+Explicit claims are also checked against the module's declarations:
+
+| Claim | Checked against the module |
+|---|---|
+| Consumer `type` | The variable's type constraint, if declared (C007) |
+| Consumer `sensitive` | The variable's sensitivity, in either direction (C008) |
+| Producer `sensitive` | The output's sensitivity, in either direction (C009) |
+| Producer `type` | Not checked against the output's value |
+| `nullable` | Compared between contracts only, not with module declarations or values |
+
+A consumer contract can be narrower than the module's input type. For example,
+a module variable declared as `map(any)` can have this consumer contract:
+
+```hcl
+consumer "./modules/app" {
+  input "tags" { type = "map(string)" }
+}
+```
+
+C007 accepts that narrowing, but reports `string` against a `number` variable:
+not every string can be converted to a number. The narrower contract documents
+the intended interface; it does not add runtime input validation.
+
+## Error classes and codes
+
+All codes are warnings in `warn` mode and errors in `enforce` mode.
+
+| Code | Reported when |
+|---|---|
+| C001 | Producer contract names an output the module does not declare |
+| C002 | Consumer contract names an input variable the module does not declare |
+| C003 | Producer type cannot be converted to the consumer's required type |
+| C004 | Consumer requires non-null but the producer does not promise `nullable = false` |
+| C005 | Producer declares `sensitive = true` but the consumer does not |
+| C006 | Contract source matches no node in the graph; update the source or remove the contract |
+| C007 | Consumer's claimed type cannot be safely converted to the module variable's declared type |
+| C008 | Consumer's explicit sensitivity differs from the module variable's declaration |
+| C009 | Producer's explicit sensitivity differs from the module output's declaration |

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,270 +1,217 @@
 # Execution model
 
+terragraph runs independent root modules in dependency order. `plan` and `apply` visit upstream nodes first; `destroy` reverses that order. Each module keeps its own state.
+
+## Inspecting the graph
+
+Start with validation and a view of the execution order:
+
+```sh
+terragraph validate
+terragraph graph
+terragraph graph --format dot > graph.dot
+```
+
+The default graph output lists execution levels. DOT output can be rendered with Graphviz; solid edges carry data and dashed edges express ordering only. See [JSON run reports](#json-run-reports) for automation-friendly output.
+
 ## Selecting nodes
 
-`plan`, `apply`, and `destroy` select the whole graph by default. Use `--node <name>` to select exactly one node, including a dotted group node name. This does not automatically select its dependencies or downstream nodes. Positional arguments such as `terragraph apply app` are rejected before loading or locking the graph; use `terragraph apply --node app` instead.
+`plan`, `apply`, and `destroy` select the whole graph by default. Use `--node <name>` to select exactly one leaf, including a dotted name such as `checkout.cluster`. Its dependencies and downstream nodes are **not** selected automatically; a group instance name does not select all its members.
+
+```sh
+terragraph apply --node checkout.cluster
+```
+
+Positional node names such as `terragraph apply checkout.cluster` are not supported.
 
 ## Validation
 
-`terragraph validate` (and `graph`/`plan`/`apply`/`destroy`, which run it first) reports two severities:
-- **Error**: blocks the command (a `from`/`to` referencing a port that doesn't exist, two data edges targeting the same input after group expansion even when they are exact duplicates, a data edge and `vars` both setting the same input, a cycle, `backend_config` set on a module with no `backend` block, two nodes sharing a module directory with identical `backend_config` maps).
-- **Warning**: printed but never blocks. A required variable with no edge feeding it may legitimately come from that module's own `terraform.tfvars` or the environment, outside the blueprint entirely; so may a `.terragraph/state/<name>.tfstate` file left behind by a node that's since been renamed or removed (see below).
+`terragraph validate` checks the blueprint and local module declarations without running Terraform/OpenTofu. `graph`, `plan`, `apply`, and `destroy` perform the same validation first:
 
-Cycle detection reports every independent cyclic cluster in one pass (Tarjan's SCC algorithm), not just the first one found.
+- **Errors** block the command: missing ports, conflicting input sources after group expansion, cycles, or invalid backend configuration. All independent cycles are reported in one pass.
+- **Warnings** allow execution: for example, a required input may come from the module's own tfvars or environment, and state may remain after a node is renamed. [Contract checks](contracts.md) also warn by default; `contracts { mode = "enforce" }` makes contract violations block the command.
 
-Concrete values from both `vars` and data edges are type-checked while resolving a node's inputs for `plan`, `apply`, or `destroy`, not by `terragraph validate`.
+Concrete values from `vars` and data edges are checked against the destination module's variable type when resolving inputs for `plan`, `apply`, or `destroy`. This accepts compatible conversions, optional object attributes and their defaults, and additional object attributes. The original value is still passed unchanged to Terraform/OpenTofu, which performs the final conversion and enforces variable defaults, nullability, and validation blocks. Static validation does not prove that real infrastructure or output values satisfy those declarations.
 
-terragraph decodes each concrete value and uses cty's type conversion and optional attribute defaults to check whether the target variable's declared type can accept it. This accepts `any`, convertible `map(any)` values, optional object attributes with defaults, and additional object attributes. The original input is passed unchanged in the tfvars file: Terraform/OpenTofu performs the final conversion, applies variable defaults and nullability rules, and evaluates variable validation blocks.
+## Known limitation
 
-## How values are passed
+A whole-graph `plan` uses **existing upstream outputs**, not values proposed by upstream plans. If an upstream change would alter an output, a downstream plan still receives the old value. It may therefore differ from the plan shown later during `apply`.
 
-Input validation errors omit value-derived details, including object and map keys, when the destination variable or the inspected upstream output is declared `sensitive`. The error still names the node, input, and declared type so you can check the value against the module's variable declaration. This applies to terragraph's encoding and type-checking errors, including their JSON run reports; it does not redact arbitrary Terraform/OpenTofu subprocess output.
+On a fresh graph, a consumer cannot be planned if a data edge needs an upstream output that is not yet available. Ordering-only edges do not have this restriction. `terragraph apply` handles bootstrap by applying upstream nodes first and passing their real outputs forward in the same run.
 
-terragraph never writes or modifies `.tf` files. Before running a node, it writes the values resolved from its incoming data edges (and its own `vars`, including literals a `use.vars` rewrote onto that node; see [blueprint.md](blueprint.md#literal-input-values-vars)) to an ephemeral, engine-managed tfvars file, then passes it to Terraform explicitly via `-var-file`. Terraform's own `*.auto.tfvars.json` auto-loading is never relied on: two nodes can share a module directory (see `backend_config` in [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), and auto-loading by a fixed filename would let them clobber each other's values.
-
-Where that file is written is controlled by an optional `tfvars` block:
-
-```hcl
-tfvars {
-  location = "workdir"   # default
-}
-```
-
-- **`workdir`** (default): `<blueprint dir>/.terragraph/vars/<node>.tfvars.json`, next to the node's other engine-managed state (`tfdata/`, `plans/`, and for `backend "local"` modules that do not set `path`, `state/<node>.tfstate`). Never touches a module's own directory, so nothing needs adding to any module's `.gitignore`, and two nodes sharing a `source` never collide on a filename. This is the right choice for a vendored module (not yours to add a `.gitignore` entry to) or one reused across many near-identical instances. If a module already declared `backend "local"` and kept `terraform.tfstate` in the module directory, the next `plan`/`apply` points state at `.terragraph/state/<node>.tfstate` instead; migrate with `terraform init -migrate-state` per node if you need the old state. `destroy` still uses the backend last cached in `TF_DATA_DIR` (it does not re-run `init`).
-- **`module`**: `<node source>/.terragraph.<node>.tfvars.json`, alongside the module's own `.tf` files, for a resolved input value that sits next to its source while the node runs. **The file does not survive the run in either location** — it holds resolved inputs in cleartext, so `plan`, `apply` and `destroy` each remove it however the node exits, and it is written owner-only while it exists. That leaves this setting choosing only *where* the file lives during the run, so most projects want the default. Add the pattern below to each module's `.gitignore`:
-
-  ```
-  .terragraph.*.tfvars.json
-  ```
-
-  `terragraph validate` warns (never deletes) about a stale file left behind in a shared module directory by a node that's since been renamed or removed from the blueprint.
-
-  `terragraph validate` likewise warns (never deletes) about a stale `state/<name>.tfstate` under the blueprint's `.terragraph/state/` — where the local backend parks state for nodes that don't set an explicit `path`. Files are matched by the backend path each current node resolves to, so a renamed or removed node's state is flagged for you to rename back, remove, or re-import.
-
-## Execution levels and parallelism
-
-Nodes are grouped into levels: every node in level *i* only depends on nodes in levels `< i`, so nodes within one level have no edge between them and are safe to run concurrently. `terragraph graph` prints these levels directly. Execution defaults to sequential (`--parallelism 1`); pass `--parallelism N` to `plan`/`apply`/`destroy` to run up to `N` nodes within a level concurrently. Output from concurrent nodes is buffered and flushed as one `=== node <name> ===` block per node so it never interleaves; with the default `--parallelism 1` it streams live as before.
-
-## Concurrent CLI processes
-
-`--parallelism` is in-process. Two separate `terragraph` invocations against the same blueprint are a different boundary: they would otherwise share `.terragraph/` (tfvars, `TF_DATA_DIR`, saved plans) and, for nodes that reuse a module `source`, that directory's `.terraform.lock.hcl`.
-
-`plan`, `apply`, `destroy` and `vendor` take an exclusive lock at `<blueprint dir>/.terragraph/lock` before they read or write module files, and hold it until the command exits. A second process targeting the same blueprint prints a one-line wait notice and blocks until the first exits; the lock is released on process exit, so a crash cannot leave it stuck. `validate`, `graph` and `language-server` do not take it, so they stay usable while a long apply is running. One process that already holds the lock can still use `--parallelism` inside the run.
-
-## Interrupting an execution
-
-On Linux and macOS, Ctrl-C or SIGTERM during `plan`, `apply`, or `destroy` cancels a pending local-lock wait and stops dispatching queued and downstream nodes. Each active runtime process group receives an interrupt and has five seconds to finish before terragraph sends SIGKILL. terragraph waits for the direct subprocess and any living members of its group before removing managed tfvars and saved plans and releasing locks. A wrapper exiting first does not shorten that grace period or release the lock while its children still run. The run fails with a cancellation error; JSON reports retain the selected nodes, including `not run` nodes.
-
-Interactive terminal reads stay in terragraph's foreground group so Ctrl-C also cancels the graph. Apply approval reads and terminal input forwarded to destroy stop on cancellation; ordinary files and pipes are passed directly to the runtime. A runtime that exits without reading stdin does not keep the command waiting for input.
-
-This cleanup cannot run if terragraph itself receives SIGKILL or crashes. Descendants that detach into another process group or session are outside its ownership. Process-state inspection failures or a process stuck in an uninterruptible kernel wait can keep terragraph waiting with its locks held, even after SIGKILL. Windows retains native console behavior and is outside this cancellation guarantee. Other commands, including `vendor` and `language-server`, retain their existing signal behavior.
-
-## Graph remote lock
-
-Flock is same-checkout only. Two machines never see `<blueprint dir>/.terragraph/lock`.
-
-An optional top-level `lock` block serializes **the graph run** across machines. Terraform still locks each node's state; this lock is the vpc-then-eks run, because per-node locks do not preserve graph order.
-
-Activation is the block, not a CLI flag. No `lock` block means current behavior (examples, solo local state).
-
-The mechanism is an S3 lock **object** via conditional writes (the same idea as Terraform 1.10+ `use_lockfile`). It is not S3 Object Lock (WORM). terragraph owns the object; it does not borrow a node's Terraform backend. The graph lock must not share an S3 object with a node: same `key` on the same bucket (or when `backend_config.bucket` is omitted and may live only in `.tf`). A matching key on another bucket or a non-s3 backend is fine.
-
-`plan` / `apply` / `destroy` take the local flock, then the graph remote lock, then per-node terraform. `validate` / `graph` / `language-server` do not take the remote lock; `validate` still rejects `lock` plus a local or missing backend.
-
-If the object already exists, the command **fails immediately** (it does not wait the way flock does).
-
-On Linux and macOS, Ctrl-C and SIGTERM during an execution wait for runtime shutdown and attempt to delete the S3 lock object. SIGKILL, crashes, and Windows console termination can leave the object because cleanup does not run (the local flock still drops with the fd). A failed `DeleteObject` after a successful run does the same: the command prints the error to stderr and still reports success. Recover with `terragraph force-unlock --yes`: it deletes the configured lock object. `--yes` is required because releasing is unconditional and could break a lock that is genuinely held; without it the command names the object and, when the object can still be read, who wrote it and when — the one thing you need to decide whether breaking it is safe.
-
-It only parses the blueprint, so it works on a checkout with nothing vendored yet, which is the usual shape of a recovery. It does refuse while another `terragraph` process on the same checkout is running, since that process is the likeliest legitimate holder; it cannot see processes on other machines, which is what `--yes` is for.
-
-IAM on the lock key needs `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject`. Conditional delete uses `If-Match`, which AWS evaluates as a Get; `s3:DeleteObject` alone is not enough.
-
-Every node must use a remote backend (`s3` / `gcs` / `azurerm` / `http` / `remote` / `cloud`). See [blueprint.md](blueprint.md#graph-remote-lock-lock) for the block.
+`terragraph apply` also currently rejects nodes using the `remote` backend or a `cloud` block, because its inspected saved-plan workflow does not support them. Both remote operations and [HCP's local execution mode](https://developer.hashicorp.com/terraform/language/backend/remote) are outside terragraph's current apply support. Use a supported backend such as `s3`, `gcs`, `azurerm`, `http`, or `local`.
 
 ## Deciding whether a node needs applying
 
-Terraform decides, every run. `terragraph apply` plans each node with `-refresh=true -detailed-exitcode`; a plan reporting no changes skips the apply, and nothing local is consulted first.
+Every `terragraph apply` starts each selected node with a fresh plan using `-refresh=true -detailed-exitcode`. A node with no changes skips apply. A changed node's plan is saved, inspected against its approval policy, shown for confirmation when required, and then applied **from that same saved plan**. A downstream node is planned when execution reaches it, using outputs available at that point.
 
-If the plan reports changes, **that same plan is what gets applied** — it is written with `-out` and handed to `apply` — so the node refreshes once rather than twice, and the change that gets made is provably the change that was planned. An argument injected into apply alone (`TF_CLI_ARGS_apply`) can no longer make apply do something the plan never described: Terraform ignores scope arguments when applying a saved plan and rejects `-var` outright. `-refresh=true` is always passed explicitly, and a command-line flag beats the same flag arriving through `TF_CLI_ARGS_plan`, so an ambient `-refresh=false` cannot turn the check into a stale-state one.
+The saved plan lives at `<blueprint dir>/.terragraph/plans/<node>.tfplan` and is removed when the node finishes, including on failure. It contains input values in cleartext. Keep `.terragraph/` out of version control.
 
-The plan file lives at `<blueprint dir>/.terragraph/plans/<node>.tfplan` and is removed when the run ends. Like the tfvars file, it holds resolved input values in cleartext, so the same "keep `.terragraph/` out of version control" rule applies.
+Saved plans are protected with directory mode `0700` and file mode `0600` on Unix, and a protected current-user DACL on Windows. Unsafe parent permissions or ownership are refused; existing plan-directory permissions are tightened where safe. Plan symlinks, and symlinks or Windows reparse points at `.terragraph` or `plans/`, are also refused. Use a private checkout or correct the permissions named in the error; on macOS, an extended ACL may require the suggested `chmod -N` remedy. These checks protect against access by other ordinary users, not administrators or processes running as you.
 
-Before Terraform writes any plan bytes, terragraph restricts `plans/` to its current user and creates an empty protected plan file. On Unix this means directory mode `0700` and file mode `0600`; on Windows both receive a protected DACL granting only the current user access. Existing broad directory permissions are tightened, and a stale regular plan is unlinked before a new file is created exclusively. A plan symlink or other non-regular file is refused instead of being followed. Symlinks and Windows reparse points at `.terragraph` or `plans/` are also refused.
-
-This requires a trusted blueprint checkout: `.terragraph` must not let other ordinary users replace the plan directory. If its ownership or write permissions are unsafe, terragraph refuses and asks for a private checkout or corrected permissions; it does not silently change `.terragraph` permissions. On macOS, an extended ACL on either directory is refused with a `chmod -N` remedy, because such ACLs can grant access despite mode `0700`. Windows ACLs on either directory permitting another ordinary user to replace children or change permissions are likewise refused, since a permission change cannot revoke rights already held by an open Windows handle. New Windows directories and files receive their protected ACL at creation without an inheritance window. This boundary protects against other ordinary users reading plan values, not administrators, a malicious process running as the same user, or replacement of the trusted checkout itself. Filesystem permission or ACL checks must succeed before a saved plan is created.
-
-A node on the `remote` or `cloud` backend cannot produce a local plan file: those backends run the plan on HCP rather than locally. `terragraph apply` refuses that node rather than applying without inspecting the plan. Every backend that runs operations locally — `s3`, `gcs`, `azurerm`, `http`, `local`, ... — can write a plan file and is unaffected. (`s3`/`gcs`/`azurerm`/`http` keep state remote; `local` keeps it on disk.) HCP support is left for later; until then, use one of those backends.
+`--force` is deprecated and has no effect; every apply already checks current state with a refreshed plan.
 
 ## What a node may do: `approve`
 
-Walking the graph and committing changes are two different things. terragraph automates the first — it runs nodes in dependency order and feeds each one's real outputs into the next. The second is a decision, and in a graph it is one nobody can make up front: a downstream node's plan cannot exist until its upstream has actually been applied (see the known limitation below). So it is delegated in advance, per node, in terms of what the plan turns out to contain.
+The `approve` policy limits resource actions before a changed node is applied. It applies to both interactive runs and runs using `--auto-approve`.
 
-That matters here more than it does for a single `terraform apply`, because a change propagates: node A's output changes, node B's input changes with it, and node B may replace its resources. Nobody saw B's plan before the run started, and nobody could have.
+| Policy | Permitted resource changes |
+| --- | --- |
+| `none` | No create, update, replace, or delete |
+| `safe` | Create and update; the default |
+| `all` | Create, update, replace, and delete |
 
-Each node resolves to one of three levels, defined by which of Terraform's planned actions they permit:
+Replacement is treated like deletion. `safe` describes permitted action categories; an in-place update can still affect a running service.
 
-| level | permits | |
-| --- | --- | --- |
-| `none` | — | planned, never applied |
-| `safe` | `create`, `update` | **default** |
-| `all` | `create`, `update`, `replace`, `delete` | |
+**`none` is not a preview mode.** Plans containing only output changes or reads can still be applied and write state. Use `terragraph plan` when you want a preview without apply.
 
-`replace` is gated as tightly as `delete`, because destroy-and-recreate is what an upstream change most often causes downstream and is just as irreversible.
-
-`safe` is a workable default rather than an obstacle. A first-ever bootstrap is all creates; ordinary steady-state work is updates; and **reconciling drift is a create too** — a resource that has vanished remotely is dropped from state by the refresh, so the plan rebuilds it rather than deleting anything. Only a genuinely destructive plan stops.
-
-Say it on the node where a destructive plan is by design:
+Declare a standing policy on a node or [group instance](groups.md):
 
 ```hcl
 node "db" {
   source  = "./stacks/db"
-  approve = "all"   # recreation is normal here
+  approve = "all"
 }
 ```
 
-...or for one run:
+For nodes without a declared policy, choose one for the run:
 
-```
-terragraph apply                    # approve = safe
-terragraph apply --approve=all      # this run, on the operator's judgement
-```
-
-Resolution follows the same layering as [`runtime`](blueprint.md#choosing-a-runtime-per-node-runtime) and [`env`](blueprint.md#extra-environment-variables-per-node-env):
-
-```
-node's own approve  >  enclosing use block  >  --approve  >  safe
+```sh
+terragraph apply --approve all
 ```
 
-...including the rule that a CLI flag only ever fills a gap nothing else spoke to. `--approve=all` does not override a node that declared `approve = "safe"`; a node that declared `approve = "all"` is not reined in by `--approve=none`. The blueprint is where a standing decision lives, and it goes through review.
+Resolution is `node's own approve > enclosing use > --approve > safe`. Nested groups use the nearest declaration. The CLI flag fills an unset policy: `--approve all` cannot override an explicit `approve = "safe"`, and `--approve none` cannot restrict an explicit `approve = "all"`.
 
-When a node's plan exceeds its level, the run stops **before that node is applied**. Levels execute in order, so nothing downstream runs either — the cascade is cut at its source rather than audited afterwards. For a node using the run's default policy:
+When a plan exceeds its policy, that node fails before apply and later execution levels do not run. The error identifies the disallowed actions and the declaration or flag to change. Other nodes in the same level can still finish; see [failure and retry](#failure-and-retry).
 
-```
-node vpc: 3 to add, 1 to change, 0 to destroy
-node eks: 0 to add, 2 to change, 0 to destroy
-node api: 0 to add, 1 to change, 2 to destroy
-error: node "api" plans 2 change(s) its approve level (safe) does not permit:
-  aws_instance.web[0]   delete
-  aws_db_instance.main  replace
-
-Stopped before applying, so no later level ran.
-If this is intended, declare approve = "all" on that node, or re-run with --approve=all.
-```
-
-If a node or enclosing `use` declares its policy, the error instead asks you to set `approve = "all"` on the declaration that sets it. `--approve=all` cannot override that declaration. The policy is checked whether or not anyone is watching; an interactive `yes` only approves a plan already permitted by the resolved policy.
-
-`destroy` is held to the same policy without a plan to read. Teardown is delete-only, so a node that **declared** anything short of `approve = "all"` has already said it must not be torn down, and destroy refuses before anything runs — with or without `--auto-approve`, for the same reason apply's check does not care whether anyone is watching. A node that declared nothing is unaffected: `terragraph destroy` on an ordinary blueprint behaves exactly as it always has, gated by Terraform's own confirmation prompt.
-
-There is deliberately no `--approve` flag on `destroy`. The layering rule is that a run-wide flag only fills a gap nothing else spoke to, so it could never permit a teardown the blueprint refused; changing the node's own `approve` is the only route, and that goes through review.
-
-The check reads the saved plan file, so it cannot run on the `remote`/`cloud` backends, which have none. Apply stops on those nodes with an error rather than applying uninspected.
+`destroy` checks the selected nodes before running any of them. An explicit `approve = "none"` or `"safe"`, including one inherited from `use`, blocks teardown. Nodes without a declared policy are allowed to reach Terraform's own confirmation prompt. `destroy` has no `--approve` flag: change the declaration if teardown is intended. `--auto-approve` does not bypass this policy.
 
 ## Approval
 
-`approve` decides what *may* happen unattended. This decides *whether someone is asked*; the two are independent.
+The `approve` policy controls allowed actions; `--auto-approve` controls confirmation questions.
 
-Without `--auto-approve`, terragraph asks before applying each node that has changes:
+Without `--auto-approve`, terragraph asks before applying each node that has changes and passes its policy:
 
-```
+```text
 Apply these changes to node eks? [y/N]:
 ```
 
-It asks about the plan you were just shown, and applies exactly that plan — a downstream node's plan cannot be produced ahead of time (see the known limitation below), so approval necessarily happens node by node, as the run reaches each one.
+- Only `y` or `yes` approves. A refusal fails that node and prevents later levels from running.
+- Unchanged nodes need no confirmation.
+- Piped input is supported, but each changed node needs an answer. If no input is available, the command fails with a remedy to use `--auto-approve`.
+- Both `--parallelism N` with N greater than 1 and `--output json` require `--auto-approve` for `apply` and `destroy`. `plan` needs no confirmation.
 
-- Only `y` or `yes` approves. Declining stops the run: every later level consumes this node's outputs, so continuing past it would be applying against values that were never produced.
-- A node with **no** changes is never asked about, so `terragraph apply` with no flags remains a usable "is everything still applied?" check with no terminal attached.
-- Input may be piped (`echo yes | terragraph apply`). If a node needs approving and there is nothing to read — a CI runner, `</dev/null` — the run stops and says to pass `--auto-approve`, rather than reporting a refusal nobody made.
-- `--parallelism N` (N > 1) requires `--auto-approve`: output from concurrent nodes is buffered and flushed a node at a time, so there is nowhere to put a prompt.
+For `destroy`, the confirmation comes from Terraform/OpenTofu itself. It does not use a terragraph saved plan and does not rerun `init`; it uses the backend configuration already cached in the node's `TF_DATA_DIR`.
 
-`terragraph destroy` is confirmed the same way, except the question comes from Terraform itself: there is no saved plan for terragraph to ask about on its behalf.
+## Execution levels and parallelism
 
-### JSON run reports
+Nodes in the same execution level have no dependency edge between them. The default `--parallelism 1` runs them sequentially and streams output live. `--parallelism N` runs up to N nodes in a level concurrently, buffering output into a separate `=== node <name> ===` block per node. terragraph completes a level before starting the next one.
 
-`terragraph plan`, `apply`, and `destroy` accept `--output json`. Stdout carries a JSON run report, and Terraform's own output and terragraph's progress messages move to stderr alongside diagnostics. The report lists each selected node's name, execution level, and status (`planned`, `applied`, `unchanged`, `destroyed`, `failed`, or `not run`), with an error message for a failed node. Entries are ordered by execution level, then node name; destroy numbers levels in reverse dependency order.
+```sh
+terragraph apply --parallelism 4 --auto-approve
+```
 
-`apply` and `destroy` require `--auto-approve` with `--output json`, even when running sequentially. Stdout is the payload, so a question there would corrupt it. Stderr is diagnostics that an automation consumer is not watching for an interactive question, so moving the prompt there would leave it unanswered. The combination is refused before execution; use text mode for interactive approval, or pass `--auto-approve`. The node's `approve` policy still applies. `plan` needs no approval and can use `--output json` on its own.
+This limit controls concurrent **nodes**; each Terraform/OpenTofu process still manages concurrency within its own module.
 
-A run that fails after starting a node still emits its report and exits non-zero; nodes in unreached levels appear as `not run`. If the command fails before any node runs, for example while parsing or validating the blueprint or acquiring a lock, stdout may be empty. Automation must check the exit status and allow for an absent JSON payload on failure; stderr carries the diagnostic.
+## Failure and retry
 
-### There is no local cache
+An ordinary node failure, policy rejection, or declined confirmation does not cancel its siblings: **the other nodes in that level continue, even with `--parallelism 1`**. No later level starts. Interrupting the command has different behavior, described [below](#interrupting-an-execution).
 
-Earlier versions kept a content-addressed cache at `<blueprint dir>/.terragraph/cache.json`, hashing each node's source files, resolved inputs, runtime and `env` to decide whether it could skip apply. Hashing local files is a proxy for a remote fact, and the gap between the two produced a series of bugs: a backend or inherited `env` change that the key never modelled, remote drift that no local hash could see, and files consumed through `file()`/`templatefile()` that never invalidated anything.
+terragraph does not roll back completed changes. A failed apply may also have changed some resources before failing, or may have succeeded before a subsequent output read failed. Inspect the reported error and current state, fix the cause, and rerun `terragraph apply`. It plans again against current state and skips unchanged nodes. Use `--node` only when you intend to retry that leaf alone; it will not update consumers afterward.
 
-Once every cache *hit* had to be confirmed by a refreshed plan anyway, the only thing the cache still did was send every *miss* straight to apply without one — so a genuinely unchanged node was re-applied on any fresh checkout, any CI runner without a warm `.terragraph/`, and every run after a `destroy`. Removing it puts every node behind the plan, which is both correct and skips more.
+## How values are passed
 
-`--force` existed to bypass that cache. It is accepted and ignored, and will be removed in a later release. `terragraph destroy` no longer has to invalidate anything either.
+terragraph never generates or edits `.tf` files. It resolves incoming data edges and [literal `vars`](blueprint.md#literal-input-values-vars), writes an ephemeral JSON tfvars file, and passes it explicitly with `-var-file`. Each node also has an isolated `TF_DATA_DIR`, including nodes that share the same source directory, so backend initialization is separate for every node.
 
-## Known limitation
+The optional `tfvars` block chooses where resolved values live while the node runs:
 
-Planning a node whose upstream has never been applied is inherently impossible: its output value doesn't exist yet, and each node has its own independent state (there's no shared unknown-value mechanism to borrow, the way a single Terraform run has for values within one plan). `terragraph plan` reports this clearly instead of guessing. `terragraph apply` handles the full bootstrap by applying in topological order and feeding real values forward as they're produced.
+```hcl
+tfvars {
+  location = "workdir" # default
+}
+```
+
+| Location | Temporary file |
+| --- | --- |
+| `workdir` (default) | `<blueprint dir>/.terragraph/vars/<node>.tfvars.json` |
+| `module` | `<node source>/.terragraph.<node>.tfvars.json` |
+
+The default avoids writing tfvars into module directories and works well for shared or vendored sources. With `module`, add `.terragraph.*.tfvars.json` to each module's `.gitignore`. Both locations contain cleartext inputs and are removed when the node finishes, including on failure. Unix files use mode `0600`; Windows tfvars use inherited filesystem permissions, without an explicit owner-only ACL. A crash or forced termination can leave files behind.
+
+terragraph's input encoding and type-checking errors omit value-derived details when the destination variable or inspected upstream output is declared sensitive. They still identify the node, input, and expected type. This also applies to JSON reports, but does not redact arbitrary Terraform/OpenTofu subprocess output.
+
+For a module declaring `backend "local"`, terragraph supplies an absolute state path at `<blueprint dir>/.terragraph/state/<node>.tfstate` unless the node or an enclosing `use` sets `backend_config.path`. A path written only in the module's backend block is overridden. Terraform writes the state there. When adopting terragraph for an existing local state, plan the backend migration per node before applying; pointing at a new empty state can propose recreating existing resources. `destroy` uses the last initialized backend, as described [above](#approval).
+
+`validate` warns about orphaned managed local state and stale module-location tfvars after a node is renamed or removed. It never deletes those files. Recover or migrate the state before removing it.
+
+## Concurrent CLI processes
+
+`plan`, `apply`, `destroy`, and `vendor` hold one exclusive local lock at `<blueprint dir>/.terragraph/lock` for the run. A second process on the same blueprint prints a wait notice and waits for the first to exit. The operating system releases this lock on exit, including a crash.
+
+The lock coordinates processes in the same checkout; it does not limit `--parallelism` within a run or coordinate different machines. `validate`, `graph`, and `language-server` do not acquire it.
+
+## Graph remote lock
+
+An optional [top-level `lock` block](blueprint.md#graph-remote-lock-lock) serializes graph execution across machines. Per-node Terraform state locks still apply, but cannot by themselves protect the order of an entire graph run.
+
+The graph lock is an S3 object created with conditional writes, not S3 Object Lock (WORM). Use a distinct object from every node's state and grant `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on the lock key. Every node must use a remote backend; validation rejects local or missing backends. The `remote`/`cloud` apply limitation still applies.
+
+`plan`, `apply`, and `destroy` acquire the local lock, then the remote lock, then execute nodes. An existing remote lock **fails immediately**, rather than waiting. `validate`, `graph`, and `language-server` do not acquire it; `vendor` uses only the local lock.
+
+A normal exit releases the object. Crashes, forced termination, or a failed S3 deletion can leave it behind. A release error is printed to stderr but does not turn an otherwise successful run into a failure.
+
+To inspect a configured lock, run `terragraph force-unlock` without `--yes`; it refuses deletion and reports the object and, when readable, its holder. After verifying that the holder is no longer running, delete it with:
+
+```sh
+terragraph force-unlock --yes
+```
+
+Deletion is unconditional. The command refuses while another terragraph process holds the same checkout's local lock, but cannot detect a legitimate holder on another machine. It only parses the blueprint, so recovery also works before vendoring.
+
+## Interrupting an execution
+
+On Linux and macOS, Ctrl-C or SIGTERM during `plan`, `apply`, or `destroy` cancels local-lock waits and stops queued and downstream nodes. Active runtime process groups receive an interrupt, then SIGKILL after a five-second grace period. terragraph waits for them to stop before removing managed tfvars and saved plans and releasing locks. JSON reports retain selected nodes, including those `not run`.
+
+Cleanup cannot run if terragraph itself crashes or receives SIGKILL. Descendants that detach into another process group are outside this guarantee; failed process inspection or an uninterruptible kernel wait can delay cleanup with locks held. Windows retains native console behavior and is outside this cancellation guarantee. It also does not cover `vendor` or `language-server`.
+
+## JSON run reports
+
+Use `--output json` for automation. Stdout carries the result; diagnostics, execution progress, and Terraform/OpenTofu output go to stderr.
+
+```sh
+terragraph validate --output json
+terragraph graph --output json
+terragraph vendor --output json
+terragraph plan --output json
+terragraph apply --output json --auto-approve
+terragraph destroy --output json --auto-approve
+```
+
+| Command | JSON result |
+| --- | --- |
+| `validate` | Object with `valid` and `problems`; each problem has `severity` and `message`. Warnings can coexist with `valid: true`. |
+| `graph` | Object with `levels`, an array of arrays of node names. Cannot combine JSON with `--format dot`. |
+| `vendor` | Array of results with `node`, `status` (`vendored`, `skipped`, or `error`), and an optional `error`. |
+| `plan`, `apply`, `destroy` | Object with `nodes`; each entry has `node`, `level`, `status`, and an optional `error`. |
+
+Run statuses are `planned`, `applied`, `unchanged`, `destroyed`, `failed`, or `not run`. Entries are ordered by execution level, then node name; destroy numbers levels in reverse dependency order.
+
+A run that fails after starting a node still emits its report and exits nonzero. A failure before execution, such as parsing, validation, or lock acquisition, may leave stdout empty. Check the exit status and allow for an absent JSON payload on failure. JSON `apply` and `destroy` require `--auto-approve` even when sequential; the `approve` policy still applies.
 
 ## Output snapshots
 
-A blueprint opts in with an empty `snapshots { }` block. Without it, nothing
-is written and input resolution is byte-for-byte what it always was.
+Add `snapshots {}` to opt in to local output snapshots. They can help resolve downstream inputs when an upstream output read fails, for example during teardown. Without the block, terragraph neither writes nor reads snapshots.
 
-With it, `apply` writes `.terragraph/outputs/<node>.json` (gitignored,
-owner-only, deterministic bytes) containing **only the non-sensitive outputs
-that a data edge consumes from that node**. An output is stored only when its
-current module schema includes sensitivity metadata and does not mark it
-`sensitive`, **and** the actual `terraform/tofu output -json` result explicitly
-reports `sensitive: false`. Runtime sensitivity takes precedence over a static
-public declaration. Missing or null runtime sensitivity is treated as unknown,
-so wrappers must preserve that metadata to enable snapshot storage. Both of
-apply's branches write it: a node that just changed and a node that plans clean
-describe the same current reality.
+Input resolution prefers this run's applied outputs, then live `terraform/tofu output`, then a snapshot **only if the live read failed**. A successful live read that lacks a particular output does not trigger fallback. A missing, corrupt, or incompatible snapshot leaves the live-read error intact.
 
-Sensitive outputs and outputs without sensitivity metadata are never stored.
-Only their port names appear in the snapshot's `withheld` list, so a node whose
-consumed outputs are all withheld still gets a file containing those names and
-an empty `outputs` object. A node with no consumed outputs gets no file, and
-reapplying it removes a prior snapshot. A successful opted-in apply rewrites
-older snapshots, removing any previously stored values now marked sensitive.
-Existing files remain on disk until that upstream node is reapplied or the
-files are manually removed; opting out does not clean them up.
+Snapshots can be stale: they do not prove that upstream infrastructure still exists. Values useful for tearing down a consumer may point to nonexistent resources during apply. Restore live outputs when possible.
 
-New snapshots use schema version 2, which records only values that passed both
-checks. Version 1 snapshots did not verify runtime sensitivity: their values
-are treated as withheld, even if the static declaration says public. Restore
-live upstream outputs or run `terragraph apply --node <producer>` to republish
-under the normal approval policy; a no-change apply also regenerates snapshots.
-Reading a legacy file does not modify or delete it. Older terragraph versions
-cannot use version 2 snapshots.
+An opted-in apply writes `.terragraph/outputs/<node>.json`, including for unchanged nodes, with only outputs consumed by data edges. A value is stored only when both the current module schema marks it non-sensitive and the runtime output explicitly reports `sensitive: false`. Missing or null sensitivity metadata is treated as unknown. Sensitive or unknown outputs contribute only their names to a `withheld` list. Wrappers must preserve runtime sensitivity metadata.
 
-A snapshot read also checks the current module schema, so a stored value cannot
-supply an output now declared sensitive or lacking sensitivity metadata. If a
-fallback needs a withheld output, resolution names the producer output and
-consumer input, explains the omission, and asks you to restore live upstream
-outputs or apply the upstream in the same run. Live outputs and this run's
-applied outputs can still carry sensitive values normally. If an output becomes
-non-sensitive, reapply the upstream before expecting it in a snapshot; its old
-withheld entry remains in effect until then.
+Reads check the current module schema again. A now-sensitive output cannot come from a snapshot; live and same-run outputs can still carry sensitive values normally. If a needed value is withheld, restore live upstream outputs or apply the upstream in the same run. Changing an output back to non-sensitive also requires reapplying its producer before a snapshot can supply it.
 
-On the read side a snapshot is a **fallback, never a preference**. Input
-resolution order is: this run's applied outputs, then live `terraform
-output`, then — only if the live read failed — the snapshot, and only when
-the blueprint opted in. The snapshot can never sit ahead of the live read:
-that is the removed incremental-apply cache returning under a new name, and
-it is worst on `destroy`, where a stale value feeding `count`/`for_each`
-changes what gets torn down. A missing, corrupt, or incompatible snapshot
-leaves the original live-read error intact.
+Reapplying a producer rewrites its snapshot, removing values that became sensitive; if it has no consumed outputs, its old snapshot is removed. Opting out does not delete existing files, and old values remain on disk until rewritten or manually removed. Keep `.terragraph/` out of version control. Snapshot files use mode `0600` on Unix; Windows uses inherited filesystem permissions without an explicit owner-only ACL. Snapshots are local to each machine.
 
-The fallback cannot distinguish a temporarily unreadable upstream from a
-permanently destroyed one. Keeping the last applied values can help `destroy`
-resolve the inputs that created downstream resources, but `apply` may use those
-same old values to reference resources that no longer exist. A snapshot does
-not prove that the upstream infrastructure still exists or is current.
+New snapshots use schema version 2. Version 1 values did not verify runtime sensitivity and are treated as withheld. Restore live outputs or run `terragraph apply --node <producer>` to republish under the normal approval policy; a no-change apply also upgrades the snapshot. Reading an old file does not rewrite it. terragraph versions supporting only schema 1 cannot consume schema 2.
 
-Static inspection selects files for the node's resolved runtime. Changing only
-`.tofu` or `.tofu.json` to mark an output sensitive therefore also blocks a prior
-public snapshot on the next run. If an arbitrary runtime wrapper leaves the
-file-selection mode ambiguous and the two modes' declarations differ, graph
-loading fails before a snapshot can be consumed. See [runtime selection](blueprint.md#choosing-a-runtime-per-node-runtime).
-Recognized OpenTofu runtimes selecting these files must also pass an execution-only
-version check (1.8.0 or newer) before any input validation or snapshot read,
-including upstream reads during a node-scoped run. Older OpenTofu modules using
-only `.tf` / `.tf.json` do not need this check. Runtime sensitivity metadata still
-protects publication, and an offline read cannot refresh that metadata.
-
-Snapshots are local and per-machine. They are regenerated by `apply`, so
-there is no freshness gate to maintain and nothing to commit.
+Module inspection and compatibility checks follow the producer's [resolved runtime](blueprint.md#choosing-a-runtime-per-node-runtime), including upstream reads in a node-scoped run. Runtime-specific sensitivity declarations therefore apply to snapshot reads too; offline reads cannot refresh runtime output metadata.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,6 +1,8 @@
 # Groups: reusable sub-blueprints
 
-A combination of nodes that's always used together (e.g. a cluster + its node group) doesn't need to be re-declared node-by-node for every new service. A `group` defines that combination once; `use` instantiates it under a new name:
+Use a group when several modules belong together, such as a cluster and its node group. A `group` defines their nodes, internal edges, and public ports once; a `use` creates an instance under a new name.
+
+This example assumes the cluster module declares `vpc_id` and `cluster_name` inputs and a `cluster_id` output, and the node group module declares a `cluster_id` input. These modules are available in [`examples/group`](../examples/group).
 
 ```hcl
 # groups/eks-service/group.hcl
@@ -14,8 +16,9 @@ group "eks-service" {
   }
 
   export {
-    input  "vpc_id"     { to   = node.cluster.input.vpc_id }
-    output "cluster_id" { from = node.cluster.output.cluster_id }
+    input "vpc_id"       { to = node.cluster.input.vpc_id }
+    input "cluster_name" { to = node.cluster.input.cluster_name }
+    output "cluster_id"  { from = node.cluster.output.cluster_id }
   }
 }
 ```
@@ -23,81 +26,7 @@ group "eks-service" {
 ```hcl
 # blueprint.hcl
 node "vpc" { source = "./modules/vpc" }
-node "dns" { source = "./modules/dns" }
 
-use "eks-service" {
-  as     = "checkout"
-  source = "./groups/eks-service"
-}
-
-edge {
-  from = node.vpc.output.vpc_id
-  to   = use.checkout.input.vpc_id
-}
-
-edge {
-  from = use.checkout.output.cluster_id
-  to   = node.dns.input.cluster_id
-}
-```
-
-This expands purely in memory when the graph is built (no files are generated) into real nodes namespaced under the instance name (`checkout.cluster`, `checkout.nodegroup`), which every command (`plan`, `apply`, `--node`, `graph`) treats exactly like any other node.
-
-The filenames above are examples: `blueprint.hcl` is the CLI's default path, and `group.hcl` is a convention. Other `.hcl` filenames work too.
-
-A few rules fall out of that expansion:
-- **Only `export`-declared ports are visible from outside the instance.** `use.checkout.output.cluster_id` works; `use.checkout.cluster.output.cluster_id` doesn't even parse. This is deliberate: a group is only safely reusable if its author can change internals without an unbounded set of external edges depending on them, the same reason Terraform modules, Go's unexported identifiers, and private class members all work this way. If a consumer needs something not currently exported, the fix is adding it to the group's `export` block, not reaching around it. Plain nodes (not inside a group) have no such restriction.
-- **A data edge into a group's exposed input can fan out** (`to = [node.a.input.x, node.b.input.x]`) because "which internal nodes need this value" is a fact about the group's own design that its author must state; it isn't inferable from graph structure. An exposed output is always a 1:1 passthrough, so it never needs this.
-- **A leaf input still takes at most one source after expansion** (a data edge or `vars`). Fan-out to distinct internal ports is not a collision. Two outer edges, an outer edge plus an internal one, or a `use.vars` key plus a data edge, that rewrite onto the same leaf are a validation Error, including exact duplicates. This is the same one-source-per-input rule as a plain blueprint; see [blueprint.md](blueprint.md#literal-input-values-vars).
-- **A bare, ordering-only edge into or out of a group needs no such declaration**: an edge with `from = node.x` and `to = use.checkout` (no port) expands automatically to every node inside the group with no internal predecessor (its "roots"); the symmetric case on the `from` side expands to every node with no internal successor (its "sinks"). Between two groups, every downstream root waits for every upstream sink, including when both sides have multiple leaves. Unlike fan-out, this is inferable directly from the group's internal graph shape.
-- **An edge into or out of an instance can carry nested `input` blocks** (see [blueprint.md](blueprint.md#several-values-between-the-same-two-nodes-input)), wiring several of the instance's exposed inputs in one block. For example, an edge with `from = node.vpc` and `to = use.checkout` can contain `input "vpc_id" { from = output.vpc_id }`. Each block expands into an ordinary data edge before any of the above applies, so an expanded edge fans out through `export` and collides on a leaf exactly as a separately written one would.
-- **`node`↔`group` and `group`↔`group` edges use identical syntax** to `node`↔`node`. A group instance is indistinguishable from a node both in edge references and in schema: internal nodes are inspected exactly as today (`module.Inspect` against their real `.tf` files), the `export` block is validated against those real schemas, and once valid it's synthesized into the same schema shape a real module has. Groups can nest (a group's own `use` blocks resolve recursively), and a group that directly or transitively uses itself is a validation error.
-
-## Source directories and filenames
-
-`use.source` names a directory, not an individual file. Terragraph reads every `.hcl` file directly inside that directory, non-recursively, then selects the `group` whose label matches the `use` label. In the example above, it looks for `group "eks-service"` anywhere in `./groups/eks-service`. Renaming `group.hcl` to `components.hcl` needs no change to the `use` block; the directory name also need not match the group name.
-
-All files use the same syntax rules. You can define a group in any `.hcl` file, but its nodes, edges, nested uses, and `export` must be inside that group's body to belong to it. A top-level node in another file is not automatically included in the group. A `runtime` declaration goes outside the group body, either in the same file or another `.hcl` file in its source directory. Defining the same `group` name in two files is rejected rather than merging their bodies.
-
-The calling blueprint can also span arbitrary filenames such as `nodes.hcl` and `edges.hcl`; run it with `--blueprint .` to include both. See [files and loading](blueprint.md#files-and-loading) for a complete split example. This directory mode is explicit for the calling blueprint and always used for group sources.
-
-## Choosing a runtime for an instance
-
-A `use` block can set `runtime` (see [blueprint.md](blueprint.md#choosing-a-runtime-per-node-runtime)), which becomes the default for every node this instance expands to, unless one of those nodes names its own:
-
-```hcl
-use "eks-service" {
-  as      = "checkout"
-  source  = "./groups/eks-service"
-  runtime = runtime.tofu   # both "checkout.cluster" and "checkout.nodegroup" run on tofu
-}
-```
-
-This only ever comes from the instantiation site, never from the group definition itself. A group's own source directory can declare and reference its own `runtime` blocks internally (a specific internal node pinned to an exact binary, say), but it cannot mark one `default = true` and have that silently apply to every node it expands to: which toolchain deploys a reusable group is a fact about where it's used, not something the group's author gets to bake in, since that would make the group less reusable every time it's instantiated somewhere with a different toolchain in mind.
-
-## Setting the environment for an instance
-
-A `use` block can likewise set `env` (see [blueprint.md](blueprint.md#extra-environment-variables-per-node-env)), which contributes default environment variables to every node this instance expands to:
-
-```hcl
-use "eks-service" {
-  as     = "checkout"
-  source = "./groups/eks-service"
-  env = {
-    AWS_PROFILE = "prod"
-  }
-}
-```
-
-Unlike `runtime`, this merges rather than replaces: an internal node that sets its own `env` only overrides the specific keys it names, still inheriting anything else the instance's `env` contributed. Nesting works the same way `runtime` does, layer by layer: an inner `use` block's own `env` merges over whatever it inherited from an outer one before passing the result down further.
-
-`TF_DATA_DIR` is reserved for terragraph's per-node backend isolation and cannot appear in any `use` or node `env`, regardless of case. Remove the entry rather than setting it to an empty string; see the [environment rules](blueprint.md#extra-environment-variables-per-node-env).
-
-## Setting literal inputs for an instance
-
-A `use` block can set `vars` (see [blueprint.md](blueprint.md#literal-input-values-vars)) to fill this instance's public inputs with literal values. Keys are **export input names**, not internal `node.input` paths: the group author still decides what is public.
-
-```hcl
 use "eks-service" {
   as     = "checkout"
   source = "./groups/eks-service"
@@ -105,15 +34,77 @@ use "eks-service" {
     cluster_name = "checkout"
   }
 }
+
+edge {
+  from = node.vpc.output.vpc_id
+  to   = use.checkout.input.vpc_id
+}
 ```
 
-That fills the group's exported `cluster_name` input, which maps to `node.cluster.input.cluster_name`. The same no-references, no-functions rule as `node.vars` applies: another node's output still needs an `edge`. After expansion the literal is rewritten onto every leaf the export names, including fan-out, and then the one-source-per-input rule applies: a key that is not an export input is an Error; `use.vars` plus a data edge on the same leaf is an Error; two vars sources on the same leaf (group-body `node.vars` and `use.vars`, or two export inputs targeting the same leaf) is an Error.
+The instance expands in memory into `checkout.cluster` and `checkout.nodegroup`; no configuration files are generated. Commands use these qualified leaf names, for example `terragraph plan --node checkout.cluster`. Selecting that leaf does not select the whole group or its dependencies. A downstream module can consume the public output through `use.checkout.output.cluster_id`.
 
-Unlike `env`, this does not cascade onto every expanded node. Unlike `runtime`, it is not a single replace-on-override choice. It fills the public inputs the group author exported.
+Add another `use "eks-service"` with a different `as` and `vars` to deploy the same combination again. The [complete example](../examples/group) instantiates it as both `checkout` and `payments`.
+
+## Exported ports and edges
+
+Only ports declared in `export` are available to external edges. `use.checkout.output.cluster_id` is valid; `use.checkout.cluster.output.cluster_id` is not. Add an export when consumers need another input or output. Terragraph checks every exported port against the internal module's declarations.
+
+An exported input may supply several internal inputs:
+
+```hcl
+export {
+  input "region" {
+    to = [node.a.input.region, node.b.input.region]
+  }
+}
+```
+
+This fan-out requires both internal nodes to declare that variable. An exported output always forwards one internal output. After expansion, each leaf input still permits only one source: multiple data edges, or a data edge combined with `vars`, are errors even when the repeated values came through different exports.
+
+Ordering-only edges need no exported ports. `from = node.vpc` and `to = use.checkout` makes every root of `checkout` wait for `vpc`; `from = use.checkout` waits for every sink before starting the destination. Between two groups, every downstream root waits for every upstream sink. Roots have no internal predecessors, and sinks have no internal successors.
+
+Edges involving groups also support [nested `input` blocks](blueprint.md#several-values-between-the-same-two-nodes-input). Each block wires a value through the relevant export just like an individual data edge.
+
+Groups can contain nested `use` blocks, and exports can forward nested ports such as `use.inner.output.cluster_id`. A group that directly or indirectly uses itself is rejected.
+
+## Source directories and filenames
+
+`use.source` names a **local directory**, not an individual file or a remote module address. It is resolved from the directory containing the calling blueprint or group definition. Local internal node sources and nested `use` sources are relative to the group's own source directory. Remote sources are supported for the group's nodes through [vendoring](#vendoring-group-nodes).
+
+Terragraph reads every `.hcl` file directly inside the group directory, non-recursively, then selects the `group` whose label matches the `use` label. In the example, it looks for `group "eks-service"` anywhere in `./groups/eks-service`. `group.hcl` is a convention: renaming it to `components.hcl` needs no change to the `use` block, and the directory name need not match the group name.
+
+All files use the same syntax rules. A group's nodes, edges, nested uses, and `export` must be inside its body to belong to it; top-level nodes in neighboring files are not included automatically. A `runtime` declaration belongs outside the group body, in the same file or another `.hcl` file in that directory. Defining the same `group` name in two files is rejected rather than merging their bodies.
+
+The calling blueprint can also span arbitrary filenames such as `nodes.hcl` and `edges.hcl`; run it with `--blueprint .` to include both. See [files and loading](blueprint.md#files-and-loading) for a complete split example. Directory loading is explicit for the calling blueprint and always used for group sources.
+
+## Setting literal inputs for an instance
+
+`use.vars` sets the group's exported inputs. For example, the `cluster_name = "checkout"` above reaches `node.cluster.input.cluster_name` through the declared export. A second instance can supply another name:
+
+```hcl
+use "eks-service" {
+  as     = "payments"
+  source = "./groups/eks-service"
+  vars = {
+    cluster_name = "payments"
+  }
+}
+
+edge {
+  from = node.vpc.output.vpc_id
+  to   = use.payments.input.vpc_id
+}
+```
+
+Keys are **export input names**, not internal node paths. As with [`node.vars`](blueprint.md#literal-input-values-vars), values are literal data with no variable references or functions; another node's output needs an edge.
+
+The value reaches every leaf named by the export, including through nested groups. An unknown export name is an error. A leaf input already set by a data edge, internal `node.vars`, or another `use.vars` is also an error; instance vars do not override existing values. They fill the exported inputs rather than applying to every node automatically.
 
 ## Isolating state for an instance
 
-A `use` block can likewise set `backend_config` (see [blueprint.md](blueprint.md#reusing-the-same-module-across-instances)), which is merged onto every node this instance expands to. A node's own keys win.
+For local state, the group's modules can declare `backend "local" {}`. When no explicit `backend_config.path` is set, terragraph supplies a unique default-workspace path per qualified leaf, such as `.terragraph/state/checkout.cluster.tfstate` and `.terragraph/state/payments.cluster.tfstate`, under the root blueprint directory. See [module reuse](blueprint.md#reusing-the-same-module-across-instances) for explicit paths, workspaces, and migration considerations.
+
+For remote state, `use.backend_config` supplies defaults to every node in the instance:
 
 ```hcl
 use "eks-service" {
@@ -127,10 +118,58 @@ use "eks-service" {
 }
 ```
 
-Use this for instance-wide remote fields (`bucket`, `profile`, `region`). Do not invent a per-leaf remote `key` here (`checkout.cluster` vs `checkout.nodegroup` needs string interpolation; that is a follow-up). For local state, put `backend "local" {}` in the group's modules; the engine fills a unique `path` per qualified leaf (`checkout.cluster` vs `payments.cluster`).
+Each module must declare a compatible backend. An inner `use` overrides inherited keys, and a node's own keys win. Use shared fields such as `bucket`, `profile`, and `region` here, and give each leaf a distinct state address. A single `key` on `use` is inherited by every leaf; terragraph does not interpolate the instance or leaf name into it. When reusing the group, also separate the instances' backend namespaces, for example with different buckets.
 
-See it end to end in [`examples/group`](../examples/group).
+## Choosing a runtime for an instance
 
-Remote node sources inside a local group are fetched by `terragraph vendor` too. Each leaf is stored under the calling blueprint's vendor directory using its full instance name, such as `vendor/prod.vpc/` or `vendor/prod.inner.vpc/`. Use `terragraph vendor --node prod.inner.vpc` to fetch one leaf. Group source directories are not modified. The root blueprint's `vendor.directory` and `vendor.manifest_file` control these copies, and the root manifest uses the same qualified names.
+`use.runtime` selects the default binary for the instance. Declare the referenced runtime in the calling scope:
 
-For compatibility, a pre-existing copy under the group's own vendor directory remains usable when the root qualified copy is absent. Older versions ignored group `vendor.directory` and executed `vendor/<leaf>` within the group source; that existing default-path copy retains priority even when a custom-path copy also exists. The declared custom directory is used only when the previous default-path entry is absent. A normal vendor run leaves that copy alone; `--force` or a recorded source change refreshes into the root vendor directory and leaves the old group copy intact. A legacy flat subdirectory source also refreshes into the package layout described in [vendoring](vendoring.md). Before changing the execution directory, the same local-state checks apply. A broken root copy is an error and never triggers a fallback to different group-local code.
+```hcl
+runtime "tofu" {
+  binary = "tofu"
+}
+
+use "eks-service" {
+  as      = "checkout"
+  source  = "./groups/eks-service"
+  runtime = runtime.tofu
+}
+```
+
+A node's own runtime or a nearer nested `use.runtime` takes precedence. The group's source directory may declare runtimes for its internal nodes and uses, but marking one `default = true` does not make it the instance's default. See [runtime selection](blueprint.md#choosing-a-runtime-per-node-runtime) for the full fallback order and Terraform/OpenTofu compatibility.
+
+## Setting the environment for an instance
+
+`use.env` supplies environment defaults to every node in the instance:
+
+```hcl
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  env = {
+    AWS_PROFILE = "prod"
+  }
+}
+```
+
+Environment maps merge: a nested `use` overrides inherited keys, and each node overrides only the keys it sets. All remaining inherited entries stay in place. `TF_DATA_DIR` is reserved and cannot appear in any node or `use` environment, regardless of case or an empty value. See the [environment rules](blueprint.md#extra-environment-variables-per-node-env).
+
+## Setting an approval policy for an instance
+
+Use `approve` to set a resource-change policy for the instance:
+
+```hcl
+use "eks-service" {
+  as      = "checkout"
+  source  = "./groups/eks-service"
+  approve = "safe"
+}
+```
+
+This allows create and update actions by default for the instance's nodes. A node's own `approve` or a nearer nested `use.approve` takes precedence. The CLI's `--approve` is only a fallback and cannot override a declared policy. `--auto-approve` controls confirmation prompts separately. See [allowed changes and execution behavior](execution-model.md#what-a-node-may-do-approve) for `none`, `safe`, and `all`.
+
+## Vendoring group nodes
+
+`terragraph vendor` fetches remote node sources inside local groups into the calling blueprint's vendor directory under their qualified names, such as `vendor/checkout.vpc/` or `vendor/prod.inner.vpc/`. Run `terragraph vendor --node prod.inner.vpc` to fetch one leaf. Each instance gets its own copy; the group's source directory is not modified.
+
+The root blueprint's `vendor.directory` and `vendor.manifest_file` control these copies and their manifest. Existing group-local copies remain usable when no root qualified copy exists. Refreshes publish into the root vendor directory and check local state before changing execution directories; see [vendoring](vendoring.md) for compatibility and refresh rules.

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -1,21 +1,19 @@
 # VS Code IntelliSense
 
-The Terragraph Blueprint extension gives Terragraph `.hcl` files language-server-backed editing, whatever their filenames. This includes split files such as `nodes.hcl`, `edges.hcl`, and `contracts.hcl`, as well as arbitrarily named files in group source directories. Open them with the **HCL** language mode. Install **Terragraph Blueprint** from the VS Code Marketplace to use these features.
+Install **Terragraph** (`cloudfluent.terragraph-vscode`) from the VS Code Marketplace and open Terragraph `.hcl` files with the **HCL** language mode. Filenames can be anything, including `nodes.hcl`, `edges.hcl`, `contracts.hcl`, and files in group source directories. The extension bundles its language server, so editor features do not require a separate CLI installation.
 
-The extension bundles a compatible language server, so nothing here requires installing the `terragraph` CLI separately.
-
-The editor uses other `.hcl` files in the same directory as context, including unsaved changes in open files. To run a split blueprint through the CLI, use `--blueprint .`: the CLI's default still reads only `blueprint.hcl`. Editor support does not change [which files the CLI loads](blueprint.md#files-and-loading).
+The editor uses other `.hcl` files in the same directory as context, including unsaved changes in open files. To run a split blueprint through the CLI, use `--blueprint .`: the CLI's default still reads only `blueprint.hcl`. See [files and loading](blueprint.md#files-and-loading).
 
 ## Completion
 
-Open the completion list with `Ctrl+Space` (`Control+Space` on macOS).
+Open the completion list with `Ctrl+Space` (`Control+Space` on macOS). Suggestions include:
 
-- Top-level blueprint blocks: `node`, `edge`, `runtime`, `group`, `use`, `vendor`, `tfvars`, `lock`, `snapshots`
-- The attributes each block accepts: a node's `source`, `vars`, `env`, `runtime`, `backend_config`, `approve`; a `use` block's `as`, `source`, `vars`, `env`, `runtime`, `backend_config`, `approve`; and so on
-- A Terraform/OpenTofu module's own input variables and outputs
-- Declared runtime names
+- Top-level blocks: `node`, `edge`, `runtime`, `group`, `use`, `vendor`, `tfvars`, `lock`, `snapshots`
+- Block attributes, such as a node's `source`, `vars`, `env`, `runtime`, `backend_config`, and `approve`
+- Declared node and runtime names, group instance references, and exported group ports
+- Local Terraform/OpenTofu module inputs and outputs, with descriptions and sensitivity; inputs also show type and whether they are required
 
-Inside a node's `vars = {}` only the input variables that module declares are suggested. Inside a `use` block's `vars = {}` only that instance's export input names are suggested. To pass another node's result, use an `edge` rather than `vars`.
+Inside a node's `vars = {}`, suggestions come from that module's inputs. Inside a `use` block's `vars = {}`, they come from the group's exported inputs. To pass another node's result, use an edge:
 
 ```hcl
 edge {
@@ -24,11 +22,7 @@ edge {
 }
 ```
 
-An input suggestion shows its type, whether it's required, whether it's sensitive, and its description. An output shows its name, description, and whether it's sensitive.
-
-Module inspection follows a node's explicit runtime or the root blueprint's default runtime, with Terraform as the editor fallback. A standalone group's unspecified runtime depends on its use site, so inspection only confirms ports when Terraform and OpenTofu expose the same declarations; a default-marked runtime in the group's source directory does not select its runtime. An ambiguous wrapper or unreadable module leaves ports unknown and does not produce missing-port errors. No runtime is executed for editor inspection.
-
-An edge's nested `input` blocks (see [blueprint.md](blueprint.md#several-values-between-the-same-two-nodes-input)) complete the same way: the block label suggests the input variables declared by the edge's `to` node, and `from = output.` suggests the outputs of its `from` node. Neither reference repeats a node name, so both suggestion lists come from that edge's own endpoints.
+An edge's [nested `input` blocks](blueprint.md#several-values-between-the-same-two-nodes-input) also complete against its endpoints: input labels come from the `to` node, and `output.` suggestions come from the `from` node.
 
 ```hcl
 edge {
@@ -43,23 +37,27 @@ edge {
 
 ## Go to definition
 
-`Cmd+Click` (macOS), `Ctrl+Click` (Windows/Linux), or `F12` on `node.vpc` or `runtime.tofu` jumps to its declaration, including nodes and runtimes declared in another `.hcl` file in the same blueprint directory.
+`Cmd+Click` (macOS), `Ctrl+Click` (Windows/Linux), or `F12` on `node.vpc` or `runtime.tofu` jumps to its declaration, including declarations in another `.hcl` file in the same directory.
 
-## Error reporting
+## Error reporting and limits
 
-Mistakes that can be found without evaluating anything are underlined as you type:
+The editor underlines unknown node names, nonexistent module ports, incorrect input/output directions, invalid `vars` keys, and invalid edge `input` mappings as you type. For unknown ports, hovering the error lists the available names.
 
-- A node name that isn't declared
-- A module input or output name that doesn't exist
-- A `from` referencing an input, or a `to` referencing an output
-- A `vars` entry the module has no such input variable for, or a `use.vars` key that is not an export input
-- An edge `input` block whose label isn't an input of the `to` node, or whose `from = output.<attr>` isn't an output of the `from` node
+Module-port completion and name checks require a readable local module. A node with a remote `source` has no module-port completion or name checks, **even after vendoring**; node-name and block completion still work.
 
-Hovering an error lists the input or output names that are available.
+Module inspection follows a node's explicit runtime or the root blueprint's default, with Terraform as the editor fallback. Inside a group definition, a node without an explicit runtime has known module ports only when Terraform and OpenTofu expose the same declarations: its runtime depends on the use site, not a default-marked runtime in the group's source directory. Ambiguous wrappers or unreadable modules leave ports unknown. Editor inspection never executes a runtime.
+
+Contract-specific completion and contract checks for `producer`, `consumer`, and `contracts` blocks are not implemented. A file named `contracts.hcl` receives the same editing support for node/edge content as any other `.hcl` file; its name does not add contract support.
+
+Editor diagnostics cover these editing checks, not the full CLI validation. Use `terragraph validate` to check the blueprint, including vendored modules and contracts. For a split blueprint:
+
+```sh
+terragraph validate --blueprint .
+```
 
 ## Pointing at your own language server
 
-Rarely needed, but to use a binary you're developing or a specific CLI version, set this in your VS Code settings:
+To use a binary you are developing or a specific CLI version, set:
 
 ```json
 {
@@ -67,11 +65,12 @@ Rarely needed, but to use a binary you're developing or a specific CLI version, 
 }
 ```
 
-Clearing the path goes back to the language server bundled with the extension.
+Clearing the path restores the bundled server. A source checkout uses its locally built binary when no bundled server is present.
 
 ## When completion doesn't appear
 
-1. Check the file has a `.hcl` extension and the language mode in the status bar is **HCL**; its basename can be anything.
-2. Reload the window with the `Developer: Reload Window` command.
-3. Under **View: Output**, select the `Terragraph Blueprint` channel and look for a language server startup error.
-4. If you're developing, run `make build` in the repository root and restart the Extension Development Host.
+1. Check that the file has a `.hcl` extension and the status bar language mode is **HCL**; its basename can be anything.
+2. For missing port suggestions, check the source and runtime limits above.
+3. Reload the window with `Developer: Reload Window`.
+4. Under **View: Output**, select the `Terragraph Blueprint` channel and look for a language server startup error.
+5. If you are developing, run `make build` in the repository root and restart the Extension Development Host.

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -1,6 +1,10 @@
 # Vendoring third-party module sources
 
-`node.source` can point at a remote git address instead of a local path, the same rule Terraform's own `module.source` uses: anything not starting with `./` or `../` is remote:
+Vendoring lets you review and commit third-party module code with your blueprint. `terragraph vendor` fetches remote `node.source` addresses into local copies; later runs use those copies. Only Git sources are supported, not Terraform/OpenTofu Registry addresses. Sources starting with `./` or `../` are local; other addresses require vendoring.
+
+## First fetch
+
+Declare the Git source and select a revision with `ref`:
 
 ```hcl
 node "vpc" {
@@ -8,9 +12,14 @@ node "vpc" {
 }
 ```
 
-Nothing fetches it live. `terragraph vendor [--node NAME] [--force]` is a separate, explicit step that downloads it once into `vendor/<name>/`, meant to be **committed**, so a version bump shows the actual `.tf` content change in `git diff`, not just a one-line ref bump the way a live `module { source = "...", version = "..." }` wrapper would. `validate`/`graph`/`plan`/`apply`/`destroy` never fetch anything; an unvendored remote node fails clearly, telling you to run `terragraph vendor` first.
+The fetched module runs directly as an independent root module. It must have the provider and backend configuration needed for that use; terragraph does not generate a wrapper or provider/backend blocks. Supply inputs and environment settings through the [node configuration](blueprint.md).
 
-Each vendored node gets an entry in `vendor.yaml` (also committed):
+```sh
+terragraph vendor
+terragraph validate
+```
+
+This creates `vendor/vpc/` and records its source in `vendor.yaml`:
 
 ```yaml
 modules:
@@ -18,33 +27,70 @@ modules:
     source: git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v5.1.0
 ```
 
-That's deliberately all that's tracked: the `ref` in `source` is already the version pin, so there's no separate resolved-commit/fetched-at/content-hash bookkeeping to keep in sync with it. Instead, `vendor.yaml` is compared against the blueprint's *current* `node.source` on every vendor run: if they differ (a `ref` bump, or any other source change), that node is re-fetched automatically; no `--force` needed, the same way `git pull` notices you're behind without being told which commit to compare against. `--force` is only for re-fetching a node whose `source` *hasn't* changed (e.g. to pick up new commits on a moving branch ref). `.git` is always stripped from the fetch, so it never ends up committed as a nested repo.
+Commit both the fetched sources and the manifest. `.git` metadata is stripped from fetched copies, so they are not nested repositories. To fetch just one node, use `terragraph vendor --node vpc`.
 
-**`exclude` is per node, not project-wide**, because different upstream repos need different files pruned. It's the one field in the manifest entry the tool never computes: it starts empty, and a vendor run only ever reads it (to prune with) and writes it back unchanged. To prune something from one specific vendored module: vendor it once, hand-edit its `exclude` list in `vendor.yaml` (patterns with `/` anchor to the full path; patterns without match the basename at any depth, e.g. `*.md`), then `terragraph vendor --node <name> --force` to re-fetch with it applied.
+`validate`, `graph`, `plan`, `apply`, and `destroy` do not fetch or update `node.source`; a missing copy tells you to run `vendor`. This does not make execution offline: Terraform/OpenTofu `init` can still download providers and remote modules referenced inside the fetched code.
 
-Project-wide layout is configurable via an optional `vendor { }` block:
+An optional top-level block changes the default storage paths:
 
 ```hcl
 vendor {
-  directory     = "vendor"       # default
-  manifest_file = "vendor.yaml"  # default
+  directory     = "vendor"
+  manifest_file = "vendor.yaml"
 }
 ```
 
-Only git sources are supported today; the fetch mechanism is an interface so a Terraform/OpenTofu Registry backend can be added later without changing anything above it.
+See [`examples/vendored`](../examples/vendored) for a runnable walkthrough.
 
-See it end to end in [`examples/vendored`](../examples/vendored).
+## Updating sources
 
-A fetch is prepared and pruned in a temporary directory before replacing the existing vendored copy. A failed fetch leaves the previous copy and manifest intact; a failed first fetch leaves no runnable node directory. Existing manually populated directories without a manifest entry are still left alone unless `--force` is requested.
+Change the node's `source` or `ref`, then run `terragraph vendor` again. A difference from the manifest triggers a fresh fetch without `--force`. Review the source diff and commit it with the updated blueprint and manifest. Changing the blueprint alone does not update the copy used by execution.
 
-For a git source selecting `//modules/app`, the vendor directory retains the **whole repository package** and `.terragraph-source.json` records `modules/app` as its execution directory. This keeps paths such as `../common` inside the original package; terragraph never rewrites `.tf` files. The metadata is engine-managed and committed with the package. An upstream repository containing a root file with this reserved name is rejected. Invalid metadata or a subdirectory escaping the package is an error, not a fallback to another module.
+If the source string is unchanged, existing copies are left alone. Use `terragraph vendor --node vpc --force` to refresh a moving branch ref or reapply exclusions. A refresh replaces the copy rather than merging local edits, so preserve any changes you need first.
 
-If metadata is damaged or its selected directory is missing, `--force` also refuses the copy because its execution directory and state paths cannot be checked safely. First inspect the affected copy and its local backend state paths, including workspace state and backups. Recover or migrate any affected state outside that copy and verify it is safe before removing **only the affected vendored copy**. Then run `terragraph vendor --node <qualified-name>` again. Keep the metadata with its package while recovering state; deleting only the marker would make the tree look like a legacy root-source copy.
+Manually populated copies without a manifest entry are also left alone unless forced, except for the legacy subdirectory upgrade described below.
 
-Older versions stored only the selected subdirectory. The next `terragraph vendor` refreshes these legacy subdirectory copies into the package layout even without `--force`; a failed refresh preserves the old copy. Existing root-source directories, including manually populated ones without a manifest, keep their previous behavior. Until refreshed, an existing flat copy is still read as before. Per-node `exclude` patterns remain relative to the selected module, while `.git` is stripped throughout the retained package. The package-layout metadata is never removed by an exclusion pattern.
+## Excluding files
 
-Before replacing any existing copy or changing its execution directory, vendoring checks its implicit or declared local backend state paths, node `backend_config` overrides, and local workspace state, including backups. Existing state at a relative path or inside the old vendor tree stops the refresh and leaves the tree and manifest unchanged. Move or migrate that state outside the vendor tree and configure a stable absolute backend path before retrying; terragraph does not move state automatically. Because vendoring does not choose an execution runtime, differing Terraform and OpenTofu declarations require review before changing directories. An unknown local backend path also requires review instead of an assumed-safe upgrade. Absolute state paths outside the tree are unaffected. These checks also apply to ordinary root-source `--force` and source/ref changes, and include state elsewhere inside a retained package. Existing copies with no local state can still be refreshed normally.
+After the first fetch, add an `exclude` list to that node's manifest entry, then refresh it:
 
-`vendor` also discovers remote leaves inside local groups without inspecting missing modules. Group leaves use qualified names in the root vendor directory and manifest: `prod.vpc` or `prod.inner.vpc`, selected with `--node prod.inner.vpc`. Each group instance receives its own copy; the group's source directory stays unchanged. Nested groups use the same expansion and cycle rules as graph building.
+```yaml
+modules:
+  - name: vpc
+    source: git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v5.1.0
+    exclude:
+      - "*.md"
+      - "examples"
+```
 
-An existing group-local copy remains the compatibility fallback while no root qualified entry exists. To retain the directory older versions actually executed, `group/vendor/<leaf>` takes priority over a declared custom group directory when both copies exist; the custom directory is used only if the default-path entry is absent. A regular vendor run preserves it, including a manually populated copy without a root manifest entry. Refreshing with `--force`, a recorded source change, or a legacy subdirectory-layout upgrade publishes into the root vendor directory only after the directory-change checks above pass. The old group-local tree is never removed. Once a root entry exists it takes precedence; a broken entry fails clearly rather than executing the legacy fallback.
+```sh
+terragraph vendor --node vpc --force
+```
+
+Exclusions are per node and preserved on later vendor runs. Patterns without `/` match a basename at any depth; patterns with `/` match the full relative path. `**` is not a recursive glob. Exclude only files the module does not need to execute. `.git` is always removed.
+
+## Groups and subdirectories
+
+Remote nodes inside [local groups](groups.md) use qualified names in the root vendor directory and manifest. For example, `prod.inner.vpc` is fetched into `vendor/prod.inner.vpc/` and selected with `--node prod.inner.vpc`. Each instance receives its own copy; the group's source directory stays unchanged.
+
+A source can select a repository subdirectory; replace the example repository below with your own:
+
+```hcl
+node "app" {
+  source = "git::https://github.com/example/modules.git//modules/app?ref=v1.0.0"
+}
+```
+
+The copy retains the whole repository package, while `.terragraph-source.json` identifies the selected execution directory. This preserves relative references such as `../common` without rewriting `.tf` files. Commit this metadata with the package; its filename is reserved and must not already exist at the upstream repository root. Exclusions are relative to the selected module, while `.git` is removed throughout the package. Exclusions cannot remove the package metadata.
+
+Older flat subdirectory copies remain readable, but the next vendor run upgrades them to the package layout, even without `--force`. The state checks below apply before replacing them.
+
+For older group layouts, an existing group-local copy is used until a root qualified copy exists. `group/vendor/<leaf>` takes priority over a custom group vendor directory when both exist. A normal vendor run preserves this fallback; a forced refresh, recorded source change, or subdirectory upgrade publishes a root copy after the state checks pass. The old group-local tree is retained. A present but broken root copy fails rather than falling back.
+
+## Recovering a failed refresh
+
+A failed fetch preserves that node's previous copy and manifest entry. A failed first fetch leaves no runnable copy. Other nodes may still finish and update their entries; a vendor run is not an all-or-nothing operation.
+
+Before replacing an existing copy, vendoring checks local backend state, including `backend_config` overrides, workspace state, and backups. Existing state at a relative path or inside the vendor tree blocks the refresh. Migrate that state outside the tree and configure a stable absolute backend path before retrying; terragraph does not move state. Absolute state paths outside the tree are unaffected. Unknown local backend paths and differing Terraform/OpenTofu declarations also require review. These checks apply to source/ref changes, `--force`, and layout upgrades.
+
+Invalid metadata or a selected directory that is missing or escapes the package is an error. `--force` cannot bypass it. Inspect the affected copy and its state paths, recover or migrate state outside it, and verify that removal is safe. Then remove only that copy and run `terragraph vendor --node <qualified-name>` again. Keep the metadata with the package during recovery; deleting only the marker can make terragraph mistake it for an older root-source copy.


### PR DESCRIPTION
## Summary

The guide mixed usage instructions with design history and claims that did not match execution. I reorganized the seven handwritten docs around configuring and running a graph, corrected the examples, and kept limitations beside the features they affect.

- Add a getting-started path, DOT/JSON usage, complete group inputs, and failure/retry guidance; preserve #86's file-loading and editor filename support.
- Clarify approval precedence, existing-output planning, static contracts, backend paths, vendoring, and editor support. Document current output-only apply behavior under `approve = "none"` and distinguish Windows tfvars/snapshot permissions from saved-plan protection.
- Remove Deferred, contract identity, proposed layouts, and cache history. The guide is about 26% shorter. Runtime code and generated `docs/cli` are unchanged.

Closes #87. The relative backend-path example correction also overlaps the documentation portion of #83.

## Verification

- [x] `make check` passes locally on macOS, including race-enabled Go tests and the actual VS Code Extension Host tests.

```text
env GOCACHE=/private/tmp/terragraph-docs-audit-gocache TERRAGRAPH_VSCODE_EXECUTABLE='/Applications/Visual Studio Code.app/Contents/MacOS/Code' make check

Selected output:
0 issues.
All matched files use Prettier code style!
PASS blueprint.hcl: completion metadata, definition, unsaved diagnostics
PASS group.hcl: completion metadata, definition, unsaved diagnostics
PASS nodes.hcl: completion metadata, definition, unsaved diagnostics
PASS edges.hcl: completion metadata, definition, unsaved diagnostics
PASS contracts.hcl: completion metadata, definition, unsaved diagnostics
PASS components.hcl: completion metadata, definition, unsaved diagnostics
Exit code:   0
```

Additional checks used temporary fixtures assembled from the documented HCL blocks and the repository's example modules: 32 CLI invocations passed, covering group expansion, arbitrary group filenames, split loading, contract warn/enforce behavior, DOT, JSON, and all five example blueprints. Representative commands and output from those fixtures:

```text
# Documented nodes.hcl + edges.hcl with examples/basic/stacks
terragraph graph --blueprint .
level 1: vpc
level 2: eks

# Documented group plus checkout and payments instances
terragraph graph --output json
{"levels":[["vpc"],["checkout.cluster","payments.cluster"],["checkout.nodegroup","payments.nodegroup"]]}
```

A CommonMark-based link check passed all 65 relative links, including inbound links and 35 anchor references. `git diff --check` passed. Temporary validation scripts and fixtures are not included in the PR.

## Checklist

- [x] Documentation examples checked against real module fixtures; no runtime behavior changes requiring new tests.
- [x] Matching handwritten documentation updated; generated CLI reference left unchanged.
