### PR TITLE
feat: add explicit execution scope selection

### DIFF
--- a/docs/cli/terragraph_apply.md
+++ b/docs/cli/terragraph_apply.md
@@ -9,14 +9,15 @@ terragraph apply [flags]
 ### Options
 
 ```
-      --approve string    what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
-      --auto-approve      skip the interactive approval prompt
-  -h, --help              help for apply
-      --node string       restrict to a single node
-      --output string     output format: text or json (default "text")
-      --parallelism int   max nodes to run concurrently within one execution level (default 1)
-      --plan string       apply the stored frontier of a saved execution without replanning
-      --retain-plan       retain optional plan artifacts while ordinary apply continues
+      --approve string     what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
+      --auto-approve       skip the interactive approval prompt
+      --downstream         include all successors of --node across data and ordering edges
+  -h, --help               help for apply
+      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string      output format: text or json (default "text")
+      --parallelism int    max nodes to run concurrently within one execution level (default 1)
+      --plan string        apply the stored frontier of a saved execution without replanning
+      --retain-plan        retain optional plan artifacts while ordinary apply continues
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -9,11 +9,12 @@ terragraph destroy [flags]
 ### Options
 
 ```
-      --auto-approve      skip interactive approval
-  -h, --help              help for destroy
-      --node string       restrict to a single node
-      --output string     output format: text or json (default "text")
-      --parallelism int   max nodes to run concurrently within one execution level (default 1)
+      --auto-approve       skip interactive approval
+      --downstream         include all successors of --node across data and ordering edges
+  -h, --help               help for destroy
+      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string      output format: text or json (default "text")
+      --parallelism int    max nodes to run concurrently within one execution level (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/terragraph_graph.md
+++ b/docs/cli/terragraph_graph.md
@@ -9,9 +9,11 @@ terragraph graph [flags]
 ### Options
 
 ```
-      --format string   output format: list or dot (default "list")
-  -h, --help            help for graph
-      --output string   output stream encoding: text or json (json is only supported with --format list) (default "text")
+      --downstream         include all successors of --node across data and ordering edges
+      --format string      output format: list or dot (default "list")
+  -h, --help               help for graph
+      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string      output stream encoding: text or json (json is only supported with --format list) (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/terragraph_plan.md
+++ b/docs/cli/terragraph_plan.md
@@ -9,13 +9,14 @@ terragraph plan [flags]
 ### Options
 
 ```
-      --approve string    default policy to assess: none, safe, or all (does not authorize apply) (default "safe")
-      --continue string   create the next frontier after applying this saved execution
-  -h, --help              help for plan
-      --node string       restrict to a single node
-      --output string     output format: text or json (default "text")
-      --parallelism int   max nodes to run concurrently within one execution level (default 1)
-      --save              save only the ready graph frontier for a later apply --plan
+      --approve string     default policy to assess: none, safe, or all (does not authorize apply) (default "safe")
+      --continue string    create the next frontier after applying this saved execution
+      --downstream         include all successors of --node across data and ordering edges
+  -h, --help               help for plan
+      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string      output format: text or json (default "text")
+      --parallelism int    max nodes to run concurrently within one execution level (default 1)
+      --save               save only the ready graph frontier for a later apply --plan
 ```
 
 ### Options inherited from parent commands

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -16,13 +16,60 @@ The default graph output lists execution levels. DOT output can be rendered with
 
 ## Selecting nodes
 
-`plan`, `apply`, and `destroy` select the whole graph by default. Use `--node <name>` to select exactly one leaf, including a dotted name such as `checkout.cluster`. Its dependencies and downstream nodes are **not** selected automatically; a group instance name does not select all its members.
+`graph`, `plan`, `apply`, and `destroy` select the whole graph by default. Repeat `--node <name>` to select exact leaves, including qualified names such as `checkout.cluster`. Add `--downstream` to include every reachable successor across both data edges and ordering-only edges. Multiple starting nodes contribute a union; each leaf runs once.
 
 ```sh
-terragraph apply --node checkout.cluster
+terragraph graph --node checkout.cluster --downstream
+terragraph plan --node checkout.cluster --downstream
+terragraph apply --node checkout.cluster --node payments.cluster --downstream
+terragraph destroy --node checkout.cluster --downstream
 ```
 
-Positional node names such as `terragraph apply checkout.cluster` are not supported.
+A single `--node` without `--downstream` still selects only that leaf. Names are case-sensitive and are neither trimmed nor interpreted as patterns. Empty names, unknown names, group instance names, and `--downstream` without a starting node are errors. `--node b,x` is a literal name, not a comma-separated list; use `--node b --node x`. Positional node names such as `terragraph apply checkout.cluster` are rejected. `--downstream=false` does not expand a selection and preserves whole-graph behavior when no nodes were specified.
+
+Membership is fixed before runtime calls. terragraph filters the original full-graph levels, removes empty levels, and numbers the remaining levels consecutively. It preserves alphabetical order within each level. It does not recompute a more parallel schedule after removing external dependencies. `destroy` uses the same membership with reversed levels. An unchanged upstream never skips a selected downstream node's fresh plan.
+
+Selection limits execution, not validation or coordination: errors anywhere in the blueprint can block the run, and existing local/remote locks and unresolved-execution recovery barriers still apply. Per-node data directories, approval policies, failure handling, and the requirement for `--auto-approve` with concurrent apply/destroy are unchanged. A failure can follow successful changes to other selected nodes; selection provides no atomicity or automatic rollback.
+
+### Dependencies outside the selection
+
+Unselected nodes never receive plan/apply/destroy calls. A selected consumer may read an unselected producer's existing output using the usual input-resolution path, including snapshot fallback only when already opted in and eligible. Runtime compatibility checks may also inspect selected nodes and their direct data producers. Missing outputs fail with the existing remedy; they do not expand selection. Saved planning and saved application retain their stricter requirement for live upstream outputs.
+
+Boundary edges preserve their original direction. Incoming data edges explain existing values a run may need; incoming ordering-only edges do not execute or verify completion of the external predecessor. Outgoing edges identify consumers that remain unselected and will not be updated by this invocation.
+
+### Selection output and compatibility
+
+An explicit `--node` or true `--downstream` adds a scope summary. Text execution commands print it to stdout before the first runtime subprocess, without introducing an approval step. Text graph output shows the summary and forward execution levels; destroy shows reverse execution levels. Early validation or selection errors may have no summary.
+
+`graph` reads configuration only: it does not invoke Terraform/OpenTofu, write execution records, or verify output existence, accessibility, or freshness. A later ordinary command recomputes its selection from the then-current blueprint. Use a [saved execution](executions.md) to retain membership across commands.
+
+JSON remains one result object, with an optional `selection` object alongside the existing `levels` or `nodes`. Plan retains its existing `schema_version` and `diagnostics`. A resolved selection is included even in preparation or execution failures; unresolved selection is omitted. Unselected leaves are never added to `nodes` as unchanged or not run. The selection contains names and relationships only, never output values, variables, or backend credentials.
+
+For `a -> b -> c`, selecting `b` with downstream expansion produces:
+
+```json
+{
+  "levels": [["b"], ["c"]],
+  "selection": {
+    "schema_version": 1,
+    "mode": "downstream",
+    "requested": ["b"],
+    "nodes": [
+      {"node": "b", "reason": "requested", "via": []},
+      {"node": "c", "reason": "downstream", "via": ["b"]}
+    ],
+    "boundary_edges": [
+      {"kind": "data", "from": {"node": "a", "output": "out"}, "to": {"node": "b", "input": "in"}}
+    ]
+  }
+}
+```
+
+`mode` is `exact` or `downstream`. Requested leaves retain `reason: "requested"` even if also reachable from another seed. Other leaves list their selected immediate predecessors in `via`, not every possible path. `requested`, `nodes`, and `via` are sorted by name. Boundary edges sort by source node/port, destination node/port, then kind. Ordering edges use `kind: "ordering"` and omit ports. All array fields are arrays, including empty arrays. Execution order comes from `levels` or each result node's `level`, not selection array order.
+
+Selected DOT output includes selected leaves and adjacent boundary context. External leaves are gray and labeled `not selected`; edges between two external leaves are omitted. Solid/dashed lines still distinguish data/ordering, and the legend and boundary labels distinguish scope. `--output json --format dot` remains invalid.
+
+Without explicit selection, existing output stays unchanged. Single-node membership also stays unchanged, but it now has a text summary and optional JSON selection. Repeated `--node` flags now select a union, replacing the previous implementation's last-value-wins behavior. `output`, `status`, `vendor`, and `run` retain their existing single-node interfaces. This feature does not add group selection, wildcards, upstream expansion, exclusions, or automatic change detection.
 
 ## Validation
 
@@ -117,7 +164,7 @@ This limit controls concurrent **nodes**; each Terraform/OpenTofu process still 
 
 An ordinary node failure, policy rejection, or declined confirmation does not cancel its siblings: **the other nodes in that level continue, even with `--parallelism 1`**. No later level starts. Interrupting the command has different behavior, described [below](#interrupting-an-execution).
 
-terragraph does not roll back completed changes. A failed apply may also have changed some resources before failing, or may have succeeded before a subsequent output read failed. Inspect the reported error and current state, fix the cause, and rerun `terragraph apply`. It plans again against current state and skips unchanged nodes. Use `--node` only when you intend to retry that leaf alone; it will not update consumers afterward.
+terragraph does not roll back completed changes. A failed apply may also have changed some resources before failing, or may have succeeded before a subsequent output read failed. Inspect the reported error and current state, fix the cause, and rerun `terragraph apply`. It plans again against current state and skips unchanged nodes. Use `--node` alone to retry that leaf; add `--downstream` when its reachable consumers should also be selected.
 
 ## How values are passed
 

--- a/docs/executions.md
+++ b/docs/executions.md
@@ -104,7 +104,21 @@ terragraph plan --save --continue <run-id> --output json
 terragraph apply --plan <run-id> --auto-approve
 ```
 
-The first command saves only the ready frontier. A downstream node whose selected predecessor has not completed stays `pending`. Applying consumes that frontier once and stops. If a later peer fails before mutation (for example, approval policy refuses it), already completed peers stay completed and unapplied plans remain available under `waiting_for_apply`. A retry applies only those remaining peers; expired or incompatible plans still require cancellation and a fresh plan. Unknown mutation outcomes keep the recovery barrier and all evidence. `--continue` plans the next frontier using live upstream outputs; snapshots cannot replace those reads. Repeat until the record says `completed`. Use `--node` only when starting an explicitly restricted selection; continuation and saved apply inherit the stored selection. Parallelism is an upper bound; saved frontiers currently execute sequentially, while ordinary apply retains its existing concurrent scheduler.
+The first command saves only the ready frontier. A downstream node whose selected predecessor has not completed stays `pending`. Applying consumes that frontier once and stops. If a later peer fails before mutation (for example, approval policy refuses it), already completed peers stay completed and unapplied plans remain available under `waiting_for_apply`. A retry applies only those remaining peers; expired or incompatible plans still require cancellation and a fresh plan. Unknown mutation outcomes keep the recovery barrier and all evidence. `--continue` plans the next frontier using live upstream outputs; snapshots cannot replace those reads. Repeat until the record says `completed`. Use repeated `--node` and optional `--downstream` only when starting an explicitly restricted selection; continuation and saved apply inherit the stored membership. Parallelism is an upper bound; saved frontiers currently execute sequentially, while ordinary apply retains its existing concurrent scheduler.
+
+To freeze a downstream selection:
+
+```sh
+terragraph plan --save --node checkout.cluster --downstream --output json
+terragraph apply --plan <run-id> --auto-approve
+terragraph plan --save --continue <run-id> --output json
+```
+
+The initial record includes every selected leaf, even though only the ready frontier receives plan artifacts. Optional version-1 selection metadata preserves the original requested leaves, inclusion reasons, and boundary edges, and is exposed in public execution JSON. Ordinary apply/destroy records also retain this metadata; it does not make those runs automatically resumable. No new storage location or infrastructure state cache is introduced.
+
+`apply --plan` and `plan --save --continue` reject any explicitly supplied `--node` or `--downstream`, including empty names and `--downstream=false`, before runtime calls. Runtime preflight for continuation and saved application covers recorded nodes and their required direct data upstreams. It never interprets absent CLI selection flags as permission to inspect or execute every graph node.
+
+Record `nodes` remains authoritative. Metadata cannot widen membership. Old records without selection metadata use their recorded nodes normally and omit public selection; original seeds or downstream intent are never inferred. Unsupported metadata schemas and contradictions with recorded membership are treated as corrupt records and block execution under the existing corrupt-record handling rules. Existing graph binding checks still reject incompatible graph changes: downstream is never traversed again to enroll new nodes. TTL, revision, no-change plan, graph-lock, and recovery rules remain in force.
 
 Saved-plan JSON includes action metadata and the policy assessment without input or output values. Review is not approval: saved apply checks the current approval policy again and asks for confirmation unless `--auto-approve` is set. A saved no-change plan still goes through native application validation, so it cannot silently bypass the runtime's stale-plan checks.
 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -41,7 +41,7 @@ edge {
 }
 ```
 
-The instance expands in memory into `checkout.cluster` and `checkout.nodegroup`; no configuration files are generated. Commands use these qualified leaf names, for example `terragraph plan --node checkout.cluster`. Selecting that leaf does not select the whole group or its dependencies. A downstream module can consume the public output through `use.checkout.output.cluster_id`.
+The instance expands in memory into `checkout.cluster` and `checkout.nodegroup`; no configuration files are generated. Commands use these qualified leaf names, for example `terragraph plan --node checkout.cluster`. Selecting that leaf alone does not select the whole group or its dependencies. For `graph`, `plan`, `apply`, and `destroy`, add `--downstream` to follow all data and ordering edges from the qualified leaf, including successors outside its group. Repeat `--node` to combine exact starting leaves. Group instance names such as `checkout` and wildcard prefixes are rejected with a qualified leaf example; unrelated siblings are not included by their shared prefix. A downstream module can consume the public output through `use.checkout.output.cluster_id`.
 
 Add another `use "eks-service"` with a different `as` and `vars` to deploy the same combination again. The [complete example](../examples/group) instantiates it as both `checkout` and `payments`.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -131,10 +131,14 @@ func checkValidate(cmd *cobra.Command, e *engine.Engine) error {
 	return nil
 }
 
-// finishRun emits a run's JSON report when requested and returns the run's error. The report is printed even for a failed run — per-node outcomes are exactly what an automation consumer needs when things went wrong — but not when nothing ran at all (the run failed before any node, e.g. a lock error), where there is no run to report.
-func finishRun(cmd *cobra.Command, output string, runs []engine.NodeRun, err error) error {
-	if output == "json" && (len(runs) > 0 || err == nil) {
-		if werr := writeJSON(cmd.OutOrStdout(), runResult{Nodes: nodeRunsToDTO(runs)}); werr != nil {
+// finishRun preserves resolved scope on preparation failures without changing the default no-result behavior of unselected runs.
+func finishRun(cmd *cobra.Command, output string, runs []engine.NodeRun, err error, selection ...*selectionDTO) error {
+	var scope *selectionDTO
+	if len(selection) > 0 {
+		scope = selection[0]
+	}
+	if output == "json" && (len(runs) > 0 || err == nil || scope != nil) {
+		if werr := writeJSON(cmd.OutOrStdout(), runResult{Nodes: nodeRunsToDTO(runs), Selection: scope}); werr != nil {
 			return werr
 		}
 	}
@@ -185,10 +189,12 @@ func newValidateCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf
 }
 
 func newGraphCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
+	var selection selectionFlags
 	var format string
 	var output string
 	cmd := &cobra.Command{
 		Use:   "graph",
+		Args:  validateRunArgs,
 		Short: "Print the resolved execution levels or a Graphviz DOT rendering",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output != "text" && output != "json" {
@@ -206,17 +212,27 @@ func newGraphCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 				return err
 			}
 
+			scope, err := graph.Select(e.Graph, selection.nodes, selection.downstream)
+			if err != nil {
+				return err
+			}
+			var names []string
+			if scope != nil {
+				names = scope.Names()
+			}
+			levels, err := graph.SelectedLevels(e.Graph, names, false)
+			if err != nil {
+				return err
+			}
+			dto := selectionToDTO(scope)
 			switch format {
 			case "dot":
-				_, _ = fmt.Fprint(cmd.OutOrStdout(), graph.DOT(e.Graph))
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), graph.SelectionDOT(e.Graph, scope))
 			case "list", "":
-				levels, err := e.Levels()
-				if err != nil {
-					return err
-				}
 				if output == "json" {
-					return writeJSON(cmd.OutOrStdout(), graphResult{Levels: levels})
+					return writeJSON(cmd.OutOrStdout(), graphResult{Levels: levels, Selection: dto})
 				}
+				printSelection(cmd.OutOrStdout(), dto, nil)
 				for i, level := range levels {
 					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "level %d: %s\n", i+1, joinNames(level))
 				}
@@ -226,6 +242,7 @@ func newGraphCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 			return nil
 		},
 	}
+	selection.add(cmd)
 	cmd.Flags().StringVar(&format, "format", "list", "output format: list or dot")
 	cmd.Flags().StringVar(&output, "output", "text", "output stream encoding: text or json (json is only supported with --format list)")
 	return cmd
@@ -251,7 +268,8 @@ func validateRunArgs(cmd *cobra.Command, args []string) error {
 }
 
 func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
-	var node, output, approve string
+	var selection selectionFlags
+	var output, approve string
 	var save bool
 	var continueID string
 	var parallelism int
@@ -261,12 +279,13 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 		RunE: func(cmd *cobra.Command, args []string) (resultErr error) {
 			var runs []engine.NodeRun
 			var savedRecord engine.ExecutionRecord
+			var scope *selectionDTO
 			phase := "arguments"
 			defer func() {
 				if save {
-					resultErr = finishSavedExecution(cmd, output, savedRecord, resultErr)
+					resultErr = finishSavedExecution(cmd, output, savedRecord, resultErr, scope)
 				} else {
-					resultErr = finishPlan(cmd, output, runs, phase, resultErr)
+					resultErr = finishPlan(cmd, output, runs, phase, resultErr, scope)
 				}
 			}()
 			if err := validateRunArgs(cmd, args); err != nil {
@@ -277,6 +296,9 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 			}
 			if continueID != "" && !save {
 				return fmt.Errorf("--continue requires --save")
+			}
+			if continueID != "" && selection.specified(cmd) {
+				return fmt.Errorf("--continue already fixes node selection; omit --node and --downstream")
 			}
 			policy, policyErr := blueprint.ParseApprove(approve)
 			if policyErr != nil {
@@ -294,15 +316,17 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 			}
 			e.Stdout = cmd.ErrOrStderr()
 			phase = "prepare"
+			opts := selection.options(cmd, output, &scope)
+			opts.Parallelism, opts.Approve = parallelism, policy
 			if save {
-				savedRecord, err = e.SavePlans(engine.Options{Node: node, Parallelism: parallelism, Approve: policy}, continueID)
+				savedRecord, err = e.SavePlans(opts, continueID)
 				return err
 			}
-			runs, err = e.ReviewPlan(engine.Options{Node: node, Parallelism: parallelism, Approve: policy}, output == "text")
+			runs, err = e.ReviewPlan(opts, output == "text")
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
+	selection.add(cmd)
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
 	cmd.Flags().StringVar(&output, "output", "text", "output format: text or json")
 	cmd.Flags().BoolVar(&save, "save", false, "save only the ready graph frontier for a later apply --plan")
@@ -313,7 +337,7 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 }
 
 func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
-	var node string
+	var selection selectionFlags
 	var planID string
 	var retainPlan bool
 	var autoApprove bool
@@ -326,6 +350,9 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 		Short: "Run terraform/tofu apply across the graph in dependency order, wiring outputs to inputs",
 		Args:  validateRunArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if planID != "" && selection.specified(cmd) {
+				return fmt.Errorf("--plan already fixes node selection; omit --node and --downstream")
+			}
 			if output != "text" && output != "json" {
 				return fmt.Errorf("unknown output %q (want \"text\" or \"json\")", output)
 			}
@@ -349,7 +376,9 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 			if output == "json" {
 				e.Stdout = cmd.ErrOrStderr()
 			}
-			opts := engine.Options{Node: node, AutoApprove: autoApprove, Approve: level, Parallelism: parallelism, RetainPlan: retainPlan}
+			var scope *selectionDTO
+			opts := selection.options(cmd, output, &scope)
+			opts.AutoApprove, opts.Approve, opts.Parallelism, opts.RetainPlan = autoApprove, level, parallelism, retainPlan
 			var runs []engine.NodeRun
 			if planID != "" {
 				if retainPlan {
@@ -359,10 +388,10 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 			} else {
 				runs, err = e.Apply(opts)
 			}
-			return finishRun(cmd, output, runs, err)
+			return finishRun(cmd, output, runs, err, scope)
 		},
 	}
-	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
+	selection.add(cmd)
 	cmd.Flags().StringVar(&planID, "plan", "", "apply the stored frontier of a saved execution without replanning")
 	cmd.Flags().BoolVar(&retainPlan, "retain-plan", false, "retain optional plan artifacts while ordinary apply continues")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip the interactive approval prompt")
@@ -376,7 +405,7 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 }
 
 func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
-	var node string
+	var selection selectionFlags
 	var autoApprove bool
 	var parallelism int
 	var output string
@@ -404,11 +433,14 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 			if output == "json" {
 				e.Stdout = cmd.ErrOrStderr()
 			}
-			runs, err := e.Destroy(engine.Options{Node: node, AutoApprove: autoApprove, Parallelism: parallelism})
-			return finishRun(cmd, output, runs, err)
+			var scope *selectionDTO
+			opts := selection.options(cmd, output, &scope)
+			opts.AutoApprove, opts.Parallelism = autoApprove, parallelism
+			runs, err := e.Destroy(opts)
+			return finishRun(cmd, output, runs, err, scope)
 		},
 	}
-	cmd.Flags().StringVar(&node, "node", "", "restrict to a single node")
+	selection.add(cmd)
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
 	cmd.Flags().StringVar(&output, "output", "text", "output format: text or json")

--- a/internal/cli/execution_records.go
+++ b/internal/cli/execution_records.go
@@ -17,6 +17,7 @@ type executionNodeDTO struct {
 }
 
 type executionDTO struct {
+	Selection   *selectionDTO      `json:"selection,omitempty"`
 	ID          string             `json:"id"`
 	Preparation string             `json:"preparation,omitempty"`
 	Backup      bool               `json:"backup_available"`
@@ -30,13 +31,14 @@ type executionDTO struct {
 }
 
 type executionHistoryDTO struct {
+	Selection     *selectionDTO   `json:"selection,omitempty"`
 	SchemaVersion int             `json:"schema_version"`
 	Executions    []executionDTO  `json:"executions"`
 	Diagnostics   []diagnosticDTO `json:"diagnostics"`
 }
 
 func executionToDTO(record engine.ExecutionRecord) executionDTO {
-	dto := executionDTO{ID: record.ID, Preparation: record.Preparation, Backup: record.Backup, Operation: record.Operation, Status: record.Status, CreatedAt: record.CreatedAt, UpdatedAt: record.UpdatedAt, FinishedAt: record.FinishedAt, RecoveryAt: record.RecoveryAt, Nodes: []executionNodeDTO{}}
+	dto := executionDTO{Selection: selectionToDTO(record.Selection), ID: record.ID, Preparation: record.Preparation, Backup: record.Backup, Operation: record.Operation, Status: record.Status, CreatedAt: record.CreatedAt, UpdatedAt: record.UpdatedAt, FinishedAt: record.FinishedAt, RecoveryAt: record.RecoveryAt, Nodes: []executionNodeDTO{}}
 	for _, node := range record.Nodes {
 		dto.Nodes = append(dto.Nodes, executionNodeDTO{Node: node.Name, Review: reviewToDTO(node.Review), Phase: node.Phase, PlanID: node.PlanID, Code: node.Code})
 	}
@@ -73,6 +75,7 @@ func newExecutionHistoryCmd(kind string, path *string) *cobra.Command {
 				for _, record := range result.Executions {
 					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s  %s  %s\n", record.ID, record.Operation, record.Status)
 					if kind == "show" {
+						printSelection(cmd.OutOrStdout(), record.Selection, nil)
 						if record.Backup {
 							_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  backup: available (export with plan show --backup)")
 						}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -23,7 +23,8 @@ type validateResult struct {
 
 // graphResult is the JSON payload for `terragraph graph --output json` (list format only; DOT has no JSON form).
 type graphResult struct {
-	Levels [][]string `json:"levels"`
+	Selection *selectionDTO `json:"selection,omitempty"`
+	Levels    [][]string    `json:"levels"`
 }
 
 // vendorResultDTO is the JSON-facing shape of one vendor.Result. vendor.Result.Err is an error interface, which encoding/json can't marshal usefully; this flattens it to a status string plus an optional message.
@@ -71,7 +72,8 @@ type nodeRunDTO struct {
 
 // runResult is the JSON payload for `terragraph plan|apply|destroy --output json`.
 type runResult struct {
-	Nodes []nodeRunDTO `json:"nodes"`
+	Selection *selectionDTO `json:"selection,omitempty"`
+	Nodes     []nodeRunDTO  `json:"nodes"`
 }
 
 func nodeRunsToDTO(runs []engine.NodeRun) []nodeRunDTO {

--- a/internal/cli/plan_review.go
+++ b/internal/cli/plan_review.go
@@ -44,6 +44,7 @@ type planReviewDTO struct {
 	Diagnostics []diagnosticDTO   `json:"diagnostics"`
 }
 type planResultDTO struct {
+	Selection     *selectionDTO   `json:"selection,omitempty"`
 	SchemaVersion int             `json:"schema_version"`
 	Nodes         []nodeRunDTO    `json:"nodes"`
 	Diagnostics   []diagnosticDTO `json:"diagnostics"`
@@ -97,8 +98,11 @@ func reviewToDTO(review *engine.PlanReview) *planReviewDTO {
 }
 
 // finishPlan emits one additive, versioned result even when preparation fails before any node can start.
-func finishPlan(cmd *cobra.Command, format string, runs []engine.NodeRun, phase string, err error) error {
+func finishPlan(cmd *cobra.Command, format string, runs []engine.NodeRun, phase string, err error, selection ...*selectionDTO) error {
 	dto := planResultDTO{SchemaVersion: 1, Nodes: nodeRunsToDTO(runs), Diagnostics: []diagnosticDTO{}}
+	if len(selection) > 0 {
+		dto.Selection = selection[0]
+	}
 	if err != nil && len(runs) == 0 {
 		dto.Diagnostics = append(dto.Diagnostics, diagnosticDTO{Source: errorLocation(err), Code: "plan_" + phase + "_failed", Phase: phase, Subject: "plan", Message: err.Error(), Remedy: "resolve the diagnostic and rerun plan"})
 	}

--- a/internal/cli/saved_execution.go
+++ b/internal/cli/saved_execution.go
@@ -7,8 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func finishSavedExecution(cmd *cobra.Command, output string, record engine.ExecutionRecord, resultErr error) error {
+func finishSavedExecution(cmd *cobra.Command, output string, record engine.ExecutionRecord, resultErr error, selection ...*selectionDTO) error {
 	result := executionHistoryDTO{SchemaVersion: 1, Executions: []executionDTO{}, Diagnostics: []diagnosticDTO{}}
+	if len(selection) > 0 {
+		result.Selection = selection[0]
+	}
 	if record.ID != "" {
 		result.Executions = append(result.Executions, executionToDTO(record))
 	}

--- a/internal/cli/selection.go
+++ b/internal/cli/selection.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cloudfluent/terragraph/internal/engine"
+	"github.com/cloudfluent/terragraph/internal/graph"
+	"github.com/spf13/cobra"
+)
+
+// selectionDTO keeps the public scope contract independent from protected execution record encoding.
+type selectionDTO struct {
+	SchemaVersion int                `json:"schema_version"`
+	Mode          string             `json:"mode"`
+	Requested     []string           `json:"requested"`
+	Nodes         []selectionNodeDTO `json:"nodes"`
+	BoundaryEdges []selectionEdgeDTO `json:"boundary_edges"`
+}
+type selectionNodeDTO struct {
+	Node   string   `json:"node"`
+	Reason string   `json:"reason"`
+	Via    []string `json:"via"`
+}
+type selectionEdgeDTO struct {
+	Kind string           `json:"kind"`
+	From selectionPortDTO `json:"from"`
+	To   selectionPortDTO `json:"to"`
+}
+type selectionPortDTO struct {
+	Node   string `json:"node"`
+	Output string `json:"output,omitempty"`
+	Input  string `json:"input,omitempty"`
+}
+
+func selectionToDTO(s *graph.Selection) *selectionDTO {
+	if s == nil {
+		return nil
+	}
+	dto := &selectionDTO{SchemaVersion: s.SchemaVersion, Mode: s.Mode, Requested: append([]string{}, s.Requested...), Nodes: []selectionNodeDTO{}, BoundaryEdges: []selectionEdgeDTO{}}
+	for _, n := range s.Nodes {
+		dto.Nodes = append(dto.Nodes, selectionNodeDTO{Node: n.Node, Reason: n.Reason, Via: append([]string{}, n.Via...)})
+	}
+	for _, e := range s.BoundaryEdges {
+		edge := selectionEdgeDTO{Kind: "ordering", From: selectionPortDTO{Node: e.From.Node}, To: selectionPortDTO{Node: e.To.Node}}
+		if e.IsDataEdge() {
+			edge.Kind = "data"
+			edge.From.Output = e.From.Name
+			edge.To.Input = e.To.Name
+		}
+		dto.BoundaryEdges = append(dto.BoundaryEdges, edge)
+	}
+	return dto
+}
+
+func printSelection(w io.Writer, s *selectionDTO, levels [][]string) {
+	if s == nil {
+		return
+	}
+	names := []string{}
+	for _, n := range s.Nodes {
+		names = append(names, n.Node)
+	}
+	_, _ = fmt.Fprintf(w, "selection: %s\nrequested: %s\nselected: %s\n", s.Mode, joinNames(s.Requested), joinNames(names))
+	for _, n := range s.Nodes {
+		why := n.Reason
+		if why == "downstream" {
+			why += " of " + joinNames(n.Via)
+		}
+		_, _ = fmt.Fprintf(w, "  %s: %s\n", n.Node, why)
+	}
+	if len(s.BoundaryEdges) > 0 {
+		_, _ = fmt.Fprintln(w, "boundary edges (one endpoint not selected):")
+		for _, e := range s.BoundaryEdges {
+			from, to := e.From.Node, e.To.Node
+			if e.Kind == "data" {
+				from += ".output." + e.From.Output
+				to += ".input." + e.To.Input
+			}
+			_, _ = fmt.Fprintf(w, "  %s -> %s (%s)\n", from, to, e.Kind)
+		}
+	}
+	for i, level := range levels {
+		_, _ = fmt.Fprintf(w, "level %d: %s\n", i+1, joinNames(level))
+	}
+}
+
+type selectionFlags struct {
+	nodes      []string
+	downstream bool
+}
+
+func (f *selectionFlags) add(cmd *cobra.Command) {
+	cmd.Flags().StringArrayVar(&f.nodes, "node", nil, "select an exact leaf name (repeat for multiple nodes; commas are literal)")
+	cmd.Flags().BoolVar(&f.downstream, "downstream", false, "include all successors of --node across data and ordering edges")
+}
+
+func (f *selectionFlags) specified(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed("node") || cmd.Flags().Changed("downstream")
+}
+
+func (f *selectionFlags) options(cmd *cobra.Command, format string, result **selectionDTO) engine.Options {
+	return engine.Options{Nodes: f.nodes, Downstream: f.downstream, SelectionSpecified: f.specified(cmd), OnSelection: func(s *graph.Selection, levels [][]string) {
+		*result = selectionToDTO(s)
+		if format == "text" {
+			printSelection(cmd.OutOrStdout(), *result, levels)
+		}
+	}}
+}

--- a/internal/cli/selection_test.go
+++ b/internal/cli/selection_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGraph_SelectionJSONQualifiedAndStable(t *testing.T) {
+	args := []string{"graph", "--node", "checkout.cluster", "--node", "checkout.cluster", "--downstream", "--output", "json"}
+	out, _, err := runCmd(t, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result graphResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result.Levels, [][]string{{"checkout.cluster"}, {"checkout.nodegroup"}}) || result.Selection == nil || len(result.Selection.Nodes) != 2 || len(result.Selection.BoundaryEdges) != 1 {
+		t.Fatalf("got = %s", out)
+	}
+	if strings.Contains(out, "null") || strings.Contains(out, "backend") || strings.Contains(out, "payments") {
+		t.Fatalf("got = %s, want only selection relationships", out)
+	}
+	out2, _, err := runCmd(t, "graph", "--node", "checkout.cluster", "--downstream", "--output", "json")
+	if err != nil || out != out2 {
+		t.Fatalf("got = %q, %v, want %q", out2, err, out)
+	}
+}
+
+func TestGraph_SelectionTextAndDOT(t *testing.T) {
+	out, _, err := runCmd(t, "graph", "--node", "checkout.cluster", "--downstream")
+	for _, want := range []string{"selection: downstream", "requested: checkout.cluster", "checkout.nodegroup: downstream of checkout.cluster", "vpc.output.vpc_id -> checkout.cluster.input.vpc_id (data)", "level 1: checkout.cluster\nlevel 2: checkout.nodegroup\n"} {
+		if err != nil || !strings.Contains(out, want) {
+			t.Fatalf("got = %q, %v, want %q", out, err, want)
+		}
+	}
+	out, _, err = runCmd(t, "graph", "--node", "checkout.cluster", "--format", "dot")
+	if err != nil || !strings.Contains(out, "checkout.nodegroup (not selected)") || !strings.Contains(out, "vpc (not selected)") || strings.Contains(out, "payments") {
+		t.Fatalf("got = %q, %v", out, err)
+	}
+}
+
+func TestGraph_DownstreamFalsePreservesDefaultOutput(t *testing.T) {
+	a, _, err := runCmd(t, "graph", "--output", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := runCmd(t, "graph", "--output", "json", "--downstream=false")
+	if err != nil || a != b || strings.Contains(b, "selection") {
+		t.Fatalf("got = %q, %v, want %q", b, err, a)
+	}
+}
+
+func TestSelection_RejectsInvalidCLIInputs(t *testing.T) {
+	for _, command := range []string{"graph", "plan", "apply", "destroy"} {
+		for _, flags := range [][]string{{"positional"}, {"--node", ""}, {"--downstream"}, {"--node", "vpc,checkout.cluster"}, {"--node", "vpc", "--node", "missing"}, {"--node", "checkout"}} {
+			args := append([]string{command}, flags...)
+			if command == "apply" || command == "destroy" {
+				args = append(args, "--auto-approve")
+			}
+			_, _, err := runCmd(t, args...)
+			if err == nil {
+				t.Fatalf("args = %q, want error", args)
+			}
+		}
+	}
+}
+
+func TestSelection_SavedOverridesRejectedBeforeLoad(t *testing.T) {
+	for _, args := range [][]string{{"apply", "--plan", "run-missing"}, {"plan", "--save", "--continue", "run-missing"}} {
+		for _, flags := range [][]string{{"--node", ""}, {"--node", "vpc"}, {"--downstream"}, {"--downstream=false"}} {
+			call := append([]string{"--blueprint", "missing-directory"}, args...)
+			call = append(call, flags...)
+			_, _, err := runRootCmd(t, call...)
+			if err == nil || !strings.Contains(err.Error(), "omit --node and --downstream") {
+				t.Fatalf("args = %q, got = %v", call, err)
+			}
+		}
+	}
+}

--- a/internal/cli/selection_unix_test.go
+++ b/internal/cli/selection_unix_test.go
@@ -1,0 +1,139 @@
+//go:build !windows
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRun_SelectionJSONIncludesSuccessAndFailures(t *testing.T) {
+	for _, command := range []string{"plan", "apply", "destroy"} {
+		for _, fail := range []bool{false, true} {
+			t.Run(command+map[bool]string{false: "_success", true: "_failure"}[fail], func(t *testing.T) {
+				bp := writeSelectionRunFixture(t)
+
+				if fail {
+					t.Setenv("TG_FAKE_PLAN_FAIL", "1")
+				}
+				args := []string{command, "--node", "a", "--downstream", "--output", "json"}
+				if command != "plan" {
+					args = append(args, "--auto-approve")
+				}
+				out, _, err := runCmdAt(t, bp, args...)
+				if (err != nil) != fail {
+					t.Fatalf("got = %s, %v, want failure %t", out, err, fail)
+				}
+				var result runResult
+				if err := json.Unmarshal([]byte(out), &result); err != nil {
+					t.Fatalf("got = %q, %v", out, err)
+				}
+				if result.Selection == nil || result.Selection.Mode != "downstream" || len(result.Nodes) != 1 || len(result.Selection.Nodes) != 1 {
+					t.Fatalf("got = %s", out)
+				}
+			})
+		}
+	}
+}
+
+func TestDestroy_SelectionJSONSurvivesPreparationFailure(t *testing.T) {
+	bp := writeSelectionRunFixture(t)
+	path := filepath.Join(filepath.Dir(bp), "blueprint.hcl")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = []byte(strings.Replace(string(body), "source = \"./module\"", "source = \"./module\"\n approve = \"none\"", 1))
+	if err := os.WriteFile(path, body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmdAt(t, bp, "destroy", "--node", "a", "--auto-approve", "--output", "json")
+	if err == nil || !strings.Contains(err.Error(), "does not permit teardown") {
+		t.Fatalf("got = %v", err)
+	}
+	var result runResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("got = %q, %v", out, err)
+	}
+	if result.Selection == nil || len(result.Nodes) != 0 {
+		t.Fatalf("got = %s", out)
+	}
+}
+
+func TestPlan_UnresolvedSelectionIsNotPublished(t *testing.T) {
+	bp := writeSelectionRunFixture(t)
+	out, _, err := runCmdAt(t, bp, "plan", "--node", "", "--output", "json")
+	if err == nil {
+		t.Fatal("empty name accepted")
+	}
+	var result planResultDTO
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Selection != nil || len(result.Nodes) != 0 || len(result.Diagnostics) != 1 {
+		t.Fatalf("got = %s", out)
+	}
+}
+
+func TestGraph_SelectionNeverCallsRuntimeOrCreatesRecords(t *testing.T) {
+	bp := writeSelectionRunFixture(t)
+	for _, format := range []string{"list", "dot"} {
+		out, stderr, err := runCmdAt(t, bp, "graph", "--node", "a", "--downstream", "--format", format)
+		if err != nil || strings.Contains(out+stderr, "terraform ") {
+			t.Fatalf("got = %q, %q, %v", out, stderr, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(bp), ".terragraph")); !os.IsNotExist(err) {
+		t.Fatalf("got = %v, graph created managed artifacts", err)
+	}
+}
+
+func TestRun_SelectionTextPrecedesFirstSubprocess(t *testing.T) {
+	bp := writeSelectionRunFixture(t)
+	out, _, err := runCmdAt(t, bp, "apply", "--node", "a", "--auto-approve")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "selection: exact\nrequested: a\nselected: a\n") || strings.Index(out, "level 1: a") > strings.Index(out, "terraform init stdout") {
+		t.Fatalf("got = %q", out)
+	}
+}
+
+func writeSelectionRunFixture(t *testing.T) string {
+	t.Helper()
+	bp := writeRunFixture(t)
+	fake := filepath.Join(filepath.Dir(bp), "terraform-fake")
+	script, err := os.ReadFile(fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(script), `if [ "$1" != show ];`, `if [ "$1" != show ] && [ "$1" != output ];`, 1)
+	updated = strings.Replace(updated, "case \"$1\" in", `case "$1" in
+ output) printf '%s' '{"id":{"value":"existing"}}'; exit 0 ;;
+ destroy) if [ -n "${TG_FAKE_PLAN_FAIL:-}" ]; then exit 1; fi; exit 0 ;;`, 1)
+	if err := os.WriteFile(fake, []byte(updated), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return bp
+}
+
+func TestGraph_SelectionCannotHideInvalidUnselectedSchema(t *testing.T) {
+	bp := writeSelectionRunFixture(t)
+	module := filepath.Join(filepath.Dir(bp), "bad", "main.tf")
+	writeFixtureFile(t, module, "output \"present\" { value = \"x\" }\n")
+	body, err := os.ReadFile(bp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = append(body, []byte("node \"bad\" { source = \"./bad\" }\nedge {\n from = node.bad.output.missing\n to = node.a.input.missing\n}\n")...)
+	if err := os.WriteFile(bp, body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = runCmdAt(t, bp, "graph", "--node", "a")
+	if err == nil || !strings.Contains(err.Error(), "terragraph validate") {
+		t.Fatalf("got = %v, want full validation failure", err)
+	}
+}

--- a/internal/engine/apply.go
+++ b/internal/engine/apply.go
@@ -15,6 +15,12 @@ import (
 //
 // When the plan does report changes, that plan is what gets applied (see Runner.PlanChanges/ApplyPlan), so a node refreshes once and the change made is the change that was planned.
 func (e *Engine) Apply(opts Options) (runs []NodeRun, resultErr error) {
+	opts, selectionErr := e.resolveSelection(opts)
+	if selectionErr != nil {
+		return nil, selectionErr
+	}
+	opts.announceSelection(false)
+
 	// Concurrent nodes have their output buffered and flushed a node at a time (see runLevels), so a prompt written mid-level would be invisible until long after the answer was needed. Rather than deadlock on that, say so — before taking the run lock, so a combination that cannot run fails immediately instead of first waiting on whatever else holds it.
 	if !opts.AutoApprove && opts.parallelism() > 1 {
 		return nil, fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
@@ -47,7 +53,7 @@ func (e *Engine) Apply(opts Options) (runs []NodeRun, resultErr error) {
 		}
 	}()
 
-	e.logger().Info("apply starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
+	e.logger().Info("apply starting", "nodes", opts.Nodes, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
 
 	return e.runLevels(opts, false, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		vars, err := e.resolveInputs(name, applied)

--- a/internal/engine/apply_unix_test.go
+++ b/internal/engine/apply_unix_test.go
@@ -579,7 +579,7 @@ func runApplyChild(t *testing.T) {
 		t.Fatalf("LoadLocked: %v", err)
 	}
 	defer unlock()
-	if _, err := e.Apply(Options{Node: os.Getenv(applyChildNodeEnv), AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{os.Getenv(applyChildNodeEnv)}, AutoApprove: true}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 }

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -14,6 +14,12 @@ import (
 //
 // Nothing has to be invalidated afterwards. Destroy once had to drop the incremental-apply cache entry for everything it tore down, because a stale "unchanged" hit against infrastructure that no longer exists would have been a correctness bug rather than a missed optimization; a later apply now asks Terraform, which plans against real state and sees the resources are gone.
 func (e *Engine) Destroy(opts Options) (runs []NodeRun, resultErr error) {
+	opts, selectionErr := e.resolveSelection(opts)
+	if selectionErr != nil {
+		return nil, selectionErr
+	}
+	opts.announceSelection(true)
+
 	// Same reason Apply refuses it: concurrent nodes have their output buffered and flushed a node at a time, so terraform's confirmation prompt would be invisible until long after the answer was needed. Checked before taking the run lock, so an unrunnable combination fails immediately instead of after waiting for whatever else holds it.
 	if !opts.AutoApprove && opts.parallelism() > 1 {
 		return nil, fmt.Errorf("--parallelism %d needs --auto-approve: output from concurrent nodes is buffered, so there is nowhere to ask for approval", opts.parallelism())
@@ -59,7 +65,7 @@ func (e *Engine) Destroy(opts Options) (runs []NodeRun, resultErr error) {
 		}
 	}()
 
-	e.logger().Info("destroy starting", "node", opts.Node, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
+	e.logger().Info("destroy starting", "nodes", opts.Nodes, "parallelism", opts.parallelism(), "autoApprove", opts.AutoApprove)
 
 	return e.runLevels(opts, true, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
 		// A destroy plan needs the same resolved input values an apply would have used (e.g. a variable feeding a resource's count or for_each), so it's evaluated identically here: every upstream dependency is still standing at this point, since destroy walks the graph in reverse topological order (downstream first).

--- a/internal/engine/env_unix_test.go
+++ b/internal/engine/env_unix_test.go
@@ -80,7 +80,7 @@ func TestPlan_ManagedEnvErrorCannotFallBackToSnapshot(t *testing.T) {
 	e := loadFallbackEngine(t, true)
 	writeFallbackSnapshot(t, e, "a", "public-value")
 	e.Graph.Nodes["a"].Env = map[string]string{"TF_DATA_DIR": "shared"}
-	runs, err := e.Plan(Options{Node: "b"})
+	runs, err := e.Plan(Options{Nodes: []string{"b"}})
 	if err == nil || !strings.Contains(err.Error(), "node.a: env.TF_DATA_DIR") || len(runs) != 0 {
 		t.Fatalf("runs = %v, error = %v, want managed upstream env conflict before fallback or execution", runs, err)
 	}

--- a/internal/engine/execution_cleanup_test.go
+++ b/internal/engine/execution_cleanup_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestExecutionCleanup_PreservesOldUnknownRecordsAndBundles(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestExecutionCleanup_PreservesOldUnknownRecordsAndBundles(t *testing.T) {
 
 func TestExecutionCleanup_ExpiresPausedPlansBeforeDeletingRecords(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("saved_apply", []string{"example"})
+	s, err := e.beginExecution("saved_apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestExecutionCleanup_ExpiresPausedPlansBeforeDeletingRecords(t *testing.T) 
 
 func TestExecutionCleanup_RemovesBackupOnlyWithExpiredResolvedRecord(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("run_state_rm", []string{"example"})
+	s, err := e.beginExecution("run_state_rm", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/execution_journal.go
+++ b/internal/engine/execution_journal.go
@@ -13,23 +13,27 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cloudfluent/terragraph/internal/graph"
 )
 
 // ExecutionRecord records observed command outcomes, never a second copy of infrastructure state.
 type ExecutionRecord struct {
-	SchemaVersion int             `json:"schema_version"`
-	Preparation   string          `json:"preparation,omitempty"`
-	Backup        bool            `json:"backup,omitempty"`
-	ID            string          `json:"id"`
-	Scope         string          `json:"scope"`
-	Binding       string          `json:"binding,omitempty"`
-	Operation     string          `json:"operation"`
-	Status        string          `json:"status"`
-	CreatedAt     time.Time       `json:"created_at"`
-	UpdatedAt     time.Time       `json:"updated_at"`
-	FinishedAt    *time.Time      `json:"finished_at,omitempty"`
-	RecoveryAt    *time.Time      `json:"recovery_at,omitempty"`
-	Nodes         []ExecutionNode `json:"nodes"`
+	// Selection is explanatory only; Nodes remains authoritative for saved execution membership.
+	Selection     *graph.Selection `json:"selection,omitempty"`
+	SchemaVersion int              `json:"schema_version"`
+	Preparation   string           `json:"preparation,omitempty"`
+	Backup        bool             `json:"backup,omitempty"`
+	ID            string           `json:"id"`
+	Scope         string           `json:"scope"`
+	Binding       string           `json:"binding,omitempty"`
+	Operation     string           `json:"operation"`
+	Status        string           `json:"status"`
+	CreatedAt     time.Time        `json:"created_at"`
+	UpdatedAt     time.Time        `json:"updated_at"`
+	FinishedAt    *time.Time       `json:"finished_at,omitempty"`
+	RecoveryAt    *time.Time       `json:"recovery_at,omitempty"`
+	Nodes         []ExecutionNode  `json:"nodes"`
 }
 
 // ExecutionNode separates successful mutation from output collection so failed post-processing cannot cause a blind replay.
@@ -151,6 +155,15 @@ func readExecutionRecord(ctx context.Context, store executionStore, id string) (
 	if record.SchemaVersion != 1 || record.ID != id || record.Scope == "" || record.Status == "" {
 		return ExecutionRecord{}, "", fmt.Errorf("execution record is incompatible or incomplete; restore a valid record")
 	}
+	if record.Selection != nil {
+		names := make([]string, 0, len(record.Nodes))
+		for _, node := range record.Nodes {
+			names = append(names, node.Name)
+		}
+		if err := record.Selection.ValidateMembership(names); err != nil {
+			return ExecutionRecord{}, "", err
+		}
+	}
 	return record, obj.Revision, nil
 }
 
@@ -170,7 +183,7 @@ func executionNeedsRecovery(record ExecutionRecord) bool {
 	return false
 }
 
-func (e *Engine) beginExecution(operation string, names []string, readOnly ...bool) (*executionSession, error) {
+func (e *Engine) beginExecution(operation string, names []string, selection *graph.Selection, readOnly ...bool) (*executionSession, error) {
 	store, err := e.openExecutionStore()
 	if err != nil {
 		return nil, err
@@ -192,7 +205,7 @@ func (e *Engine) beginExecution(operation string, names []string, readOnly ...bo
 		return nil, err
 	}
 	now := time.Now().UTC()
-	record := ExecutionRecord{SchemaVersion: 1, ID: newExecutionID("run"), Scope: scope, Operation: operation, Status: "preparing", CreatedAt: now, UpdatedAt: now, Nodes: []ExecutionNode{}}
+	record := ExecutionRecord{Selection: selection, SchemaVersion: 1, ID: newExecutionID("run"), Scope: scope, Operation: operation, Status: "preparing", CreatedAt: now, UpdatedAt: now, Nodes: []ExecutionNode{}}
 	for _, name := range names {
 		target, err := e.executionTarget(name)
 		if err != nil {
@@ -336,7 +349,7 @@ func (e *Engine) startExecution(operation string, opts Options, reverse bool) (*
 	for _, level := range levels {
 		names = append(names, level...)
 	}
-	return e.beginExecution(operation, names)
+	return e.beginExecution(operation, names, opts.selection)
 }
 
 // GetExecution reads only the requested object so corrupt siblings cannot hide recovery evidence.

--- a/internal/engine/execution_journal_test.go
+++ b/internal/engine/execution_journal_test.go
@@ -27,7 +27,7 @@ func journalFixture(t *testing.T) (*Engine, func()) {
 
 func TestExecutionJournal_BlocksNewRunAfterUncertainMutation(t *testing.T) {
 	e, _ := journalFixture(t)
-	session, err := e.beginExecution("apply", []string{"example"})
+	session, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestExecutionJournal_BlocksNewRunAfterUncertainMutation(t *testing.T) {
 	}
 	id := session.record.ID
 	session.close()
-	if _, err := e.beginExecution("apply", []string{"example"}); err == nil || !strings.Contains(err.Error(), id) {
+	if _, err := e.beginExecution("apply", []string{"example"}, nil); err == nil || !strings.Contains(err.Error(), id) {
 		t.Fatalf("got = %v", err)
 	}
 	records, err := e.ListExecutions()
@@ -50,7 +50,7 @@ func TestExecutionJournal_BlocksNewRunAfterUncertainMutation(t *testing.T) {
 
 func TestExecutionJournal_PreservesAppliedWhenOutputReadFails(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestExecutionJournal_PreservesAppliedWhenOutputReadFails(t *testing.T) {
 
 func TestExecutionJournal_FinishedRunDoesNotCreatePlanBundle(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestExecutionJournal_FinishedRunDoesNotCreatePlanBundle(t *testing.T) {
 		t.Fatalf("got = %v, %v", keys, err)
 	}
 	s.close()
-	next, err := e.beginExecution("apply", []string{"example"})
+	next, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestExecutionJournal_RecordsInterruptedResultAfterCancellation(t *testing.T
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	e.Context = ctx
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestExecutionJournal_RecordsInterruptedResultAfterCancellation(t *testing.T
 
 func TestExecutionJournal_HistorySurfacesForeignScope(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestExecutionJournal_HistorySurfacesForeignScope(t *testing.T) {
 
 func TestExecutionJournal_FinishedSavedOutcomeSurvivesCleanupFailure(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("saved_apply", []string{"example"})
+	s, err := e.beginExecution("saved_apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/execution_recovery_unix_test.go
+++ b/internal/engine/execution_recovery_unix_test.go
@@ -38,7 +38,7 @@ func TestRecoverExecution_AppliedOnlyReadsOutputs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := e.beginExecution("apply", names[0])
+	s, err := e.beginExecution("apply", names[0], nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestRecoverExecution_AppliedOnlyReadsOutputs(t *testing.T) {
 
 func TestRecoverExecution_UnknownRequiresInspectionAndPreservesOutcome(t *testing.T) {
 	e, _ := journalFixture(t)
-	s, err := e.beginExecution("apply", []string{"example"})
+	s, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestRecoverExecution_UnknownRequiresInspectionAndPreservesOutcome(t *testin
 	if err != nil || record.Nodes[0].Phase != "indeterminate" || record.Status != "recovered_replan_required" {
 		t.Fatalf("got = %+v, %v", record, err)
 	}
-	next, err := e.beginExecution("apply", []string{"example"})
+	next, err := e.beginExecution("apply", []string{"example"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestRecoverExecution_MixedUnknownDoesNotHideAppliedSibling(t *testing.T) {
 	peer := *e.Graph.Nodes["cached"]
 	peer.Name = "peer"
 	e.Graph.Nodes["peer"] = &peer
-	s, err := e.beginExecution("apply", []string{"cached", "peer"})
+	s, err := e.beginExecution("apply", []string{"cached", "peer"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestRecoverExecution_MixedUnknownDoesNotHideAppliedSibling(t *testing.T) {
 	if err != nil || record.Nodes[0].Phase != "completed" || record.Nodes[1].Phase != "indeterminate" || record.RecoveryAt != nil {
 		t.Fatalf("got = %+v, %v", record, err)
 	}
-	if _, err := e.beginExecution("apply", []string{"cached"}); err == nil {
+	if _, err := e.beginExecution("apply", []string{"cached"}, nil); err == nil {
 		t.Fatal("partial recovery released barrier")
 	}
 }

--- a/internal/engine/node_operation.go
+++ b/internal/engine/node_operation.go
@@ -52,7 +52,7 @@ func (e *Engine) RunNode(name string, args []string) (resultErr error) {
 			return fmt.Errorf("run: %s", problem.Message)
 		}
 	}
-	if err := e.checkRuntimeFiles(Options{Node: name}); err != nil {
+	if err := e.checkRuntimeFiles(Options{Nodes: []string{name}}); err != nil {
 		return err
 	}
 	if !op.init {
@@ -65,7 +65,7 @@ func (e *Engine) RunNode(name string, args []string) (resultErr error) {
 		return err
 	}
 	defer unlockGraph()
-	s, err := e.beginExecution("run_"+strings.ReplaceAll(op.name, " ", "_"), []string{name}, op.readOnly)
+	s, err := e.beginExecution("run_"+strings.ReplaceAll(op.name, " ", "_"), []string{name}, nil, op.readOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/node_operation_real_test.go
+++ b/internal/engine/node_operation_real_test.go
@@ -61,7 +61,7 @@ resource "terraform_data" "second" {}
 
 func TestRunNode_RealUsesOrdinaryApplyInitialization(t *testing.T) {
 	e := savedRuntimeFixture(t)
-	if _, err := e.Apply(Options{Node: "upstream", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"upstream"}, AutoApprove: true}); err != nil {
 		t.Fatal(err)
 	}
 	if err := e.RunNode("upstream", []string{"state", "pull"}); err != nil {

--- a/internal/engine/node_operation_unix_test.go
+++ b/internal/engine/node_operation_unix_test.go
@@ -83,7 +83,7 @@ func TestRunNode_ReadAllowedDuringUnknownButMutationBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := e.beginExecution("apply", []string{"cached"})
+	s, err := e.beginExecution("apply", []string{"cached"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/node_target_test.go
+++ b/internal/engine/node_target_test.go
@@ -6,7 +6,7 @@ import "testing"
 func TestExecutionLevels_DottedNodeTarget(t *testing.T) {
 	e := newTestEngine([]string{"vpc", "checkout.cluster", "checkout.nodegroup"}, nil)
 
-	levels, err := e.executionLevels(Options{Node: "checkout.cluster"}, false)
+	levels, err := e.executionLevels(Options{Nodes: []string{"checkout.cluster"}}, false)
 	if err != nil {
 		t.Fatalf("executionLevels: %v", err)
 	}
@@ -17,7 +17,7 @@ func TestExecutionLevels_DottedNodeTarget(t *testing.T) {
 
 func TestExecutionLevels_UnknownDottedNodeTarget(t *testing.T) {
 	e := newTestEngine([]string{"vpc"}, nil)
-	if _, err := e.executionLevels(Options{Node: "checkout.cluster"}, false); err == nil {
+	if _, err := e.executionLevels(Options{Nodes: []string{"checkout.cluster"}}, false); err == nil {
 		t.Fatalf("expected an error for an unknown node target")
 	}
 }

--- a/internal/engine/numbers_unix_test.go
+++ b/internal/engine/numbers_unix_test.go
@@ -139,7 +139,7 @@ edge {
 
 func TestPlan_LiveOutputNumbersReachTerraformExactly(t *testing.T) {
 	e := loadNumberEdgeEngine(t)
-	if _, err := e.Plan(Options{Node: "b"}); err != nil {
+	if _, err := e.Plan(Options{Nodes: []string{"b"}}); err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
 	assertNumberInputs(t, e)
@@ -147,7 +147,7 @@ func TestPlan_LiveOutputNumbersReachTerraformExactly(t *testing.T) {
 
 func TestPlan_SnapshotNumbersReachTerraformExactlyAfterReload(t *testing.T) {
 	e := loadNumberEdgeEngine(t)
-	if _, err := e.Apply(Options{Node: "a"}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}}); err != nil {
 		t.Fatalf("Apply upstream: %v", err)
 	}
 	if err := osWriteFile(filepath.Join(e.BaseDir, "producer", "output-unavailable"), nil); err != nil {
@@ -157,7 +157,7 @@ func TestPlan_SnapshotNumbersReachTerraformExactlyAfterReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after upstream apply: %v", err)
 	}
-	if _, err := reloaded.Plan(Options{Node: "b"}); err != nil {
+	if _, err := reloaded.Plan(Options{Nodes: []string{"b"}}); err != nil {
 		t.Fatalf("Plan using snapshot: %v", err)
 	}
 	assertNumberInputs(t, reloaded)
@@ -173,14 +173,14 @@ func TestPlan_LiveOutputRejectsTrailingJSON(t *testing.T) {
 	if err := osWriteFile(path, append(data, []byte("\n{}")...)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Plan(Options{Node: "b"}); err == nil || !strings.Contains(err.Error(), "expected a single JSON value") {
+	if _, err := e.Plan(Options{Nodes: []string{"b"}}); err == nil || !strings.Contains(err.Error(), "expected a single JSON value") {
 		t.Fatalf("Plan error = %v, want malformed live output rejected", err)
 	}
 }
 
 func TestPlan_SnapshotRejectsTrailingJSON(t *testing.T) {
 	e := loadNumberEdgeEngine(t)
-	if _, err := e.Apply(Options{Node: "a"}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}}); err != nil {
 		t.Fatalf("Apply upstream: %v", err)
 	}
 	if err := osWriteFile(filepath.Join(e.BaseDir, "producer", "output-unavailable"), nil); err != nil {
@@ -194,7 +194,7 @@ func TestPlan_SnapshotRejectsTrailingJSON(t *testing.T) {
 	if err := osWriteFile(path, append(data, []byte("\n{}")...)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Plan(Options{Node: "b"}); err == nil || !strings.Contains(err.Error(), "output -json") {
+	if _, err := e.Plan(Options{Nodes: []string{"b"}}); err == nil || !strings.Contains(err.Error(), "output -json") {
 		t.Fatalf("Plan error = %v, want original live output failure without corrupt fallback", err)
 	}
 }

--- a/internal/engine/observe_test.go
+++ b/internal/engine/observe_test.go
@@ -268,7 +268,7 @@ func TestReviewPlan_RealOutputOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runs, err := e.ReviewPlan(Options{Node: "first"}, false)
+	runs, err := e.ReviewPlan(Options{Nodes: []string{"first"}}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -21,6 +21,12 @@ func (e *Engine) ReviewPlan(opts Options, allowTextFallback bool) ([]NodeRun, er
 }
 
 func (e *Engine) plan(opts Options, inspect, allowTextFallback bool) (runs []NodeRun, resultErr error) {
+	opts, selectionErr := e.resolveSelection(opts)
+	if selectionErr != nil {
+		return nil, selectionErr
+	}
+	opts.announceSelection(false)
+
 	unlock, err := e.lockRun()
 	if err != nil {
 		return nil, err
@@ -50,7 +56,7 @@ func (e *Engine) plan(opts Options, inspect, allowTextFallback bool) (runs []Nod
 		}
 	}()
 
-	e.logger().Info("plan starting", "node", opts.Node, "parallelism", opts.parallelism())
+	e.logger().Info("plan starting", "nodes", opts.Nodes, "parallelism", opts.parallelism())
 	var reviewMu sync.Mutex
 	reviews := map[string]*PlanReview{}
 	runs, runErr := e.runLevels(opts, false, func(name string, applied map[string]exec.Outputs, out io.Writer) (exec.Outputs, string, error) {
@@ -67,7 +73,7 @@ func (e *Engine) plan(opts Options, inspect, allowTextFallback bool) (runs []Nod
 			return nil, "", err
 		}
 		if inspect {
-			if err := e.checkRuntimeFiles(Options{Node: name}); err != nil {
+			if err := e.checkRuntimeFiles(Options{Nodes: []string{name}}); err != nil {
 				return fail("runtime_incompatible", "prepare", err)
 			}
 		}

--- a/internal/engine/plan_review_unix_test.go
+++ b/internal/engine/plan_review_unix_test.go
@@ -150,7 +150,7 @@ func TestReviewPlan_UpstreamMissingDiffersFromCredentialFailure(t *testing.T) {
 	body := reviewNode("created") + reviewNode("consumer") + "edge {\n from = node.created.output.id\n to = node.consumer.input.input\n}\n"
 	e := reviewFixture(t, body)
 	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
-	runs, err := e.ReviewPlan(Options{Node: "consumer"}, false)
+	runs, err := e.ReviewPlan(Options{Nodes: []string{"consumer"}}, false)
 	if err == nil || runs[0].Review.Diagnostic.Code != "upstream_output_unavailable" || runs[0].Review.HasChanges != nil {
 		t.Fatalf("got = %+v, %v", runs, err)
 	}
@@ -162,7 +162,7 @@ func TestReviewPlan_UpstreamMissingDiffersFromCredentialFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
-	runs, err = e.ReviewPlan(Options{Node: "consumer"}, false)
+	runs, err = e.ReviewPlan(Options{Nodes: []string{"consumer"}}, false)
 	if err == nil || runs[0].Review.Diagnostic.Code != "input_resolution_failed" || strings.Contains(err.Error(), "has not been applied") {
 		t.Fatalf("got = %+v, %v", runs, err)
 	}
@@ -171,7 +171,7 @@ func TestReviewPlan_UpstreamMissingDiffersFromCredentialFailure(t *testing.T) {
 func TestReviewPlan_LiveAndSnapshotBasis(t *testing.T) {
 	body := "snapshots {}\n" + reviewNode("created") + reviewNode("consumer") + "edge {\n from = node.created.output.id\n to = node.consumer.input.input\n}\n"
 	e := reviewFixture(t, body)
-	runs, err := e.ReviewPlan(Options{Node: "consumer"}, false)
+	runs, err := e.ReviewPlan(Options{Nodes: []string{"consumer"}}, false)
 	if err != nil || runs[0].Review.Inputs[0].Source != "live" || len(runs[0].Review.Limitations) < 2 {
 		t.Fatalf("got = %+v, %v", runs, err)
 	}
@@ -180,7 +180,7 @@ func TestReviewPlan_LiveAndSnapshotBasis(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
-	runs, err = e.ReviewPlan(Options{Node: "consumer"}, false)
+	runs, err = e.ReviewPlan(Options{Nodes: []string{"consumer"}}, false)
 	if err != nil || runs[0].Review.Inputs[0].Source != "snapshot" {
 		t.Fatalf("got = %+v, %v", runs, err)
 	}
@@ -238,14 +238,14 @@ func TestReviewPlan_InspectionFailureRemovesPlan(t *testing.T) {
 func TestApply_MissingUpstreamStatePreservesReadFailure(t *testing.T) {
 	e := reviewFixture(t, reviewNode("created")+reviewNode("consumer")+"edge {\n from = node.created.output.id\n to = node.consumer.input.input\n}\n")
 	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
-	_, err := e.Apply(Options{Node: "consumer", AutoApprove: true})
+	_, err := e.Apply(Options{Nodes: []string{"consumer"}, AutoApprove: true})
 	assertMissingUpstreamState(t, e, err)
 }
 
 func TestDestroy_MissingUpstreamStatePreservesReadFailure(t *testing.T) {
 	e := reviewFixture(t, reviewNode("created")+reviewNode("consumer")+"edge {\n from = node.created.output.id\n to = node.consumer.input.input\n}\n")
 	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
-	_, err := e.Destroy(Options{Node: "consumer", AutoApprove: true})
+	_, err := e.Destroy(Options{Nodes: []string{"consumer"}, AutoApprove: true})
 	assertMissingUpstreamState(t, e, err)
 }
 

--- a/internal/engine/recovery_real_test.go
+++ b/internal/engine/recovery_real_test.go
@@ -19,10 +19,10 @@ func TestRecoverExecution_RealFreshBackendCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Apply(Options{Node: "first", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"first"}, AutoApprove: true}); err != nil {
 		t.Fatal(err)
 	}
-	s, err := e.beginExecution("apply", []string{"first"})
+	s, err := e.beginExecution("apply", []string{"first"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"sync"
 
@@ -17,8 +18,16 @@ import (
 type Options struct {
 	// RetainPlan persists optional plan artifacts without pausing ordinary apply.
 	RetainPlan bool
-	// Node restricts the operation to a single node. Empty means the whole graph, in topological (or, for Destroy, reverse topological) order.
-	Node string
+	// Nodes is nil for the whole graph; a non-nil empty list must never silently broaden execution.
+	Nodes []string
+	// Downstream follows both data and ordering dependencies so consumers cannot be omitted by edge kind.
+	Downstream bool
+	// SelectionSpecified preserves explicit false flags so stored executions reject every scope override.
+	SelectionSpecified bool
+	// OnSelection publishes resolved scope before runtime subprocesses, keeping presentation out of the engine.
+	OnSelection func(*graph.Selection, [][]string)
+	selection   *graph.Selection
+	levels      [][]string
 	// AutoApprove skips the interactive approval Apply would otherwise ask for, and is forwarded to `terraform destroy` as -auto-approve. It governs only whether a human is asked; what a node is permitted to do unattended is Approve's job, and the two are checked independently.
 	AutoApprove bool
 	// Approve is the run-wide default approve level (see blueprint.Approve) for nodes that declare none of their own. Empty means blueprint.ApproveSafe.
@@ -35,21 +44,16 @@ func (o Options) parallelism() int {
 }
 
 func (e *Engine) executionLevels(opts Options, reverse bool) ([][]string, error) {
-	if opts.Node != "" {
-		if _, ok := e.Graph.Nodes[opts.Node]; !ok {
-			return nil, fmt.Errorf("unknown node %q", opts.Node)
+	if opts.levels == nil {
+		var err error
+		opts, err = e.resolveSelection(opts)
+		if err != nil {
+			return nil, err
 		}
-		return [][]string{{opts.Node}}, nil
 	}
-
-	levels, err := graph.Levels(e.Graph)
-	if err != nil {
-		return nil, err
-	}
+	levels := append([][]string{}, opts.levels...)
 	if reverse {
-		for i, j := 0, len(levels)-1; i < j; i, j = i+1, j-1 {
-			levels[i], levels[j] = levels[j], levels[i]
-		}
+		slices.Reverse(levels)
 	}
 	return levels, nil
 }
@@ -213,4 +217,37 @@ func markNotRun(runs []NodeRun, levels [][]string, from int) []NodeRun {
 		}
 	}
 	return runs
+}
+
+// resolveSelection freezes membership before runtime checks and keeps every scheduler on the same filtered levels.
+func (e *Engine) resolveSelection(opts Options) (Options, error) {
+	selection, err := graph.Select(e.Graph, opts.Nodes, opts.Downstream)
+	if err != nil {
+		return opts, err
+	}
+	var names []string
+	if selection != nil {
+		names = selection.Names()
+	}
+	levels, err := graph.SelectedLevels(e.Graph, names, false)
+	if err != nil {
+		return opts, err
+	}
+	opts.selection, opts.levels = selection, levels
+	return opts, nil
+}
+
+func (o Options) hasSelectionFlags() bool {
+	return o.SelectionSpecified || o.Nodes != nil || o.Downstream
+}
+
+func (o Options) announceSelection(reverse bool) {
+	if o.OnSelection == nil {
+		return
+	}
+	levels := append([][]string{}, o.levels...)
+	if reverse {
+		slices.Reverse(levels)
+	}
+	o.OnSelection(o.selection, levels)
 }

--- a/internal/engine/runtime_preflight_unix_test.go
+++ b/internal/engine/runtime_preflight_unix_test.go
@@ -125,7 +125,7 @@ edge {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = e.Apply(Options{Node: "b", AutoApprove: true})
+	_, err = e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 	if err == nil || !strings.Contains(err.Error(), "node.a.runtime") || !strings.Contains(err.Error(), "OpenTofu 1.8.0") {
 		t.Fatalf("run error = %v, want upstream file compatibility refusal", err)
 	}
@@ -146,7 +146,7 @@ func TestApply_OldTofuTFOnlyDoesNotProbeVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatal(err)
 	}
 	observed, err := os.ReadFile(calls)
@@ -174,7 +174,7 @@ node "b" { source = "./unselected" }`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatal(err)
 	}
 	observed, err := os.ReadFile(calls)

--- a/internal/engine/saved_execution.go
+++ b/internal/engine/saved_execution.go
@@ -7,17 +7,31 @@ import (
 	"time"
 
 	"github.com/cloudfluent/terragraph/internal/exec"
+	"github.com/cloudfluent/terragraph/internal/graph"
 )
 
 // SavePlans freezes only the current frontier; later inputs must come from real upstream outputs after the reviewed frontier has been applied.
 func (e *Engine) SavePlans(opts Options, continueID string) (record ExecutionRecord, resultErr error) {
+	if continueID != "" && opts.hasSelectionFlags() {
+		return record, fmt.Errorf("--continue already fixes node selection; omit --node and --downstream")
+	}
+	if continueID == "" {
+		var err error
+		opts, err = e.resolveSelection(opts)
+		if err != nil {
+			return record, err
+		}
+		opts.announceSelection(false)
+	}
 	unlock, err := e.lockRun()
 	if err != nil {
 		return record, err
 	}
 	defer unlock()
-	if err := e.checkRuntimeFiles(opts); err != nil {
-		return record, err
+	if continueID == "" {
+		if err := e.checkRuntimeFiles(opts); err != nil {
+			return record, err
+		}
 	}
 	unlockGraph, err := e.lockGraph()
 	if err != nil {
@@ -34,8 +48,16 @@ func (e *Engine) SavePlans(opts Options, continueID string) (record ExecutionRec
 		return record, err
 	}
 	defer s.close()
-	if continueID != "" && opts.Node != "" {
-		return record, fmt.Errorf("--continue already fixes node selection; omit --node")
+	record = s.record
+	if continueID != "" {
+		opts, err = e.storedSelection(opts, s.record)
+		opts.announceSelection(false)
+		if err != nil {
+			return record, err
+		}
+		if err := e.checkRuntimeFiles(opts); err != nil {
+			return record, err
+		}
 	}
 	if s.record.Status != "preparing" && s.record.Status != "ready_for_next_plan" {
 		return record, fmt.Errorf("execution %s is %s; apply its pending plans or start a fresh execution", s.record.ID, s.record.Status)
@@ -151,8 +173,8 @@ func (e *Engine) saveFrontierNode(s *executionSession, name string, opts Options
 
 // ApplySavedPlans applies exactly the stored frontier and never plans or applies downstream nodes in the same invocation.
 func (e *Engine) ApplySavedPlans(id string, opts Options) (runs []NodeRun, resultErr error) {
-	if opts.Node != "" {
-		return nil, fmt.Errorf("--plan already fixes node selection; omit --node")
+	if opts.hasSelectionFlags() {
+		return nil, fmt.Errorf("--plan already fixes node selection; omit --node and --downstream")
 	}
 	if opts.parallelism() > 1 && !opts.AutoApprove {
 		return nil, fmt.Errorf("--parallelism needs --auto-approve")
@@ -172,6 +194,14 @@ func (e *Engine) ApplySavedPlans(id string, opts Options) (runs []NodeRun, resul
 		return nil, err
 	}
 	defer s.close()
+	opts, err = e.storedSelection(opts, s.record)
+	opts.announceSelection(false)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.checkRuntimeFiles(opts); err != nil {
+		return nil, err
+	}
 	if s.record.Status != "waiting_for_apply" {
 		return nil, fmt.Errorf("execution %s is %s; only waiting_for_apply can be applied", id, s.record.Status)
 	}
@@ -394,4 +424,19 @@ func (s *executionSession) noteSavedFailure(name, code string) error {
 		}
 	}
 	return fmt.Errorf("node.%s: absent from execution", name)
+}
+
+// storedSelection uses record membership even for old records whose original selection intent is unknown.
+func (e *Engine) storedSelection(opts Options, record ExecutionRecord) (Options, error) {
+	opts.selection = record.Selection
+	names := make([]string, 0, len(record.Nodes))
+	for _, node := range record.Nodes {
+		names = append(names, node.Name)
+	}
+	levels, err := graph.SelectedLevels(e.Graph, names, false)
+	if err != nil {
+		return opts, err
+	}
+	opts.selection, opts.levels = record.Selection, levels
+	return opts, nil
 }

--- a/internal/engine/saved_execution_real_test.go
+++ b/internal/engine/saved_execution_real_test.go
@@ -106,7 +106,7 @@ func TestSavedExecution_RealFrontierAndExactApplication(t *testing.T) {
 
 func TestSavedExecution_RealChangedSourceRefused(t *testing.T) {
 	e := savedRuntimeFixture(t)
-	record, err := e.SavePlans(Options{Node: "upstream"}, "")
+	record, err := e.SavePlans(Options{Nodes: []string{"upstream"}}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/saved_execution_unix_test.go
+++ b/internal/engine/saved_execution_unix_test.go
@@ -60,7 +60,7 @@ func TestSavedExecution_BlocksOnAnotherUncertainExecution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := e.beginExecution("apply", []string{"cached"})
+	s, err := e.beginExecution("apply", []string{"cached"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/selection_unix_test.go
+++ b/internal/engine/selection_unix_test.go
@@ -1,0 +1,489 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+	"github.com/cloudfluent/terragraph/internal/graph"
+)
+
+func selectionEngine(t *testing.T) *Engine {
+	t.Helper()
+	body := ""
+	for _, name := range []string{"a", "b", "c", "d", "x", "p", "q"} {
+		body += reviewNode(name)
+	}
+	body += `edge {
+ from = node.a.output.id
+ to = node.b.input.input
+}
+edge {
+ from = node.b.output.id
+ to = node.c.input.input
+}
+edge {
+ from = node.x.output.id
+ to = node.c.input.extra
+}
+edge {
+ from = node.c
+ to = node.d
+}
+edge {
+ from = node.p
+ to = node.q
+}
+`
+	e := reviewFixture(t, body)
+	modulePath := filepath.Join(e.BaseDir, "module", "main.tf")
+	src, err := os.ReadFile(modulePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src = append(src, []byte("variable \"extra\" {\n type = string\n default = \"none\"\n}\n")...)
+	if err := os.WriteFile(modulePath, src, 0600); err != nil {
+		t.Fatal(err)
+	}
+	script, err := os.ReadFile(string(e.Binary))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script = bytes.Replace(script, []byte("case \"$1\" in"), []byte(`if [ "$1" = plan ] || [ "$1" = destroy ]; then
+ for arg in "$@"; do
+  case "$arg" in -var-file=*) cp "${arg#-var-file=}" "$TG_SELECTION_DIR/$name.inputs.json" ;; esac
+ done
+fi
+case "$1" in
+version) printf '%s' '{"terraform_version":"1.5.7","platform":"fixture"}'; exit 0 ;;
+apply|destroy) exit 0 ;;`), 1)
+	script = bytes.Replace(script, []byte("case \"$name\" in unchanged|outputonly)"), []byte("case \"$name\" in b|unchanged|outputonly)"), 1)
+	script = bytes.Replace(script, []byte("unchanged) action="), []byte("b|unchanged) action="), 1)
+	if err := os.WriteFile(string(e.Binary), script, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TG_SELECTION_DIR", e.BaseDir)
+	loaded, err := Load(filepath.Join(e.BaseDir, "blueprint.hcl"), e.Binary, e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}
+
+func selectionCalls(t *testing.T, e *Engine) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(e.BaseDir, "calls"))
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertSelectedRuns(t *testing.T, runs []NodeRun, want []string) {
+	t.Helper()
+	names := []string{}
+	for _, r := range runs {
+		names = append(names, r.Node)
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("got = %v, want %v", names, want)
+	}
+}
+
+func TestApply_SelectionReadsExternalInputsAndPlansAfterNoOp(t *testing.T) {
+	e := selectionEngine(t)
+	announced := false
+	opts := Options{Nodes: []string{"b"}, Downstream: true, AutoApprove: true, OnSelection: func(s *graph.Selection, levels [][]string) {
+		if selectionCalls(t, e) != "" {
+			t.Fatal("scope was announced after runtime started")
+		}
+		if !reflect.DeepEqual(s.Names(), []string{"b", "c", "d"}) || len(levels) != 3 {
+			t.Fatalf("got = %+v, %v", s, levels)
+		}
+		announced = true
+	}}
+	runs, err := e.Apply(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSelectedRuns(t, runs, []string{"b", "c", "d"})
+	if !announced || runs[0].Status != StatusUnchanged || runs[1].Status != StatusApplied {
+		t.Fatalf("got = %+v, announced = %t", runs, announced)
+	}
+	calls := selectionCalls(t, e)
+	for _, name := range []string{"a", "x", "p", "q"} {
+		for _, command := range []string{"plan", "apply", "destroy", "init"} {
+			if strings.Contains(calls, name+" "+command+"\n") {
+				t.Fatalf("got = %s, excluded node executed", calls)
+			}
+		}
+	}
+	if strings.Count(calls, "c plan\n") != 1 || strings.Count(calls, "d plan\n") != 1 || !strings.Contains(calls, "a output\n") || !strings.Contains(calls, "x output\n") {
+		t.Fatalf("got = %s", calls)
+	}
+	inputs, err := os.ReadFile(filepath.Join(e.BaseDir, "c.inputs.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var values map[string]any
+	if err := json.Unmarshal(inputs, &values); err != nil {
+		t.Fatal(err)
+	}
+	if values["input"] != "existing" || values["extra"] != "existing" {
+		t.Fatalf("got = %s", inputs)
+	}
+	records, err := e.ListExecutions()
+	if err != nil || len(records) != 1 || records[0].Selection == nil || len(records[0].Nodes) != 3 {
+		t.Fatalf("got = %+v, %v", records, err)
+	}
+}
+
+func TestApply_MultipleSeedsRunConvergenceOnce(t *testing.T) {
+	e := selectionEngine(t)
+	runs, err := e.Apply(Options{Nodes: []string{"x", "b", "b"}, Downstream: true, AutoApprove: true, Parallelism: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Full-graph levels retain x before b, even though a is not selected.
+	assertSelectedRuns(t, runs, []string{"x", "b", "c", "d"})
+	if calls := selectionCalls(t, e); strings.Count(calls, "c plan\n") != 1 || strings.Count(calls, "c apply\n") != 1 {
+		t.Fatalf("got = %s", calls)
+	}
+}
+
+func TestApply_SelectionKeepsDuplicateDataEdges(t *testing.T) {
+	e := selectionEngine(t)
+	path := filepath.Join(e.BaseDir, "blueprint.hcl")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = bytes.ReplaceAll(body, []byte("node.x.output.id"), []byte("node.b.output.id"))
+	if err := os.WriteFile(path, body, 0600); err != nil {
+		t.Fatal(err)
+	}
+	e, err = Load(path, e.Binary, e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := e.Apply(Options{Nodes: []string{"b"}, Downstream: true, AutoApprove: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSelectedRuns(t, runs, []string{"b", "c", "d"})
+	calls := selectionCalls(t, e)
+	if strings.Count(calls, "c plan\n") != 1 || strings.Contains(calls, "x output\n") {
+		t.Fatalf("got = %s", calls)
+	}
+	data, err := os.ReadFile(filepath.Join(e.BaseDir, "c.inputs.json"))
+	if err != nil || !strings.Contains(string(data), `"extra": "existing"`) || !strings.Contains(string(data), `"input": "existing"`) {
+		t.Fatalf("got = %s, %v", data, err)
+	}
+}
+
+func TestDestroy_SelectionReversesOrderAndPreservesPolicy(t *testing.T) {
+	e := selectionEngine(t)
+	runs, err := e.Destroy(Options{Nodes: []string{"b"}, Downstream: true, AutoApprove: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSelectedRuns(t, runs, []string{"d", "c", "b"})
+	calls := selectionCalls(t, e)
+	for _, name := range []string{"a", "x", "p", "q"} {
+		if strings.Contains(calls, name+" destroy\n") {
+			t.Fatalf("got = %s", calls)
+		}
+	}
+	if _, err := e.Destroy(Options{Nodes: []string{"b"}, Downstream: true, Parallelism: 2}); err == nil || !strings.Contains(err.Error(), "--auto-approve") {
+		t.Fatalf("got = %v", err)
+	}
+}
+
+func TestApply_SelectionOutputFailureNeverExpandsScope(t *testing.T) {
+	e := selectionEngine(t)
+	t.Setenv("TG_REVIEW_OUTPUT_FAIL", "1")
+	runs, err := e.Apply(Options{Nodes: []string{"b"}, Downstream: true, AutoApprove: true})
+	if err == nil {
+		t.Fatal("missing outputs accepted")
+	}
+	assertSelectedRuns(t, runs, []string{"b", "c", "d"})
+	if runs[0].Status != StatusFailed || runs[1].Status != StatusNotRun {
+		t.Fatalf("got = %+v", runs)
+	}
+	calls := selectionCalls(t, e)
+	if strings.Contains(calls, " plan\n") || strings.Contains(calls, " apply\n") {
+		t.Fatalf("got = %s", calls)
+	}
+}
+
+func TestSavedExecution_SelectionStaysFixedAcrossFrontiers(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(record.Nodes) != 3 || record.Selection == nil || record.Nodes[0].Phase != "planned" || record.Nodes[1].Phase != "pending" {
+		t.Fatalf("got = %+v", record)
+	}
+	for _, want := range []string{"b", "c", "d"} {
+		runs, err := e.ApplySavedPlans(record.ID, Options{AutoApprove: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSelectedRuns(t, runs, []string{want})
+		if want != "d" {
+			next, err := e.SavePlans(Options{}, record.ID)
+			if err != nil || !reflect.DeepEqual(next.Selection, record.Selection) || len(next.Nodes) != 3 {
+				t.Fatalf("got = %+v, %v", next, err)
+			}
+		}
+	}
+	calls := selectionCalls(t, e)
+	for _, name := range []string{"a", "x", "p", "q"} {
+		if strings.Contains(calls, name+" plan\n") || strings.Contains(calls, name+" apply\n") {
+			t.Fatalf("got = %s", calls)
+		}
+	}
+	for _, name := range []string{"b", "c", "d"} {
+		if strings.Count(calls, name+" plan\n") != 1 {
+			t.Fatalf("got = %s", calls)
+		}
+	}
+}
+
+func TestSavedExecution_SelectionOverridesNeverCallRuntime(t *testing.T) {
+	e := selectionEngine(t)
+	for _, opts := range []Options{{Nodes: []string{"b"}}, {Nodes: []string{""}}, {Downstream: true}, {SelectionSpecified: true}} {
+		if _, err := e.SavePlans(opts, "run-missing"); err == nil || !strings.Contains(err.Error(), "omit --node and --downstream") {
+			t.Fatalf("got = %v", err)
+		}
+		if _, err := e.ApplySavedPlans("run-missing", opts); err == nil || !strings.Contains(err.Error(), "omit --node and --downstream") {
+			t.Fatalf("got = %v", err)
+		}
+	}
+	if calls := selectionCalls(t, e); calls != "" {
+		t.Fatalf("got = %s", calls)
+	}
+}
+
+func TestSavedExecution_ContinuationRuntimeUsesRecordedMembership(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.ApplySavedPlans(record.ID, Options{AutoApprove: true}); err != nil {
+		t.Fatal(err)
+	}
+	// An unrelated module's file requirement would reject this Terraform binary if continuation mistook nil options for all nodes.
+	schema := *e.Graph.Nodes["p"].Schema
+	schema.RequiresTofuFiles = true
+	e.Graph.Nodes["p"].Schema = &schema
+	if _, err := e.SavePlans(Options{}, record.ID); err != nil {
+		t.Fatal(err)
+	}
+	upstreamSchema := *e.Graph.Nodes["x"].Schema
+	upstreamSchema.RequiresTofuFiles = true
+	e.Graph.Nodes["x"].Schema = &upstreamSchema
+	if _, err := e.ApplySavedPlans(record.ID, Options{AutoApprove: true}); err == nil || !strings.Contains(err.Error(), "node.x.runtime") {
+		t.Fatalf("got = %v, want direct upstream compatibility check", err)
+	}
+}
+
+func TestSavedExecution_OldRecordKeepsMembershipWithoutMetadata(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := e.openExecutionStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.close() }()
+	stored, rev, err := readExecutionRecord(e.context(), store, record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored.Selection = nil
+	data, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.write(e.context(), record.ID+".json", data, rev); err != nil {
+		t.Fatal(err)
+	}
+	var selection *graph.Selection
+	runs, err := e.ApplySavedPlans(record.ID, Options{AutoApprove: true, OnSelection: func(s *graph.Selection, _ [][]string) { selection = s }})
+	if err != nil || selection != nil {
+		t.Fatalf("got = %+v, %v", selection, err)
+	}
+	assertSelectedRuns(t, runs, []string{"b"})
+	next, err := e.SavePlans(Options{}, record.ID)
+	if err != nil || next.Selection != nil || len(next.Nodes) != 3 {
+		t.Fatalf("got = %+v, %v", next, err)
+	}
+}
+
+func TestSavedExecution_CorruptSelectionCannotExecuteOrBePublished(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := e.openExecutionStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.close() }()
+	stored, rev, err := readExecutionRecord(e.context(), store, record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored.Selection.Nodes = stored.Selection.Nodes[:1]
+	data, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.write(e.context(), record.ID+".json", data, rev); err != nil {
+		t.Fatal(err)
+	}
+	before := selectionCalls(t, e)
+	if _, err := e.ApplySavedPlans(record.ID, Options{AutoApprove: true}); err == nil || !strings.Contains(err.Error(), "selection") {
+		t.Fatalf("got = %v", err)
+	}
+	if got, err := e.GetExecution(record.ID); err == nil || got.ID != "" {
+		t.Fatalf("got = %+v, %v", got, err)
+	}
+	if calls := selectionCalls(t, e); calls != before {
+		t.Fatalf("got = %s, want %s", calls, before)
+	}
+}
+
+func TestSavedExecution_GraphChangeDoesNotAddNewSuccessors(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(e.BaseDir, "blueprint.hcl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, []byte("edge {\n from = node.d\n to = node.q\n}\n")...)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := Load(path, exec.Binary(e.Binary), e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := changed.ApplySavedPlans(record.ID, Options{AutoApprove: true}); err == nil || !strings.Contains(err.Error(), "graph configuration changed") {
+		t.Fatalf("got = %v", err)
+	}
+	stored, err := e.GetExecution(record.ID)
+	if err != nil || len(stored.Nodes) != 3 {
+		t.Fatalf("got = %+v, %v", stored, err)
+	}
+}
+
+func TestApply_SelectionCannotBypassUnrelatedRecovery(t *testing.T) {
+	e := selectionEngine(t)
+	e, unlock, err := LoadLocked(filepath.Join(e.BaseDir, "blueprint.hcl"), e.Binary, e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	session, err := e.beginExecution("apply", []string{"p"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.transition("p", "indeterminate", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	session.close()
+	runs, err := e.Apply(Options{Nodes: []string{"b"}, Downstream: true, AutoApprove: true})
+	if err == nil || !strings.Contains(err.Error(), "unresolved mutation") || len(runs) != 0 {
+		t.Fatalf("got = %+v, %v", runs, err)
+	}
+	if calls := selectionCalls(t, e); calls != "" {
+		t.Fatalf("got = %s", calls)
+	}
+}
+
+func TestSavedExecution_RemovedNodeStillReportsStoredSelection(t *testing.T) {
+	e := selectionEngine(t)
+	record, err := e.SavePlans(Options{Nodes: []string{"b"}, Downstream: true}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(e.BaseDir, "blueprint.hcl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Replace(string(data), reviewNode("d"), "", 1)
+	body = strings.Replace(body, "edge {\n from = node.c\n to = node.d\n}\n", "", 1)
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := Load(path, e.Binary, e.Stdout, e.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var scope *graph.Selection
+	_, err = changed.ApplySavedPlans(record.ID, Options{AutoApprove: true, OnSelection: func(s *graph.Selection, _ [][]string) { scope = s }})
+	if err == nil || !strings.Contains(err.Error(), "removed from graph") || !reflect.DeepEqual(scope, record.Selection) {
+		t.Fatalf("got = %+v, %v", scope, err)
+	}
+}
+
+func TestReviewPlan_SelectionPreservesIndependentFailureHandling(t *testing.T) {
+	e := reviewFixture(t, reviewNode("failed")+reviewNode("dependent")+reviewNode("created")+reviewNode("unselected")+"edge {\n from = node.failed\n to = node.dependent\n}\n")
+	runs, err := e.ReviewPlan(Options{Nodes: []string{"failed", "created"}, Downstream: true, Parallelism: 2}, false)
+	if err == nil {
+		t.Fatal("provider failure accepted")
+	}
+	assertSelectedRuns(t, runs, []string{"created", "failed", "dependent"})
+	if runs[0].Status != StatusPlanned || runs[1].Status != StatusFailed || runs[2].Status != StatusNotRun {
+		t.Fatalf("got = %+v", runs)
+	}
+	calls := selectionCalls(t, e)
+	if strings.Contains(calls, "unselected ") || strings.Contains(calls, "dependent plan\n") {
+		t.Fatalf("got = %s", calls)
+	}
+}
+
+func TestApply_SelectionReducesIndependentRuntimeCalls(t *testing.T) {
+	for _, selected := range []bool{false, true} {
+		e := selectionEngine(t)
+		opts := Options{AutoApprove: true}
+		want := 7
+		if selected {
+			opts.Nodes = []string{"b"}
+			opts.Downstream = true
+			want = 3
+		}
+		runs, err := e.Apply(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := selectionCalls(t, e)
+		plans, inits := strings.Count(calls, " plan\n"), strings.Count(calls, " init\n")
+		if len(runs) != want || plans != want || inits != want {
+			t.Fatalf("got = %d nodes, %d plans, %d inits; want %d", len(runs), plans, inits, want)
+		}
+		t.Logf("selected=%t nodes=%d plan=%d init=%d apply=%d", selected, len(runs), plans, inits, strings.Count(calls, " apply\n"))
+	}
+}

--- a/internal/engine/sensitive_runtime_unix_test.go
+++ b/internal/engine/sensitive_runtime_unix_test.go
@@ -41,7 +41,11 @@ func TestApply_RuntimeSensitiveInputErrorsWithholdPayload(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					runs, err := e.Apply(Options{Node: node, AutoApprove: true, Parallelism: 2})
+					var nodes []string
+					if node != "" {
+						nodes = []string{node}
+					}
+					runs, err := e.Apply(Options{Nodes: nodes, AutoApprove: true, Parallelism: 2})
 					if metadata == `"sensitive":false,` {
 						if err == nil || !strings.Contains(err.Error(), "PRIVATE_PAYLOAD_KEY") || strings.Contains(err.Error(), "value details withheld") {
 							t.Fatalf("error = %v, want detailed public input error", err)

--- a/internal/engine/snapshot_fallback_unix_test.go
+++ b/internal/engine/snapshot_fallback_unix_test.go
@@ -150,7 +150,7 @@ func TestResolveInputs_SnapshotFallsBackWhenLiveOutputFails(t *testing.T) {
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
 
 	// Applies only b: a is upstream, standing, and unreadable live.
-	if _, err := e.Apply(Options{Node: "b", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestResolveInputs_LiveOutputBeatsStaleSnapshot(t *testing.T) {
 	writeFallbackSnapshot(t, e, "a", "stale-snap")
 	t.Setenv("TG_OUTPUT_FIRST", "live")
 
-	if _, err := e.Apply(Options{Node: "b", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
@@ -203,7 +203,7 @@ func TestResolveInputs_OptOutFailsDespiteSnapshotFile(t *testing.T) {
 	writeFallbackSnapshot(t, e, "a", "snap")
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
 
-	_, err := e.Apply(Options{Node: "b", AutoApprove: true})
+	_, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 	if err == nil {
 		t.Fatal("Apply succeeded with an opted-out graph and a failing live read, want the original resolution error")
 	}
@@ -227,7 +227,7 @@ func TestResolveInputs_CorruptSnapshotIsNotAnError(t *testing.T) {
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
 
-	_, err := e.Apply(Options{Node: "b", AutoApprove: true})
+	_, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 	if err == nil {
 		t.Fatal("Apply succeeded on a corrupt snapshot and a failing live read, want the original resolution error")
 	}

--- a/internal/engine/snapshot_runtime_unix_test.go
+++ b/internal/engine/snapshot_runtime_unix_test.go
@@ -53,7 +53,7 @@ func snapshotRefusedAfterTofuSensitivityChanges(t *testing.T, ext string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("publish public snapshot: %v", err)
 	}
 	public, err := os.ReadFile(e.snapshotPath("a"))
@@ -125,11 +125,11 @@ func TestApply_LegacySnapshotNeedsRuntimeVerifiedRepublishing(t *testing.T) {
 		t.Fatal("reading a legacy snapshot changed its file")
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "")
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("republish: %v", err)
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
-	if _, err := e.Apply(Options{Node: "b", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true}); err != nil {
 		t.Fatalf("fallback after republishing: %v", err)
 	}
 	if !strings.Contains(varfileSeen(t, e, "b"), "first") {
@@ -190,7 +190,7 @@ func TestApply_RuntimeSensitiveValuesFlowLiveButNotThroughSnapshot(t *testing.T)
 
 func TestApply_SnapshotRewriteRemovesRuntimeSensitiveValue(t *testing.T) {
 	e := loadFallbackEngine(t, true)
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("initial Apply: %v", err)
 	}
 	path := filepath.Join(e.BaseDir, "terraform-fake")
@@ -202,7 +202,7 @@ func TestApply_SnapshotRewriteRemovesRuntimeSensitiveValue(t *testing.T) {
 	if err := os.WriteFile(path, script, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("sensitive Apply: %v", err)
 	}
 	assertSnapshotWithheld(t, e, "a", "consumed")

--- a/internal/engine/snapshot_sensitive_unix_test.go
+++ b/internal/engine/snapshot_sensitive_unix_test.go
@@ -63,7 +63,7 @@ func assertSnapshotWithheld(t *testing.T, e *Engine, node, output string) []byte
 // assertSnapshotRefused pins the consumer diagnostic, remedy, and original subprocess failure without exposing the withheld value.
 func assertSnapshotRefused(t *testing.T, e *Engine) {
 	t.Helper()
-	_, err := e.Apply(Options{Node: "b", AutoApprove: true})
+	_, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 	if err == nil {
 		t.Fatal("Apply reused a sensitive snapshot value, want a withheld-output error")
 	}
@@ -124,7 +124,7 @@ func TestResolveInputs_SensitiveLegacySnapshotIsRefused(t *testing.T) {
 
 func TestResolveInputs_PublishedWithheldSnapshotExplainsFailure(t *testing.T) {
 	e := setSnapshotOutputSensitive(t, loadFallbackEngine(t, true), "consumed", true)
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("publishing Apply: %v", err)
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
@@ -135,7 +135,7 @@ func TestResolveInputs_SensitiveLiveOutputStillWorks(t *testing.T) {
 	e := setSnapshotOutputSensitive(t, loadFallbackEngine(t, true), "consumed", true)
 	writeFallbackSnapshot(t, e, "a", "stale-snapshot-fixture")
 	t.Setenv("TG_OUTPUT_FIRST", "live-sensitive-fixture")
-	if _, err := e.Apply(Options{Node: "b", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if !strings.Contains(varfileSeen(t, e, "b"), "live-sensitive-fixture") {
@@ -217,7 +217,7 @@ func TestResolveInputs_UnknownSensitivityLegacySnapshotIsRefused(t *testing.T) {
 
 func TestResolveInputs_WithheldSnapshotNeedsRepublishingAfterSensitivityRemoval(t *testing.T) {
 	e := setSnapshotOutputSensitive(t, loadFallbackEngine(t, true), "consumed", true)
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("publishing sensitive Apply: %v", err)
 	}
 	e = setSnapshotOutputSensitive(t, e, "consumed", false)
@@ -226,11 +226,11 @@ func TestResolveInputs_WithheldSnapshotNeedsRepublishingAfterSensitivityRemoval(
 
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "")
 	t.Setenv("TG_OUTPUT_LATER", "republished-public-fixture")
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("republishing non-sensitive Apply: %v", err)
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
-	if _, err := e.Apply(Options{Node: "b", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true}); err != nil {
 		t.Fatalf("Apply after republishing: %v", err)
 	}
 	if !strings.Contains(varfileSeen(t, e, "b"), "republished-public-fixture") {
@@ -259,7 +259,7 @@ func TestResolveInputs_UnusableSnapshotPreservesLiveErrorForSensitiveOutput(t *t
 				}
 			}
 			t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
-			_, err := e.Apply(Options{Node: "b", AutoApprove: true})
+			_, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 			if err == nil || !strings.Contains(err.Error(), `reading existing outputs from upstream node "a" failed`) || strings.Contains(err.Error(), "withheld") {
 				t.Fatal("unusable snapshot replaced the original live-read diagnostic")
 			}
@@ -278,7 +278,7 @@ func TestApply_SensitiveSnapshotOptOutLeavesExistingFileUntouched(t *testing.T) 
 	if err != nil {
 		t.Fatalf("reading original snapshot: %v", err)
 	}
-	if _, err := e.Apply(Options{Node: "a", AutoApprove: true}); err != nil {
+	if _, err := e.Apply(Options{Nodes: []string{"a"}, AutoApprove: true}); err != nil {
 		t.Fatalf("opted-out Apply: %v", err)
 	}
 	after, err := os.ReadFile(e.snapshotPath("a"))
@@ -286,7 +286,7 @@ func TestApply_SensitiveSnapshotOptOutLeavesExistingFileUntouched(t *testing.T) 
 		t.Fatal("opted-out Apply changed the existing snapshot")
 	}
 	t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
-	_, err = e.Apply(Options{Node: "b", AutoApprove: true})
+	_, err = e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 	if err == nil || !strings.Contains(err.Error(), `reading existing outputs from upstream node "a" failed`) || strings.Contains(err.Error(), "withheld") {
 		t.Fatal("opted-out Apply consulted a sensitive snapshot")
 	}
@@ -307,7 +307,7 @@ func TestResolveInputs_StructurallyCorruptSnapshotPreservesLiveError(t *testing.
 				t.Fatalf("writing structurally corrupt snapshot: %v", err)
 			}
 			t.Setenv("TG_OUTPUT_FAIL_NODE", "a")
-			_, err := e.Apply(Options{Node: "b", AutoApprove: true})
+			_, err := e.Apply(Options{Nodes: []string{"b"}, AutoApprove: true})
 			var exitErr *osexec.ExitError
 			if !errors.As(err, &exitErr) {
 				t.Fatal("structurally corrupt snapshot discarded the live output error chain")

--- a/internal/graph/dot.go
+++ b/internal/graph/dot.go
@@ -32,3 +32,51 @@ func DOT(g *Graph) string {
 	b.WriteString("}\n")
 	return b.String()
 }
+
+// SelectionDOT includes boundary context without mutating the graph used by input resolution and validation.
+func SelectionDOT(g *Graph, selection *Selection) string {
+	if selection == nil {
+		return DOT(g)
+	}
+	selected := map[string]bool{}
+	visible := map[string]bool{}
+	for _, n := range selection.Nodes {
+		selected[n.Node] = true
+		visible[n.Node] = true
+	}
+	for _, e := range selection.BoundaryEdges {
+		visible[e.From.Node] = true
+		visible[e.To.Node] = true
+	}
+	names := make([]string, 0, len(visible))
+	for name := range visible {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString("digraph terragraph {\n  rankdir=LR;\n  label=\"selected: black; not selected: gray (context only)\";\n")
+	for _, name := range names {
+		if selected[name] {
+			fmt.Fprintf(&b, "  %q [color=black];\n", name)
+		} else {
+			fmt.Fprintf(&b, "  %q [color=gray, fontcolor=gray, label=%q];\n", name, name+" (not selected)")
+		}
+	}
+	for _, e := range g.Edges {
+		if !selected[e.From.Node] && !selected[e.To.Node] {
+			continue
+		}
+		style, label := "solid", e.From.Name+" -> "+e.To.Name
+		if !e.IsDataEdge() {
+			style, label = "dashed", "ordering"
+		}
+		color := "black"
+		if selected[e.From.Node] != selected[e.To.Node] {
+			color = "gray"
+			label += " (not selected boundary)"
+		}
+		fmt.Fprintf(&b, "  %q -> %q [style=%s, color=%s, label=%q];\n", e.From.Node, e.To.Node, style, color, label)
+	}
+	b.WriteString("}\n")
+	return b.String()
+}

--- a/internal/graph/selection.go
+++ b/internal/graph/selection.go
@@ -1,0 +1,243 @@
+package graph
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+// Selection preserves why leaves were selected without retaining input values or changing the source graph.
+type Selection struct {
+	SchemaVersion int              `json:"schema_version"`
+	Mode          string           `json:"mode"`
+	Requested     []string         `json:"requested"`
+	Nodes         []SelectionNode  `json:"nodes"`
+	BoundaryEdges []blueprint.Edge `json:"boundary_edges"`
+}
+
+// SelectionNode records immediate predecessors instead of exponentially many reachability paths.
+type SelectionNode struct {
+	Node   string   `json:"node"`
+	Reason string   `json:"reason"`
+	Via    []string `json:"via"`
+}
+
+// Select resolves exact leaf names; nil requests mean the default whole graph, while an empty non-nil request is invalid.
+func Select(g *Graph, requested []string, downstream bool) (*Selection, error) {
+	if requested == nil && !downstream {
+		return nil, nil
+	}
+	if len(requested) == 0 {
+		return nil, fmt.Errorf("selection: specify at least one --node <leaf> with --downstream")
+	}
+	seeds := append([]string{}, requested...)
+	sort.Strings(seeds)
+	seeds = slices.Compact(seeds)
+	selected := map[string]bool{}
+	requestedSet := map[string]bool{}
+	for _, name := range seeds {
+		if name == "" {
+			return nil, fmt.Errorf("selection: empty --node; specify an exact leaf name")
+		}
+		if g.Nodes[name] == nil {
+			examples := []string{}
+			for leaf := range g.Nodes {
+				if strings.HasPrefix(leaf, name+".") {
+					examples = append(examples, leaf)
+				}
+			}
+			sort.Strings(examples)
+			if len(examples) > 0 {
+				return nil, fmt.Errorf("node.%s: select a qualified leaf such as --node %s; group selection is not supported", name, examples[0])
+			}
+			return nil, fmt.Errorf("unknown node %q; use an exact leaf name and repeat --node for multiple nodes (commas are not separators)", name)
+		}
+		selected[name] = true
+		requestedSet[name] = true
+	}
+	if downstream {
+		queue := append([]string{}, seeds...)
+		for i := 0; i < len(queue); i++ {
+			for _, name := range g.Out[queue[i]] {
+				if !selected[name] {
+					selected[name] = true
+					queue = append(queue, name)
+				}
+			}
+		}
+	}
+	s := &Selection{SchemaVersion: 1, Mode: "exact", Requested: seeds, Nodes: []SelectionNode{}, BoundaryEdges: []blueprint.Edge{}}
+	if downstream {
+		s.Mode = "downstream"
+	}
+	names := make([]string, 0, len(selected))
+	for name := range selected {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		n := SelectionNode{Node: name, Reason: "requested", Via: []string{}}
+		if !requestedSet[name] {
+			n.Reason = "downstream"
+			for _, parent := range g.In[name] {
+				if selected[parent] {
+					n.Via = append(n.Via, parent)
+				}
+			}
+			sort.Strings(n.Via)
+			n.Via = slices.Compact(n.Via)
+		}
+		s.Nodes = append(s.Nodes, n)
+	}
+	for _, edge := range g.Edges {
+		if selected[edge.From.Node] != selected[edge.To.Node] {
+			s.BoundaryEdges = append(s.BoundaryEdges, edge)
+		}
+	}
+	sort.Slice(s.BoundaryEdges, func(i, j int) bool {
+		return compareBoundaryEdges(s.BoundaryEdges[i], s.BoundaryEdges[j]) < 0
+	})
+	return s, nil
+}
+
+func compareBoundaryEdges(a, b blueprint.Edge) int {
+	return slices.Compare([]string{a.From.Node, a.From.Name, a.To.Node, a.To.Name, edgeKind(a)}, []string{b.From.Node, b.From.Name, b.To.Node, b.To.Name, edgeKind(b)})
+}
+
+func edgeKind(e blueprint.Edge) string {
+	if e.IsDataEdge() {
+		return "data"
+	}
+	return "ordering"
+}
+
+// SelectedLevels filters the original schedule, preserving full-graph ordering even when omitted predecessors leave gaps.
+func SelectedLevels(g *Graph, names []string, reverse bool) ([][]string, error) {
+	levels, err := Levels(g)
+	if err != nil {
+		return nil, err
+	}
+	if names == nil {
+		if reverse {
+			slices.Reverse(levels)
+		}
+		return levels, nil
+	}
+	selected := map[string]bool{}
+	for _, name := range names {
+		if g.Nodes[name] == nil {
+			return nil, fmt.Errorf("node.%s: removed from graph; create a fresh plan", name)
+		}
+		selected[name] = true
+	}
+	out := [][]string{}
+	for _, level := range levels {
+		kept := []string{}
+		for _, name := range level {
+			if selected[name] {
+				kept = append(kept, name)
+			}
+		}
+		if len(kept) > 0 {
+			out = append(out, kept)
+		}
+	}
+	if reverse {
+		slices.Reverse(out)
+	}
+	return out, nil
+}
+
+// Names returns an explicit membership list so an empty resolved selection cannot become a whole-graph run.
+func (s *Selection) Names() []string {
+	names := make([]string, 0, len(s.Nodes))
+	for _, n := range s.Nodes {
+		names = append(names, n.Node)
+	}
+	return names
+}
+
+// ValidateMembership rejects corrupt stored metadata without using it to widen authoritative record membership.
+func (s *Selection) ValidateMembership(names []string) error {
+	invalid := func() error {
+		return fmt.Errorf("execution selection is incompatible or inconsistent with recorded nodes; restore a valid record")
+	}
+	if s.SchemaVersion != 1 || (s.Mode != "exact" && s.Mode != "downstream") || len(s.Requested) == 0 || s.Nodes == nil || s.BoundaryEdges == nil {
+		return invalid()
+	}
+	members := map[string]bool{}
+	for _, name := range names {
+		if members[name] || name == "" {
+			return invalid()
+		}
+		members[name] = true
+	}
+	if len(s.Nodes) != len(members) || !slices.IsSorted(s.Requested) {
+		return invalid()
+	}
+	seeds := map[string]bool{}
+	for _, name := range s.Requested {
+		if !members[name] || seeds[name] {
+			return invalid()
+		}
+		seeds[name] = true
+	}
+	seen := map[string]bool{}
+	for i, n := range s.Nodes {
+		if !members[n.Node] || seen[n.Node] || n.Via == nil || (i > 0 && s.Nodes[i-1].Node >= n.Node) {
+			return invalid()
+		}
+		seen[n.Node] = true
+		if seeds[n.Node] {
+			if n.Reason != "requested" || len(n.Via) != 0 {
+				return invalid()
+			}
+		} else {
+			if s.Mode != "downstream" || n.Reason != "downstream" || len(n.Via) == 0 || !slices.IsSorted(n.Via) {
+				return invalid()
+			}
+			for j, p := range n.Via {
+				if !members[p] || p == n.Node || (j > 0 && n.Via[j-1] == p) {
+					return invalid()
+				}
+			}
+		}
+	}
+	reachable := map[string]bool{}
+	for name := range seeds {
+		reachable[name] = true
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, n := range s.Nodes {
+			for _, p := range n.Via {
+				if reachable[p] && !reachable[n.Node] {
+					reachable[n.Node] = true
+					changed = true
+				}
+			}
+		}
+	}
+	if len(reachable) != len(members) {
+		return invalid()
+	}
+	for i, edge := range s.BoundaryEdges {
+		if i > 0 && compareBoundaryEdges(s.BoundaryEdges[i-1], edge) > 0 {
+			return invalid()
+		}
+		if edge.From.Node == "" || edge.To.Node == "" || members[edge.From.Node] == members[edge.To.Node] {
+			return invalid()
+		}
+		if edge.IsDataEdge() {
+			if edge.From.Kind != blueprint.PortOutput || edge.To.Kind != blueprint.PortInput || edge.From.Name == "" || edge.To.Name == "" {
+				return invalid()
+			}
+		} else if edge.From.IsPort() || edge.To.IsPort() || edge.From.Name != "" || edge.To.Name != "" {
+			return invalid()
+		}
+	}
+	return nil
+}

--- a/internal/graph/selection_test.go
+++ b/internal/graph/selection_test.go
@@ -1,0 +1,177 @@
+package graph
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func selectionFixture(t *testing.T) *Graph {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "module", "main.tf"), "terraform {\n backend \"local\" {}\n}\noutput \"out\" { value = \"v\" }\nvariable \"in\" { default = \"\" }\nvariable \"extra\" { default = \"\" }\n")
+	body := ""
+	for _, name := range []string{"a", "b", "c", "d", "x", "p", "q"} {
+		body += "node \"" + name + "\" { source = \"./module\" }\n"
+	}
+	body += `edge {
+ from = node.a.output.out
+ to = node.b.input.in
+}
+edge {
+ from = node.b.output.out
+ to = node.c.input.in
+}
+edge {
+ from = node.x.output.out
+ to = node.c.input.extra
+}
+edge {
+ from = node.c
+ to = node.d
+}
+edge {
+ from = node.p
+ to = node.q
+}
+`
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), body)
+	return parseAndBuild(t, root)
+}
+
+func TestSelect_DownstreamPreservesBoundaryAndGraph(t *testing.T) {
+	g := selectionFixture(t)
+	before, _ := json.Marshal(g)
+	s, err := Select(g, []string{"b"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Names(); !reflect.DeepEqual(got, []string{"b", "c", "d"}) {
+		t.Fatalf("got = %v, want b c d", got)
+	}
+	if !reflect.DeepEqual(s.Nodes[2].Via, []string{"c"}) || len(s.BoundaryEdges) != 2 {
+		t.Fatalf("got = %+v", s)
+	}
+	levels, err := SelectedLevels(g, s.Names(), false)
+	if err != nil || !reflect.DeepEqual(levels, [][]string{{"b"}, {"c"}, {"d"}}) {
+		t.Fatalf("got = %v, %v", levels, err)
+	}
+	dot := SelectionDOT(g, s)
+	for _, want := range []string{"a (not selected)", "x (not selected)", "style=dashed", `"c" -> "d"`} {
+		if !strings.Contains(dot, want) {
+			t.Fatalf("got = %s, want %q", dot, want)
+		}
+	}
+	if strings.Contains(dot, `"p"`) || strings.Contains(dot, `"q"`) {
+		t.Fatalf("got = %s, want no unrelated nodes", dot)
+	}
+	after, _ := json.Marshal(g)
+	if string(before) != string(after) {
+		t.Fatal("selection mutated the source graph")
+	}
+}
+
+func TestSelect_MultipleSeedsAreDeterministic(t *testing.T) {
+	g := selectionFixture(t)
+	a, err := Select(g, []string{"x", "b", "b"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Select(g, []string{"b", "x"}, true)
+	if err != nil || !reflect.DeepEqual(a, b) {
+		t.Fatalf("got = %+v, %v, want %+v", b, err, a)
+	}
+	if !reflect.DeepEqual(a.Nodes[1].Via, []string{"b", "x"}) {
+		t.Fatalf("got = %+v", a.Nodes)
+	}
+}
+
+func TestSelect_ExactShowsOutgoingBoundary(t *testing.T) {
+	g := selectionFixture(t)
+	s, err := Select(g, []string{"b"}, false)
+	if err != nil || len(s.Nodes) != 1 || len(s.BoundaryEdges) != 2 {
+		t.Fatalf("got = %+v, %v", s, err)
+	}
+	if s.BoundaryEdges[1].To.Node != "c" {
+		t.Fatalf("got = %+v", s.BoundaryEdges)
+	}
+	s, err = Select(g, []string{"d"}, false)
+	if err != nil || len(s.BoundaryEdges) != 1 || s.BoundaryEdges[0].IsDataEdge() {
+		t.Fatalf("got = %+v, %v", s, err)
+	}
+}
+
+func TestSelectedLevels_CompactsGapsAndReverses(t *testing.T) {
+	g := selectionFixture(t)
+	levels, err := SelectedLevels(g, []string{"a", "d"}, true)
+	if err != nil || !reflect.DeepEqual(levels, [][]string{{"d"}, {"a"}}) {
+		t.Fatalf("got = %v, %v", levels, err)
+	}
+	levels, err = SelectedLevels(g, []string{}, false)
+	if err != nil || len(levels) != 0 {
+		t.Fatalf("got = %v, %v, want empty selection", levels, err)
+	}
+}
+
+func TestSelect_InvalidSeedsNeverFallBackToAll(t *testing.T) {
+	g := selectionFixture(t)
+	for _, seeds := range [][]string{{}, {""}, {"b", "missing"}, {"b,x"}, {"B"}, {" b"}} {
+		s, err := Select(g, seeds, false)
+		if err == nil || s != nil || !strings.Contains(err.Error(), ";") && !strings.Contains(err.Error(), "specify") {
+			t.Fatalf("seeds = %q, got = %+v, %v", seeds, s, err)
+		}
+	}
+	if s, err := Select(g, nil, true); err == nil || s != nil {
+		t.Fatalf("got = %+v, %v", s, err)
+	}
+	if s, err := Select(g, nil, false); err != nil || s != nil {
+		t.Fatalf("got = %+v, %v", s, err)
+	}
+}
+
+func TestSelect_QualifiedLeafDoesNotSelectSibling(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "module", "main.tf"), "terraform {\n backend \"local\" {}\n}\n")
+	writeFixtureFile(t, filepath.Join(root, "group", "group.hcl"), `group "g" {
+ node "cluster" { source = "../module" }
+ node "other" { source = "../module" }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `use "g" {
+ as = "checkout"
+ source = "./group"
+}`)
+	g := parseAndBuild(t, root)
+	s, err := Select(g, []string{"checkout.cluster"}, true)
+	if err != nil || !reflect.DeepEqual(s.Names(), []string{"checkout.cluster"}) {
+		t.Fatalf("got = %+v, %v", s, err)
+	}
+	if _, err := Select(g, []string{"checkout"}, false); err == nil || !strings.Contains(err.Error(), "checkout.cluster") {
+		t.Fatalf("got = %v", err)
+	}
+}
+
+func TestSelection_RejectsCorruptMembership(t *testing.T) {
+	g := selectionFixture(t)
+	for _, mutate := range []func(*Selection){
+		func(s *Selection) { s.SchemaVersion = 2 },
+		func(s *Selection) { s.Nodes = s.Nodes[:1] },
+		func(s *Selection) { s.Requested = []string{"p"} },
+		func(s *Selection) { s.Nodes[1].Via = []string{"p"} },
+		func(s *Selection) { s.Nodes[1].Via = []string{"d"}; s.Nodes[2].Via = []string{"c"} },
+		func(s *Selection) { s.BoundaryEdges[0].From.Node = "b" },
+	} {
+		s, err := Select(g, []string{"b"}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ValidateMembership([]string{"b", "c", "d"}); err != nil {
+			t.Fatal(err)
+		}
+		mutate(s)
+		if err := s.ValidateMembership([]string{"b", "c", "d"}); err == nil {
+			t.Fatalf("accepted corrupt metadata: %+v", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Users can now select a network node and its downstream services in one command, preview the scope, and execute only those leaves while reading existing outputs from producers outside the selection.

- Add repeatable exact `--node` selection and recursive `--downstream` expansion to `graph`, `plan`, `apply`, and `destroy`, following both data and ordering edges. Preserve the full graph for validation and input resolution, filter its existing levels, and reverse those levels for destroy.
- Show inclusion reasons and boundary edges in text, optional versioned JSON selection metadata, and DOT context. Execution summaries precede runtime subprocesses; JSON remains a single result object, including resolved selection on preparation failures.
- Persist selection metadata alongside authoritative execution membership. Saved apply and continuation retain that membership, reject selection overrides (including `--downstream=false`), and scope runtime preflight to recorded nodes and direct data producers. Records without metadata remain supported; inconsistent metadata blocks execution.

Compatibility: a single `--node` still selects one leaf, but now adds a scope summary. Repeated `--node` flags now select a union instead of retaining only the last value. Commands without selection flags keep their existing output. `output`, `status`, `vendor`, and `run` retain their single-node interfaces.

## Verification

- [x] `make check` passes locally (fmt, lint, docs, build, test)

The final `make check` completed successfully, including the full Go race suite and VS Code integration tests. Output excerpts:

```text
$ make check
...
0 issues.
...
ok  github.com/cloudfluent/terragraph/internal/cli     34.243s
ok  github.com/cloudfluent/terragraph/internal/engine  83.337s
ok  github.com/cloudfluent/terragraph/internal/graph   2.622s
...
PASS contracts.hcl: completion metadata, definition, unsaved diagnostics
PASS components.hcl: completion metadata, definition, unsaved diagnostics
Exit code:   0
```

Representative CLI reproduction:

```text
$ ./terragraph --blueprint examples/group graph --node checkout.cluster --downstream
selection: downstream
requested: checkout.cluster
selected: checkout.cluster, checkout.nodegroup
  checkout.cluster: requested
  checkout.nodegroup: downstream of checkout.cluster
boundary edges (one endpoint not selected):
  vpc.output.vpc_id -> checkout.cluster.input.vpc_id (data)
level 1: checkout.cluster
level 2: checkout.nodegroup
```

The subprocess-recording fixture confirms 7 nodes / 7 plans / 7 inits / 6 applies for a whole-graph run, versus 3 nodes / 3 plans / 3 inits / 2 applies for `b --downstream`. Excluded nodes receive no plan/apply/destroy calls. This verifies scope reduction with a test runtime, not real-provider performance.

Both cross-compilation commands also exited successfully without output:

```sh
GOOS=windows GOARCH=amd64 go build -o /tmp/terragraph-selection-windows.exe ./cmd/terragraph
GOOS=linux GOARCH=amd64 go build -o /tmp/terragraph-selection-linux ./cmd/terragraph
```

## Checklist

- [x] Tests added or updated for the behavior change
- [x] `docs/*.md` updated if this changes blueprint semantics, CLI flags, or an example's output (see [CONTRIBUTING.md](../CONTRIBUTING.md))

Added 33 selection tests covering reachability, convergence, external inputs, no-op predecessors, failure handling, JSON/text/DOT, saved frontiers, legacy/corrupt records, and validation/recovery barriers. Updated execution, group, and saved-execution documentation and regenerated CLI help with `make docs`.

**PR title, not this body, becomes the commit message on `main` (squash-merge).** It follows `type: summary`.
