### PR TITLE
feat: load blueprint directories by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install **Terragraph Blueprint** from the VS Code Marketplace to get completion 
 
 ## Quick look
 
-A blueprint is a flat list of `node` and `edge` facts. Save this example as `blueprint.hcl`, the CLI's default path:
+A blueprint is a flat list of `node` and `edge` facts. Save this example as `blueprint.hcl` in your working directory:
 
 ```hcl
 node "vpc" { source = "./stacks/vpc" }
@@ -49,7 +49,7 @@ terragraph apply --parallelism 2 --auto-approve
 
 `terragraph` resolves the graph, runs `terraform`/`tofu` for each node in dependency order, and passes `vpc`'s real `vpc_id` output into `eks`'s input at runtime. See [`examples/basic`](examples/basic) for this exact setup running end to end.
 
-Filenames are flexible: `--blueprint topology.hcl` reads that file alone, while `--blueprint .` merges every `.hcl` file directly in the current directory. Without the flag, only `blueprint.hcl` is read. A group's `group.hcl` filename is also a convention; groups are selected by their block names. See [file loading and a split blueprint example](docs/blueprint.md#files-and-loading) and [group source directories](docs/groups.md#source-directories-and-filenames).
+By default, commands merge the `.hcl` files directly in the current directory, excluding `.terraform.lock.hcl`. Filenames are flexible: `--blueprint topology.hcl` reads that file alone, while `--blueprint path/to/config` selects another directory. To keep the previous single-file behavior, pass `--blueprint blueprint.hcl`; sibling `.hcl` files are now included unless a file is explicitly selected. A group's `group.hcl` filename is also a convention; groups are selected by their block names. See [file loading and a split blueprint example](docs/blueprint.md#files-and-loading) and [group source directories](docs/groups.md#source-directories-and-filenames).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ terragraph apply
 
 For a new graph, `apply` can create upstream resources and pass their outputs to downstream nodes in the same run. `plan` reads existing upstream outputs, so it cannot preview a consumer whose required output is unavailable, or propagate upstream's newly planned values. Read the [planning limitation](execution-model.md#known-limitation) before using a whole-graph plan as a change preview.
 
-For your own modules, start with [nodes, edges, and literal inputs](blueprint.md). If a node uses a remote source, run [vendoring](vendoring.md) before validation or execution. For a blueprint split across files, select its directory with `--blueprint .`; see [files and loading](blueprint.md#files-and-loading).
+For your own modules, start with [nodes, edges, and literal inputs](blueprint.md). If a node uses a remote source, run [vendoring](vendoring.md) before validation or execution. For a blueprint split across files, run commands in its directory or select another directory with `--blueprint <directory>`; see [files and loading](blueprint.md#files-and-loading).
 
 ## Find the next task
 

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -1,6 +1,6 @@
 # Blueprint
 
-A blueprint describes independent Terraform/OpenTofu root modules (`node` blocks) and the connections between them (`edge` blocks). The CLI reads `blueprint.hcl` by default; select another file or a directory with `--blueprint`.
+A blueprint describes independent Terraform/OpenTofu root modules (`node` blocks) and the connections between them (`edge` blocks). The CLI reads the current directory by default, merging its `.hcl` files except `.terraform.lock.hcl`; select a single file or another directory with `--blueprint`.
 
 ```hcl
 node "vpc" {
@@ -79,11 +79,16 @@ Either endpoint may be a group instance, such as `use.checkout`. Its values reso
 
 | Invocation | Files read |
 |---|---|
-| `terragraph graph` | `blueprint.hcl` only |
+| `terragraph graph` | Eligible `.hcl` files directly in the current directory |
 | `terragraph graph --blueprint topology.hcl` | `topology.hcl` only |
-| `terragraph graph --blueprint .` | Every `.hcl` file directly in the current directory, non-recursively |
+| `terragraph graph --blueprint .` | Same as the default |
+| `terragraph graph --blueprint ./config` | Eligible `.hcl` files directly in `./config` |
 
-Single-file loading does not merge neighboring files. For example, adding `contracts.hcl` next to `blueprint.hcl` only includes those contracts when you select the directory. Directory loading includes hidden `.hcl` files too, including `.terraform.lock.hcl`; keep another tool's HCL configuration in its own directory. `.tf`, `.HCL`, and `.hcl.json` files are not collected by directory loading.
+Directory loading is non-recursive and excludes `.terraform.lock.hcl`. Other hidden `.hcl` files are included; keep another tool's HCL configuration in its own directory. `.tf`, `.HCL`, and `.hcl.json` files are not collected. Subdirectories are visited only through module and group source references.
+
+All configuration-loading commands use this default: `validate`, `graph`, `plan`, `apply`, `destroy`, `output`, `status`, `vendor`, and `force-unlock`. A selected directory with no eligible configuration files is an error, including one containing only Terraform files or `.terraform.lock.hcl`. An empty configuration file or a file containing only group definitions remains valid; having no executable nodes is distinct from having no configuration files.
+
+Previously, commands without `--blueprint` read only `blueprint.hcl`. They now also include sibling files such as `contracts.hcl`, which may add nodes, settings, or duplicate declarations. Pass `--blueprint blueprint.hcl` to retain single-file loading. Explicit file selection reads exactly that file, without applying the directory filename filter.
 
 You can split a blueprint without creating either `blueprint.hcl` or `group.hcl`. In a new directory, copy the `stacks` directory from [`examples/basic`](../examples/basic) and create these two files:
 
@@ -102,7 +107,7 @@ edge {
 ```
 
 ```sh
-terragraph graph --blueprint .
+terragraph graph
 # level 1: vpc
 # level 2: eks
 ```

--- a/docs/cli/terragraph.md
+++ b/docs/cli/terragraph.md
@@ -5,7 +5,7 @@ Graph-based orchestration for independent Terraform/OpenTofu root modules
 ### Options
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
   -h, --help               help for terragraph
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform

--- a/docs/cli/terragraph_apply.md
+++ b/docs/cli/terragraph_apply.md
@@ -20,7 +20,7 @@ terragraph apply [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -19,7 +19,7 @@ terragraph destroy [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_force-unlock.md
+++ b/docs/cli/terragraph_force-unlock.md
@@ -16,7 +16,7 @@ terragraph force-unlock [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_graph.md
+++ b/docs/cli/terragraph_graph.md
@@ -17,7 +17,7 @@ terragraph graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_language-server.md
+++ b/docs/cli/terragraph_language-server.md
@@ -15,7 +15,7 @@ terragraph language-server [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_output.md
+++ b/docs/cli/terragraph_output.md
@@ -19,7 +19,7 @@ terragraph output [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_plan.md
+++ b/docs/cli/terragraph_plan.md
@@ -19,7 +19,7 @@ terragraph plan [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_status.md
+++ b/docs/cli/terragraph_status.md
@@ -17,7 +17,7 @@ terragraph status [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_validate.md
+++ b/docs/cli/terragraph_validate.md
@@ -16,7 +16,7 @@ terragraph validate [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/cli/terragraph_vendor.md
+++ b/docs/cli/terragraph_vendor.md
@@ -18,7 +18,7 @@ terragraph vendor [flags]
 ### Options inherited from parent commands
 
 ```
-      --blueprint string   path to the blueprint file, or a directory whose .hcl files are merged into one blueprint (default "blueprint.hcl")
+      --blueprint string   path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl (default ".")
       --log-level string   log verbosity for internal diagnostics on stderr: debug, info, warn, or error (default "warn")
       --tofu               use the tofu binary instead of terraform
 ```

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -71,11 +71,11 @@ Groups can contain nested `use` blocks, and exports can forward nested ports suc
 
 `use.source` names a **local directory**, not an individual file or a remote module address. It is resolved from the directory containing the calling blueprint or group definition. Local internal node sources and nested `use` sources are relative to the group's own source directory. Remote sources are supported for the group's nodes through [vendoring](#vendoring-group-nodes).
 
-Terragraph reads every `.hcl` file directly inside the group directory, non-recursively, then selects the `group` whose label matches the `use` label. In the example, it looks for `group "eks-service"` anywhere in `./groups/eks-service`. `group.hcl` is a convention: renaming it to `components.hcl` needs no change to the `use` block, and the directory name need not match the group name.
+Terragraph reads `.hcl` files directly inside the group directory, excluding `.terraform.lock.hcl` and without recursion, then selects the `group` whose label matches the `use` label. In the example, it looks for `group "eks-service"` anywhere in `./groups/eks-service`. `group.hcl` is a convention: renaming it to `components.hcl` needs no change to the `use` block, and the directory name need not match the group name.
 
 All files use the same syntax rules. A group's nodes, edges, nested uses, and `export` must be inside its body to belong to it; top-level nodes in neighboring files are not included automatically. A `runtime` declaration belongs outside the group body, in the same file or another `.hcl` file in that directory. Defining the same `group` name in two files is rejected rather than merging their bodies.
 
-The calling blueprint can also span arbitrary filenames such as `nodes.hcl` and `edges.hcl`; run it with `--blueprint .` to include both. See [files and loading](blueprint.md#files-and-loading) for a complete split example. Directory loading is explicit for the calling blueprint and always used for group sources.
+The calling blueprint can also span arbitrary filenames such as `nodes.hcl` and `edges.hcl`; commands include both by default when run in that directory. See [files and loading](blueprint.md#files-and-loading) for a complete split example. The calling blueprint can select one file with `--blueprint <file>`; group sources always use directory loading with the same filename filter.
 
 ## Setting literal inputs for an instance
 

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -2,7 +2,7 @@
 
 Install **Terragraph** (`cloudfluent.terragraph-vscode`) from the VS Code Marketplace and open Terragraph `.hcl` files with the **HCL** language mode. Filenames can be anything, including `nodes.hcl`, `edges.hcl`, `contracts.hcl`, and files in group source directories. The extension bundles its language server, so editor features do not require a separate CLI installation.
 
-The editor uses other `.hcl` files in the same directory as context, including unsaved changes in open files. To run a split blueprint through the CLI, use `--blueprint .`: the CLI's default still reads only `blueprint.hcl`. See [files and loading](blueprint.md#files-and-loading).
+The editor uses other `.hcl` files in the same directory as context, including unsaved changes in open files. Like the CLI's default directory loading, it excludes `.terraform.lock.hcl` from both disk files and unsaved document context. The CLI reads saved files; save your edits before running a split blueprint. See [files and loading](blueprint.md#files-and-loading).
 
 ## Completion
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -2,7 +2,7 @@
 
 This extension starts `terragraph language-server` and supplies completion with port metadata, definition navigation, and diagnostics for Terragraph `.hcl` files opened as HCL. Filenames are flexible: `nodes.hcl`, `edges.hcl`, `contracts.hcl`, and files in group source directories receive the same editing support as the conventional `blueprint.hcl` and `group.hcl` names.
 
-Open-file edits are sent to the server without saving. It also reads neighboring `.hcl` files for context. When running a split blueprint in the CLI, use `--blueprint .`; omitting the flag still loads only `blueprint.hcl`. See [files and loading](../../docs/blueprint.md#files-and-loading).
+Open-file edits are sent to the server without saving. It also reads neighboring `.hcl` files for context, excluding `.terraform.lock.hcl` on disk and in unsaved documents. The CLI defaults to the same directory file selection, using saved files; save your edits before running commands. Use `--blueprint <file>` to read one file explicitly. See [files and loading](../../docs/blueprint.md#files-and-loading).
 
 Marketplace releases contain a matching `terragraph language-server` binary, so no separate CLI installation is required for editor features. Set `terragraph.languageServer.path` only to override that bundled binary.
 

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -156,11 +156,22 @@ func ParseFile(path string) (*Blueprint, error) {
 	return bp, nil
 }
 
-// ParseDir reads and parses every .hcl file directly inside dir (not recursively) and merges them into a single Blueprint, the same way loadGroupDef already treats a group source directory: node/group/use names, the vendor block, and each contract (role, source, port) must be unique across the whole directory, not just within one file, and an edge in one file may reference a node or use instance declared in another. There are no reserved filenames: every .hcl file merges, whatever it is called. Files are visited in the order os.ReadDir returns them (lexical by name), so a duplicate-name error always names the second file, deterministically.
+// IsBlueprintFilename keeps Terraform's provider lock file out of both executable configuration and editor context without excluding user-authored hidden HCL files.
+func IsBlueprintFilename(name string) bool {
+	return strings.HasSuffix(name, ".hcl") && name != ".terraform.lock.hcl"
+}
+
+// ParseDir merges eligible files directly inside dir in lexical order so cross-file references work and duplicate errors identify the same file deterministically; empty group source directories remain valid parse results.
 func ParseDir(dir string) (*Blueprint, error) {
+	bp, _, err := parseDir(dir)
+	return bp, err
+}
+
+// parseDir reports the file count so command inputs can reject missing configuration without rejecting empty files or scanning a directory twice.
+func parseDir(dir string) (*Blueprint, int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("reading blueprint directory: %w", err)
+		return nil, 0, fmt.Errorf("reading blueprint directory: %w", err)
 	}
 
 	bp := &Blueprint{}
@@ -169,33 +180,38 @@ func ParseDir(dir string) (*Blueprint, error) {
 	seenUses := map[string]bool{}
 	seenRuntimes := map[string]bool{}
 	seenContractPorts := map[string]bool{}
+	fileCount := 0
 
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".hcl") {
+		if e.IsDir() || !IsBlueprintFilename(e.Name()) {
 			continue
 		}
 		if err := parseOneFile(filepath.Join(dir, e.Name()), bp, seenNodes, seenGroups, seenUses, seenRuntimes, seenContractPorts); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		fileCount++
 	}
 
 	if err := validateEdges(bp, seenNodes, seenUses); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if err := validateRuntimes(bp); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return bp, nil
+	return bp, fileCount, nil
 }
 
-// LoadPath resolves path to a Blueprint and the base directory its node/group sources resolve against. If path names a directory, every .hcl file directly inside it is parsed and merged (see ParseDir) and baseDir is path itself. If path names a file, only that file is parsed (see ParseFile) and baseDir is its parent directory.
+// LoadPath preserves the source base directory for either input form and rejects directories with no configuration so a command in the wrong directory cannot silently succeed.
 func LoadPath(path string) (*Blueprint, string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, "", fmt.Errorf("resolving blueprint path: %w", err)
 	}
 	if info.IsDir() {
-		bp, err := ParseDir(path)
+		bp, fileCount, err := parseDir(path)
+		if err == nil && fileCount == 0 {
+			err = fmt.Errorf("blueprint directory %q: no configuration files; add a .hcl file or use --blueprint to select a file or directory", path)
+		}
 		return bp, path, err
 	}
 	bp, err := ParseFile(path)

--- a/internal/blueprint/parse_dir_test.go
+++ b/internal/blueprint/parse_dir_test.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -170,5 +171,73 @@ func TestLoadPath_Directory(t *testing.T) {
 	}
 	if baseDir != dir {
 		t.Fatalf("baseDir = %q, want %q", baseDir, dir)
+	}
+}
+
+func TestParseDir_ExcludesTerraformLockButKeepsHiddenConfiguration(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		".terraform.lock.hcl": `provider "registry.terraform.io/hashicorp/null" { version = "3.2.4" }`,
+		".nodes.hcl":          `node "a" { source = "./a" }`,
+	})
+	bp, err := ParseDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bp.Nodes) != 1 || bp.Nodes[0].Name != "a" {
+		t.Fatalf("got = %v, want node a", bp.Nodes)
+	}
+}
+
+func TestParseDir_RejectsOtherToolsHCL(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{"backend.hcl": `bucket = "state"`})
+	if _, err := ParseDir(dir); err == nil || !strings.Contains(err.Error(), "Unsupported argument") {
+		t.Fatalf("got = %v, want unsupported argument", err)
+	}
+}
+
+func TestLoadPath_RejectsDirectoryWithoutConfiguration(t *testing.T) {
+	for _, contents := range []struct {
+		name  string
+		files map[string]string
+	}{
+		{name: "empty"},
+		{name: "terraform_only", files: map[string]string{"main.tf": `output "id" { value = "a" }`}},
+		{name: "lock_only", files: map[string]string{".terraform.lock.hcl": `provider "example" {}`}},
+		{name: "nested_only", files: map[string]string{"nested/nodes.hcl": `node "a" { source = "./a" }`}},
+	} {
+		t.Run(contents.name, func(t *testing.T) {
+			dir := writeDirTemp(t, contents.files)
+			_, _, err := LoadPath(dir)
+			if err == nil || !strings.Contains(err.Error(), "no configuration files") || !strings.Contains(err.Error(), "--blueprint") {
+				t.Fatalf("got = %v, want missing configuration with path remedy", err)
+			}
+		})
+	}
+}
+
+func TestLoadPath_AcceptsConfigurationWithoutExecutableNodes(t *testing.T) {
+	for _, source := range []string{"", `group "empty" {}`} {
+		dir := writeDirTemp(t, map[string]string{"configuration.hcl": source})
+		bp, _, err := LoadPath(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bp.Nodes) != 0 {
+			t.Fatalf("got = %v, want no nodes", bp.Nodes)
+		}
+	}
+}
+
+func TestLoadPath_ExplicitFileIgnoresDirectoryFilter(t *testing.T) {
+	dir := writeDirTemp(t, map[string]string{
+		".terraform.lock.hcl": `node "explicit" { source = "./a" }`,
+		"invalid.hcl":         "not valid hcl {{{",
+	})
+	bp, _, err := LoadPath(filepath.Join(dir, ".terraform.lock.hcl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bp.Nodes) != 1 || bp.Nodes[0].Name != "explicit" {
+		t.Fatalf("got = %v, want explicit file's node", bp.Nodes)
 	}
 }

--- a/internal/cli/blueprint_default_test.go
+++ b/internal/cli/blueprint_default_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGraph_DefaultBlueprintMergesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFixtureFile(t, filepath.Join(dir, "nodes.hcl"), "node \"a\" { source = \"./a\" }\nnode \"b\" { source = \"./b\" }\n")
+	writeFixtureFile(t, filepath.Join(dir, "edges.hcl"), "edge {\n from = node.a.output.id\n to = node.b.input.id\n}\n")
+	writeFixtureFile(t, filepath.Join(dir, "a", "main.tf"), `output "id" { value = "a" }`)
+	writeFixtureFile(t, filepath.Join(dir, "b", "main.tf"), `variable "id" { type = string }`)
+	writeFixtureFile(t, filepath.Join(dir, ".terraform.lock.hcl"), `provider "registry.terraform.io/hashicorp/null" { version = "3.2.4" }`)
+	writeFixtureFile(t, filepath.Join(dir, "unreferenced", "invalid.hcl"), "not valid hcl {{{")
+	stdout, stderr, err := runRootCmd(t, "graph")
+	if err != nil || stderr != "" || stdout != "level 1: a\nlevel 2: b\n" {
+		t.Fatalf("got = %q, %q, %v, want two execution levels", stdout, stderr, err)
+	}
+	explicit, diagnostics, err := runRootCmd(t, "graph", "--blueprint", ".")
+	if err != nil || diagnostics != stderr || explicit != stdout {
+		t.Fatalf("got = %q, %q, %v, want same explicit-directory result", explicit, diagnostics, err)
+	}
+}
+
+func TestGraph_ExplicitBlueprintKeepsSingleFileLoading(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFixtureFile(t, filepath.Join(dir, "blueprint.hcl"), `node "a" { source = "./a" }`)
+	writeFixtureFile(t, filepath.Join(dir, "a", "main.tf"), `output "id" { value = "a" }`)
+	writeFixtureFile(t, filepath.Join(dir, "backend.hcl"), `bucket = "state"`)
+	stdout, stderr, err := runRootCmd(t, "graph", "--blueprint", "blueprint.hcl")
+	if err != nil || stderr != "" || stdout != "level 1: a\n" {
+		t.Fatalf("got = %q, %q, %v, want only node a", stdout, stderr, err)
+	}
+	if _, _, err := runRootCmd(t, "graph"); err == nil || !strings.Contains(err.Error(), "Unsupported argument") {
+		t.Fatalf("got = %v, want sibling HCL error", err)
+	}
+}
+
+func TestRoot_DefaultBlueprintRejectsMissingConfiguration(t *testing.T) {
+	for _, command := range []string{"validate", "graph", "plan", "apply", "destroy", "output", "status", "vendor", "force-unlock"} {
+		t.Run(command, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			stdout, _, err := runRootCmd(t, command)
+			if err == nil || stdout != "" {
+				t.Fatalf("got = %q, %v, want missing configuration failure", stdout, err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, ".terragraph")); !os.IsNotExist(err) {
+				t.Fatalf("got = %v, want failure before creating managed files", err)
+			}
+		})
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -54,7 +54,7 @@ func NewRootCmd(version string) *cobra.Command {
 			return nil
 		},
 	}
-	root.PersistentFlags().StringVar(&blueprintPath, "blueprint", "blueprint.hcl", "path to the blueprint file, or a directory whose .hcl files are merged into one blueprint")
+	root.PersistentFlags().StringVar(&blueprintPath, "blueprint", ".", "path to a blueprint file or a directory whose .hcl files are merged, excluding .terraform.lock.hcl")
 	root.PersistentFlags().BoolVar(&useTofu, "tofu", false, "use the tofu binary instead of terraform")
 	root.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "log verbosity for internal diagnostics on stderr: debug, info, warn, or error")
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12,11 +12,17 @@ import (
 // runCmd executes the terragraph command tree with args and returns stdout, stderr, and any error. It targets examples/group/blueprint.hcl (relative local module sources, no terraform/tofu binary or network access required, since engine.Load only parses .tf files and never shells out).
 func runCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
+	return runRootCmd(t, append([]string{"--blueprint", "../../examples/group/blueprint.hcl"}, args...)...)
+}
+
+// runRootCmd leaves blueprint selection to the caller so default-input tests cannot accidentally exercise an explicit file instead.
+func runRootCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
 	root := NewRootCmd("test")
 	var outBuf, errBuf bytes.Buffer
 	root.SetOut(&outBuf)
 	root.SetErr(&errBuf)
-	root.SetArgs(append([]string{"--blueprint", "../../examples/group/blueprint.hcl"}, args...))
+	root.SetArgs(args)
 	err = root.Execute()
 	return outBuf.String(), errBuf.String(), err
 }
@@ -32,7 +38,7 @@ func writeFixtureFile(t *testing.T, path, contents string) {
 	}
 }
 
-// TestGraph_BlueprintFlagAcceptsDirectory proves --blueprint may name a directory: every .hcl file directly inside it (nodes.hcl, edges.hcl below) is merged into one blueprint, the same way a group source directory already merges its own .hcl files.
+// TestGraph_BlueprintFlagAcceptsDirectory proves explicit directory selection merges eligible sibling files just like the default input and group sources.
 func TestGraph_BlueprintFlagAcceptsDirectory(t *testing.T) {
 	dir := t.TempDir()
 	writeFixtureFile(t, filepath.Join(dir, "nodes.hcl"), `

--- a/internal/engine/directory_test.go
+++ b/internal/engine/directory_test.go
@@ -1,0 +1,168 @@
+package engine
+
+import (
+	"io"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+	"github.com/cloudfluent/terragraph/internal/graph"
+)
+
+func TestLoad_DirectoryBlueprintPreservesNestedGroupDAG(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "environments", "prod")
+	nodes := `node "seed" { source = "../../modules/seed" }
+node "final" { source = "../../modules/join" }
+`
+	uses := `use "pair" {
+ as = "west"
+ source = "../../catalog"
+}
+use "pair" {
+ as = "east"
+ source = "../../catalog"
+}
+`
+	edges := `edge {
+ from = node.seed.output.id
+ to = use.west.input.id
+}
+edge {
+ from = node.seed.output.id
+ to = use.east.input.id
+}
+edge {
+ from = use.west.output.id
+ to = node.final.input.left
+}
+edge {
+ from = use.east.output.id
+ to = node.final.input.right
+}
+`
+	for path, content := range map[string]string{
+		filepath.Join(dir, "nodes.hcl"):                       nodes,
+		filepath.Join(dir, "uses.hcl"):                        uses,
+		filepath.Join(dir, "edges.hcl"):                       edges,
+		filepath.Join(dir, "comparison.txt"):                  nodes + uses + edges,
+		filepath.Join(dir, ".terraform.lock.hcl"):             `provider "example" {}`,
+		filepath.Join(root, "catalog", ".terraform.lock.hcl"): `provider "example" {}`,
+		filepath.Join(root, "catalog", "leaf.hcl"): `group "leaf" {
+ node "worker" { source = "../modules/worker" }
+ export {
+  input "id" { to = node.worker.input.id }
+  output "id" { from = node.worker.output.id }
+ }
+}`,
+		filepath.Join(root, "catalog", "nested", "wrapper.hcl"): `group "wrapper" {
+ use "leaf" {
+  as = "inner"
+  source = ".."
+ }
+ export {
+  input "id" { to = use.inner.input.id }
+  output "id" { from = use.inner.output.id }
+ }
+}`,
+		filepath.Join(root, "catalog", "pair.hcl"): `group "pair" {
+ use "wrapper" {
+  as = "left"
+  source = "./nested"
+ }
+ use "wrapper" {
+  as = "right"
+  source = "./nested"
+ }
+ node "merge" { source = "../modules/join" }
+ edge {
+  from = use.left.output.id
+  to = node.merge.input.left
+ }
+ edge {
+  from = use.right.output.id
+  to = node.merge.input.right
+ }
+ export {
+  input "id" { to = [use.left.input.id, use.right.input.id] }
+  output "id" { from = node.merge.output.id }
+ }
+}`,
+		filepath.Join(root, "modules", "seed", "main.tf"): `output "id" { value = "seed" }`,
+		filepath.Join(root, "modules", "worker", "main.tf"): `terraform {
+ backend "local" {}
+}
+variable "id" { type = string }
+output "id" { value = var.id }`,
+		filepath.Join(root, "modules", "join", "main.tf"): `terraform {
+ backend "local" {}
+}
+variable "left" { type = string }
+variable "right" { type = string }
+output "id" { value = var.left }`,
+	} {
+		if err := osWriteFile(path, []byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e, err := Load(dir, exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if problems := e.Validate(); len(problems) != 0 {
+		t.Fatalf("got = %v, want no validation problems", problems)
+	}
+	single, err := Load(filepath.Join(dir, "comparison.txt"), exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(e.Graph, single.Graph) {
+		t.Fatal("directory and single-file graphs differ")
+	}
+	wantLevels := [][]string{
+		{"seed"},
+		{"east.left.inner.worker", "east.right.inner.worker", "west.left.inner.worker", "west.right.inner.worker"},
+		{"east.merge", "west.merge"},
+		{"final"},
+	}
+	if levels, err := e.Levels(); err != nil || !reflect.DeepEqual(levels, wantLevels) {
+		t.Fatalf("got = %v, %v, want %v", levels, err, wantLevels)
+	}
+	for name, node := range e.Graph.Nodes {
+		module := "join"
+		if name == "seed" {
+			module = "seed"
+		} else if strings.HasSuffix(name, ".worker") {
+			module = "worker"
+		}
+		if want := filepath.Join(root, "modules", module); node.Dir != want {
+			t.Fatalf("%s directory = %q, want %q", name, node.Dir, want)
+		}
+		if name != "seed" {
+			if want := filepath.Join(dir, ".terragraph", "state", name+".tfstate"); node.BackendConfig["path"] != want {
+				t.Fatalf("%s state = %q, want %q", name, node.BackendConfig["path"], want)
+			}
+		}
+		if want := filepath.Join(dir, ".terragraph", "tfdata", name); e.dataDir(name) != want || single.dataDir(name) != want {
+			t.Fatalf("%s data directory = %q, want %q", name, e.dataDir(name), want)
+		}
+	}
+	sources, err := graph.SourceNodes(e.Blueprint, e.BaseDir)
+	if err != nil || len(sources) != len(e.Graph.Nodes) {
+		t.Fatalf("got = %v, %v, want the same vendor leaf set", sources, err)
+	}
+	for _, source := range sources {
+		if e.Graph.Nodes[source.Name] == nil {
+			t.Fatalf("vendor discovered unexpected leaf %q", source.Name)
+		}
+	}
+	vars, err := e.resolveInputs("final", map[string]exec.Outputs{
+		"west.merge": {"id": {Value: "west"}},
+		"east.merge": {"id": {Value: "east"}},
+	})
+	if err != nil || vars["left"] != "west" || vars["right"] != "east" {
+		t.Fatalf("got = %v, %v, want independent group outputs", vars, err)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -140,7 +140,7 @@ func (e *Engine) lockGraph() (func(), error) {
 	}, nil
 }
 
-// Load parses the blueprint at blueprintPath and builds its graph. blueprintPath may name a single file or a directory (every .hcl file directly inside it is merged, see blueprint.LoadPath); node sources are resolved relative to the resulting base directory. It does not take the process lock; use LoadLocked for plan/apply/destroy so graph.Build cannot inspect module files while vendor rewrites them.
+// Load parses the blueprint at blueprintPath and builds its graph. blueprintPath may name a single file or a directory (eligible .hcl files directly inside it are merged, see blueprint.LoadPath); node sources are resolved relative to the resulting base directory. It does not take the process lock; use LoadLocked for plan/apply/destroy so graph.Build cannot inspect module files while vendor rewrites them.
 func Load(blueprintPath string, binary exec.Binary, stdout, stderr io.Writer) (*Engine, error) {
 	e, _, err := load(context.Background(), blueprintPath, binary, stdout, stderr, false)
 	return e, err

--- a/internal/graph/group.go
+++ b/internal/graph/group.go
@@ -35,7 +35,7 @@ func (rc *resolveContext) push(dir, name string) (func(), error) {
 	return func() { rc.stack = rc.stack[:len(rc.stack)-1] }, nil
 }
 
-// parseGroupDir returns dir merged as a Blueprint (every .hcl file directly inside it, see blueprint.ParseDir), parsing it at most once per Build() call regardless of how many `use` blocks reference dir.
+// parseGroupDir returns dir merged as a Blueprint (eligible .hcl files directly inside it, see blueprint.ParseDir), parsing it at most once per Build() call regardless of how many `use` blocks reference dir.
 func (rc *resolveContext) parseGroupDir(dir string) (*blueprint.Blueprint, error) {
 	if bp, ok := rc.groupDirs[dir]; ok {
 		return bp, nil

--- a/internal/language/workspace.go
+++ b/internal/language/workspace.go
@@ -634,9 +634,7 @@ func relativeOutputCompletions(m workspaceModel, text []byte, fragment string, s
 	})
 }
 
-// Definition resolves the node or runtime segment under offset. It searches
-// every .hcl file directly in the same blueprint directory, matching the
-// parser's multi-file blueprint layout.
+// Definition follows directory loading's filename filter so excluded files cannot supply destinations that execution never reads.
 func (w *Workspace) Definition(_ context.Context, path string, offset int) (Location, bool) {
 	path = absolute(path)
 	text := w.document(path)
@@ -886,7 +884,12 @@ func referenceAt(text []byte, offset int) (string, string, bool) {
 }
 
 func (w *Workspace) blueprintFiles(path string) []string {
-	return uniqueSorted(append(w.hclFiles(filepath.Dir(path)), path))
+	files := w.hclFiles(filepath.Dir(path))
+	// Explicitly opened non-HCL filenames retain editor support, just as explicit CLI file selection bypasses directory discovery.
+	if filepath.Ext(path) != ".hcl" || blueprint.IsBlueprintFilename(filepath.Base(path)) {
+		files = append(files, path)
+	}
+	return uniqueSorted(files)
 }
 
 // Open file overlays remain part of their directory even before the first save or after a disk deletion.
@@ -894,13 +897,13 @@ func (w *Workspace) hclFiles(dir string) []string {
 	entries, _ := os.ReadDir(dir)
 	files := []string{}
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".hcl" {
+		if !entry.IsDir() && blueprint.IsBlueprintFilename(entry.Name()) {
 			files = append(files, filepath.Join(dir, entry.Name()))
 		}
 	}
 	w.mu.RLock()
 	for path := range w.documents {
-		if filepath.Dir(path) == dir && filepath.Ext(path) == ".hcl" {
+		if filepath.Dir(path) == dir && blueprint.IsBlueprintFilename(filepath.Base(path)) {
 			files = append(files, path)
 		}
 	}

--- a/internal/language/workspace_overlay_test.go
+++ b/internal/language/workspace_overlay_test.go
@@ -60,3 +60,87 @@ func TestWorkspace_UnsavedSiblingParticipatesInFileScope(t *testing.T) {
 		t.Fatalf("diagnostics = %#v, want none", got)
 	}
 }
+
+func checkLockFileExcludedFromScope(t *testing.T, unsaved bool) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nodes.hcl")
+	lock := filepath.Join(dir, ".terraform.lock.hcl")
+	writeFile(t, filepath.Join(dir, ".visible.hcl"), `node "visible" { source = "./m" }`)
+	ws := NewWorkspace(dir)
+	contents := []byte(`node "ignored" { source = "./m" }`)
+	if unsaved {
+		ws.SetDocument(lock, contents)
+	} else {
+		writeFile(t, lock, string(contents))
+	}
+	text := "edge {\n from = node.ignored\n to = node.visible\n}"
+	ws.SetDocument(path, []byte(text))
+	offset := strings.Index(text, "node.ignored") + len("node.")
+	if got := ws.Complete(context.Background(), path, offset); contains(got, "ignored") || !contains(got, "visible") {
+		t.Fatalf("got = %#v, want visible without ignored", got)
+	}
+	if got, ok := ws.Definition(context.Background(), path, offset+1); ok {
+		t.Fatalf("got = %#v, want no definition from lock file", got)
+	}
+}
+
+func TestWorkspace_LockFileExcludedFromDiskScope(t *testing.T) {
+	checkLockFileExcludedFromScope(t, false)
+}
+
+func TestWorkspace_LockFileExcludedFromUnsavedScope(t *testing.T) {
+	checkLockFileExcludedFromScope(t, true)
+}
+
+func TestWorkspace_ActiveLockFileDoesNotReenterScope(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".terraform.lock.hcl")
+	ws := NewWorkspace(dir)
+	text := "node \"ignored\" { source = \"./m\" }\nedge {\n from = node.\n}"
+	ws.SetDocument(path, []byte(text))
+	offset := strings.LastIndex(text, "node.") + len("node.")
+	if got := ws.Complete(context.Background(), path, offset); contains(got, "ignored") {
+		t.Fatalf("got = %#v, want no node from active lock file", got)
+	}
+}
+
+func TestWorkspace_ExplicitNonHCLDocumentRetainsSymbols(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "topology.config")
+	ws := NewWorkspace(dir)
+	text := "node \"visible\" { source = \"./m\" }\nedge {\n from = node.\n}"
+	ws.SetDocument(path, []byte(text))
+	offset := strings.LastIndex(text, "node.") + len("node.")
+	if got := ws.Complete(context.Background(), path, offset); !contains(got, "visible") {
+		t.Fatalf("got = %#v, want explicit document's node", got)
+	}
+}
+
+func TestWorkspace_GroupSourceExcludesLockFiles(t *testing.T) {
+	for _, unsaved := range []bool{false, true} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "nodes.hcl")
+		group := filepath.Join(dir, "g", "components.hcl")
+		lock := filepath.Join(dir, "g", ".terraform.lock.hcl")
+		definition := `group "g" {
+ export {
+  output "visible" { from = node.a.output.id }
+ }
+}`
+		writeFile(t, group, definition)
+		ws := NewWorkspace(dir)
+		ignored := strings.ReplaceAll(definition, "visible", "ignored")
+		if unsaved {
+			ws.SetDocument(lock, []byte(ignored))
+		} else {
+			writeFile(t, lock, ignored)
+		}
+		text := "use \"g\" {\n as = \"g\"\n source = \"./g\"\n}\nedge {\n from = use.g.output.\n}"
+		ws.SetDocument(path, []byte(text))
+		offset := strings.Index(text, "use.g.output.") + len("use.g.output.")
+		if got := ws.Complete(context.Background(), path, offset); contains(got, "ignored") || !contains(got, "visible") {
+			t.Fatalf("got = %#v, want visible group output without ignored (unsaved=%v)", got, unsaved)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Commands now load the current directory by default, so splitting a blueprint into `nodes.hcl` and `edges.hcl` no longer requires repeating `--blueprint .`.

I reviewed the full diff: the shared loader rejects directories with no configuration before execution, and the CLI, group loader, and editor use the same Terraform lock-file exclusion rule. Explicit file selection and nested-group state isolation remain intact.

- Applies to all nine configuration-loading commands, including `vendor` and `force-unlock`.
- Excludes `.terraform.lock.hcl` from directory discovery and LSP disk/unsaved context; other hidden HCL still participates.
- Documents the compatibility change: sibling HCL is now included by default; use `--blueprint blueprint.hcl` to retain single-file loading.

Closes #96.

## Verification

- [x] `GOCACHE=/tmp/terragraph-audit-go-cache npm_config_cache=/tmp/terragraph-npm-cache make check` passes, including all Go race tests and VS Code integration tests (exit 0).
- Nested group DAG coverage verifies parent-directory references, repeated instances, export fan-out and joins, source paths, state/data-directory isolation, and vendor leaf identities.

Actual CLI reproduction in a directory with `nodes.hcl`, `edges.hcl`, local `a`/`b` modules, and `.terraform.lock.hcl`, but no `blueprint.hcl`:

```text
# Before
$ terragraph graph
error: resolving blueprint path: stat blueprint.hcl: no such file or directory
# exit 1

# After
$ terragraph graph
level 1: a
level 2: b
$ terragraph validate
blueprint is valid
# both exit 0
```

In an empty directory:

```text
# Before
$ terragraph apply --blueprint .
# no output, exit 0

# After
$ terragraph apply
error: blueprint directory ".": no configuration files; add a .hcl file or use --blueprint to select a file or directory
# exit 1
```

No live infrastructure was modified during these reproductions.

## Checklist

- [x] Tests added for the behavior change
- [x] User documentation updated and CLI documentation regenerated
