### PR TITLE
docs: add complete multi-account AWS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ See [docs/](docs/README.md) for the blueprint model, groups, vendoring, the exec
 
 ## Examples
 
-Self-contained and cloud-credential-free (`random`/`local` providers only). Clone and run directly, each with its own README:
+Self-contained and cloud-credential-free (built-in resources or `random`/`local` providers only). Clone and run directly, each with its own README:
 
 - [`examples/basic`](examples/basic): one node feeding two independent downstream nodes (wiring, parallel execution, skipping unchanged nodes).
 - [`examples/reuse`](examples/reuse): the same module instantiated twice, proving the local state default isolates each node.
 - [`examples/group`](examples/group): a group instantiated twice via `use`, proving expansion, export wiring, and per-instance state isolation.
 - [`examples/contracts`](examples/contracts): producer and consumer declarations checked against an edge and the modules' schemas.
 - [`examples/vendored`](examples/vendored): a node sourced from a remote git address, showing the vendor workflow.
+- [`examples/compelete`](examples/compelete): a 63-node AWS multi-account landscape with dev/stg/prd VPCs, EKS, data services, nested DRY groups, enforced contracts, and executable lifecycle labs; uses only built-in resources, with no provider downloads.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ terragraph apply
 
 `validate` checks the blueprint against its modules, `graph` shows execution order, and `apply` plans and asks for confirmation as it reaches each changed node. Add `--tofu` to use OpenTofu. The example may download providers during initialization.
 
+For a larger walkthrough, the [complete AWS landscape](../examples/compelete) models six accounts, seven VPCs, three EKS platforms, and six applications using only built-in local fixtures. It combines nested groups and enforced contracts with runnable saved-plan, native-operation, and offline-vendoring labs.
+
 For a new graph, `apply` can create upstream resources and pass their outputs to downstream nodes in the same run. `plan` reads existing upstream outputs, so it cannot preview a consumer whose required output is unavailable, or propagate upstream's newly planned values. Read the [planning limitation](execution-model.md#known-limitation) before using a whole-graph plan as a change preview.
 
 For your own modules, start with [nodes, edges, and literal inputs](blueprint.md). If a node uses a remote source, run [vendoring](vendoring.md) before validation or execution. For a blueprint split across files, run commands in its directory or select another directory with `--blueprint <directory>`; see [files and loading](blueprint.md#files-and-loading).

--- a/examples/compelete/.gitignore
+++ b/examples/compelete/.gitignore
@@ -1,0 +1,3 @@
+# Read-only observation requires a lockfile even when all resources are built in.
+!modules/*/.terraform.lock.hcl
+__pycache__/

--- a/examples/compelete/README.md
+++ b/examples/compelete/README.md
@@ -216,6 +216,22 @@ Change dev's checkout image tag in `environments.hcl` and apply the graph to
 observe downstream propagation. Leave an unchanged environment alone; a
 leaf-only apply will not update its release or the final landscape for you.
 
+Repeat `--node` to select several exact leaves, and add `--downstream` to
+include their successors across data and ordering edges:
+
+```sh
+../../terragraph graph --node dev.checkout.deployment --node dev.payments.deployment --downstream
+../../terragraph apply --node dev.checkout.deployment --node dev.payments.deployment --downstream --auto-approve --parallelism 4
+```
+
+This selects four leaves: both dev deployments, `dev.release`, and
+`landscape`. The boundary summary shows that landscape also needs existing
+outputs from `stg.release` and `prd.release`; neither environment is applied.
+Upstream dependencies are never included automatically. A group name such
+as `dev` is not a valid leaf selector. For saved execution, supply selection
+flags only on the initial `plan --save`; continuation and saved apply keep
+the recorded membership.
+
 The default `safe` policy permits create/update and refuses replacement.
 Changing a VPC CIDR triggers replacement in this fixture. `--auto-approve`
 does not bypass that refusal. `--approve none` can reject all resource
@@ -289,7 +305,7 @@ dependencies. The native fixture execution requires no network access.
 
 | Mode | Exercises |
 |---|---|
-| `smoke` (default) | Validation, 63-node parallel bootstrap, idempotency, warmed plan, six unique environment VPCs, output/status, sensitive redaction/snapshots, exact leaf selection, runtime precondition, contract rejection, replacement refusal, saved leaf, production destroy refusal, reverse teardown |
+| `smoke` (default) | Validation, 63-node parallel bootstrap, idempotency, warmed plan, six unique environment VPCs, output/status, sensitive redaction/snapshots, exact and downstream selection with boundary inputs, runtime precondition, contract rejection, replacement refusal, saved leaf, production destroy refusal, reverse teardown |
 | `saved` | Fresh 12-frontier reviewed bootstrap, continuation, cancellation, pruning, teardown |
 | `native` | Scoped init, console, state list/show/pull/mv/rm, import, and archived native backup export, using only the organization fixture |
 | `vendor` | Local Git upstream, pinned commit and source subdirectory, nested group leaves, custom vendor directory/manifest, exclusions, one-leaf fetch, skip, forced refresh, apply/destroy |
@@ -311,6 +327,7 @@ running any consumers. The native lab verifies that reconciliation step.
 |---|---|
 | Directory loading, nested groups, exports, fan-out, literal inputs, source reuse | Main 63-node graph |
 | Scalar/multi-input data edges and node/group ordering | Main graph |
+| Repeated exact selectors, downstream union, selection reasons and boundary inputs | Day-two walkthrough and smoke graph/apply assertions |
 | Strict type/nullability/sensitivity contracts | Every main-graph data connection |
 | Per-instance env and leaf overrides | Environment/account `env`, nested platform `env`, system-pool override |
 | State and `TF_DATA_DIR` isolation, temporary tfvars, local process lock | Real execution, with state/source checks in verifier |

--- a/examples/compelete/README.md
+++ b/examples/compelete/README.md
@@ -1,0 +1,371 @@
+# Complete AWS landscape, without AWS
+
+This example models six AWS member accounts, seven VPCs, three EKS platforms,
+and six applications using **63 independent roots in 12 execution levels**.
+The directory is named `compelete` intentionally to match the requested example path.
+
+Every root is a checked-in local fixture using the built-in `terraform_data`
+resource. Terraform/OpenTofu really initializes isolated backends, plans,
+applies, reads outputs, and destroys state. The AWS identifiers and service
+settings are simulated data. There are no AWS, Kubernetes, Helm, random, or
+local provider downloads, remote Terraform modules, provisioners, containers,
+cloud API calls, or credentials. No EKS cluster or AWS resource is created.
+
+Use Terraform **>= 1.4, < 2.0** or OpenTofu **>= 1.6, < 2.0** on PATH. The
+fixtures use `.tf` syntax common to both. The walkthrough was exercised with
+Terraform 1.5.7 and OpenTofu 1.11.0. Kubernetes `1.34` is sample input, not an
+assertion about currently supported EKS versions. Local default-workspace
+state is the only backend used by the runnable example.
+
+`terraform_data` is available without an external provider installation;
+see the [Terraform resource reference](https://developer.hashicorp.com/terraform/language/resources/terraform-data)
+and [OpenTofu built-in provider](https://opentofu.org/docs/language/providers/builtin/).
+The comment-only `.terraform.lock.hcl` files intentionally record no provider
+selections: Terragraph's read-only output/status preparation still requires
+a lockfile to exist. Keep those files with the example.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    org[Organization: naming, region, tags, DNS suffix]
+    security[Security account: guardrails and audit archive]
+    network[Network account: hub VPC and Transit Gateway / RAM]
+    shared[Shared account: ECR and DNS]
+    org --> security
+    org --> network
+    org --> shared
+    security --> shared
+    network --> environments
+    shared --> environments
+    security --> environments
+    subgraph environments[Repeated for dev, stg, and prd]
+        account[Account identity and guardrails]
+        apps[Apps VPC: private subnets and NAT]
+        data[Data VPC: isolated subnets]
+        routes[TGW attachments and environment route domain]
+        eks[EKS: cluster, system pool, workload pool, add-ons]
+        stores[PostgreSQL, cache, SQS and DLQ]
+        workloads[Checkout and payments: pod identities and deployments]
+        release[Environment release]
+        account --> apps
+        account --> data
+        apps --> routes
+        data --> routes
+        routes --> eks
+        data --> stores
+        eks --> workloads
+        stores --> workloads
+        workloads --> release
+    end
+    environments --> landscape[Landscape: six application URLs]
+```
+
+| Member account | Fictional ID | VPC CIDRs | Responsibility |
+|---|---|---|---|
+| security | `111111111111` | None | Audit archive, telemetry, encryption key fixture |
+| network | `222222222222` | `10.0.0.0/16` | Hub VPC, TGW, RAM sharing, separate route domains |
+| shared | `333333333333` | None | Shared registry, cross-account pull intent, DNS suffix |
+| dev | `444444444444` | Apps `10.16.0.0/16`, data `10.17.0.0/16` | Spot workload pool, one NAT, one cache node, one replica per app |
+| stg | `555555555555` | Apps `10.32.0.0/16`, data `10.33.0.0/16` | On-demand workload pool, multi-AZ database, two replicas |
+| prd | `666666666666` | Apps `10.48.0.0/16`, data `10.49.0.0/16` | Three NATs, four workload nodes, three cache nodes and replicas, 35 backup days |
+
+All accounts inherit Seoul and the `ane2` naming abbreviation from the
+organization. Each VPC defaults to three AZs derived from that region; an
+explicit `availability_zones` list can override them. Data VPCs have no NAT.
+The fixture records private service endpoints and explicitly empty
+cross-environment routes. These values describe intended network isolation;
+they do not prove real AWS routing, IAM permissions, availability, or security.
+
+Naming follows `acme-ane2-<resource>-<stage>-<purpose>`, with `Namespace` in
+tags. Shared identifiers include their account when needed. Account IDs,
+ARNs, image addresses, credentials, and `.invalid` endpoints are examples.
+The fake database password exists solely to exercise sensitive data edges.
+
+## Run it
+
+From the repository root:
+
+```sh
+make build
+cd examples/compelete
+../../terragraph validate
+../../terragraph graph
+../../terragraph graph --format dot > /tmp/compelete.dot
+../../terragraph apply --auto-approve --parallelism 4
+../../terragraph output --node landscape
+../../terragraph output summary --node landscape --raw
+../../terragraph status --node prd.platform.cluster --output json
+../../terragraph apply --auto-approve --parallelism 4
+../../terragraph plan --parallelism 4
+```
+
+The first apply reports 63 applied nodes. The second reports 63 unchanged
+nodes. `landscape` lists both applications in all three environments; for
+example, `https://checkout.prd.commerce.example.invalid`.
+
+Commands load **the directory**, merging `blueprint.hcl`, `environments.hcl`,
+`settings.hcl`, and `contracts.hcl`. Do not select `blueprint.hcl` alone:
+that would omit the environment instances, strict contract mode, and other
+settings. From elsewhere, pass `--blueprint /path/to/examples/compelete`.
+
+Add `--tofu` consistently to use OpenTofu in a fresh copy. Keep a given
+checkout's states and retained plans on the same runtime; the verification
+script creates separate copies for each runtime automatically.
+
+A fresh whole-graph `plan` cannot predict missing upstream outputs. Ordinary
+`apply` bootstraps this graph with real upstream results. After bootstrap,
+`plan` uses existing upstream state, even if an upstream plan proposes a
+different value. Use saved frontiers below for a separate review step.
+
+## Where the repetition went
+
+| File or directory | Owns |
+|---|---|
+| `blueprint.hcl` | Organization values and the three shared accounts/services |
+| `environments.hcl` | Three instances containing only their account and sizing/network/application differences |
+| `groups/account` | Identity, group-scoped guardrail contracts, and a context export that waits for guardrails |
+| `groups/network` | Two uses of the same VPC root, TGW connectivity, context fan-out |
+| `groups/eks` | Cluster, two uses of the node-pool root, add-on ordering |
+| `groups/data` | Database, cache, queue, and a sensitive credentials export |
+| `groups/service` | Per-service pod identity and deployment |
+| `groups/environment` | Nested composition and all connections between the layers |
+| `contracts.hcl` | Source-scoped producer and consumer declarations reused across instances |
+| `settings.hcl` | Enforced contracts, snapshots, temporary inputs, execution retention |
+| `modules` | Eighteen small, always-present root fixtures with typed inputs and apply-time outputs |
+
+`use.vars` fills exported inputs; it is not an override map. For example,
+one environment `data_config` fans out to the database and cache, and one
+`context` fans out through nested groups. The fixed system pool is defined
+once inside the EKS group. Account context flows from applied outputs,
+so it does not need to be copied into every leaf's `vars`.
+
+Blueprint `vars` supports literal data, without functions, locals, variable
+references, loops, or interpolation of node names into backend keys. The
+three `use "environment"` declarations and their external edges remain
+explicit. Naming, AZ defaults, and subnet calculations belong in the local
+fixtures. Adding `qa` means adding an instance, unique CIDRs/account data,
+its shared-service edges, and an export consumer if it should appear in
+the final landscape. No group implementation needs to be copied.
+
+There are scalar port edges, nested multi-input edges, and ordering-only
+edges. `use.network -> use.platform` waits for the connectivity sink before
+starting the platform roots. Pool-to-add-on ordering waits for capacity
+without inventing a data input just to express sequencing.
+
+Each leaf has its own `.terragraph/state/<qualified-name>.tfstate` and
+`.terragraph/tfdata/<qualified-name>/`, including seven instances of the
+same VPC source. Modules declare `backend "local" {}` so Terragraph can
+supply an absolute path. Module sources remain unchanged by execution.
+Group and leaf names are state addresses: renaming a leaf is a migration
+decision, not a cosmetic edit.
+
+## Contracts and actual values
+
+Every data edge has both a producer and consumer contract with type,
+nullability, and sensitivity claims. Contracts are keyed by source, so a
+single VPC declaration covers the hub and all six environment VPCs. All
+claims run under `contracts { mode = "enforce" }`.
+The account group carries its own guardrail contracts, which are merged
+when the group is instantiated in six places.
+
+The credentials path is sensitive end to end:
+
+```text
+database.credentials -> data export -> environment wiring
+                     -> service export -> workload.credentials
+```
+
+```sh
+../../terragraph output --node dev.data.database --output json
+../../terragraph output credentials --node dev.data.database --show-sensitive
+```
+
+The first command redacts credentials. The second explicitly reveals the
+fake value. Snapshots store consumed non-sensitive outputs and record
+`credentials` in `withheld`. Sensitive inputs still exist in native state,
+temporary input files while running, retained plan bytes, and native state
+backups. Sensitivity is not encryption or a replacement for access control.
+
+Contracts compare declarations, not returned values. They do not validate
+that a producer returned the promised type or that a VPC belongs to an
+account. Fixture preconditions separately reject incorrect account/VPC
+connections, public production EKS endpoints, insufficient production
+database retention, and undersized production cache configurations.
+The runnable verifier demonstrates a plan that passes contract validation
+but fails the production endpoint precondition.
+
+`optional(...)` defaults belong in module variables. Contract type strings
+use the one-argument optional form accepted by the current contract parser.
+Non-null claims describe these always-present roots; disabling a resource
+would require redesigning its contract and downstream graph.
+
+## Day-two operations
+
+An exact leaf selection never expands to its parents or consumers:
+
+```sh
+../../terragraph plan --node dev.checkout.deployment
+../../terragraph apply --node dev.checkout.deployment --auto-approve
+../../terragraph run --node dev.checkout.deployment -- state list
+../../terragraph run --node dev.checkout.deployment -- state show terraform_data.this
+../../terragraph plan list --output json
+```
+
+Change dev's checkout image tag in `environments.hcl` and apply the graph to
+observe downstream propagation. Leave an unchanged environment alone; a
+leaf-only apply will not update its release or the final landscape for you.
+
+The default `safe` policy permits create/update and refuses replacement.
+Changing a VPC CIDR triggers replacement in this fixture. `--auto-approve`
+does not bypass that refusal. `--approve none` can reject all resource
+changes on nodes without a standing policy. It is not a preview mode.
+The disposable landscape node explicitly declares `all`; production's
+environment explicitly declares `safe`, inherited by its 17 leaves.
+CLI `--approve all` cannot widen that production declaration.
+
+To tear down this local example, change only production's `approve` from
+`safe` to `all` in `environments.hcl`, then run:
+
+```sh
+../../terragraph destroy --auto-approve --parallelism 4
+```
+
+Destroy runs the 12 levels in reverse. Restore production's `safe` policy
+afterwards. For an isolated scratch copy, the verifier performs this edit
+and cleanup automatically. There is no real infrastructure rollback here;
+reapplying recreates local fixture state. Preserve failed execution evidence
+until recovery is understood, rather than deleting `.terragraph` to retry.
+
+## Reviewed plans and recovery
+
+From a fresh copy:
+
+```sh
+../../terragraph plan --save --output json
+../../terragraph plan show <run-id> --output json
+../../terragraph apply --plan <run-id> --auto-approve
+../../terragraph plan --save --continue <run-id> --output json
+```
+
+Review and apply each newly prepared frontier, repeating `--continue` until
+`plan show` says `completed`. This example needs 12 frontiers on a fresh
+graph. The first contains only `organization`; no fake downstream values
+are used to manufacture a complete plan. Saved frontiers currently execute
+sequentially. Ordinary apply supports parallel nodes. Saved apply retains
+the original selection and consumes native plans once.
+
+`apply --retain-plan --auto-approve` retains bundles during ordinary apply;
+it does not pause for review. `plan cancel <run-id>` abandons an unconsumed
+execution, and `plan prune` removes eligible expired bundles and resolved
+records. `settings.hcl` gives plans a two-hour start window and completed
+records seven days of retention. Cleanup is command-driven, without a daemon.
+
+For an interrupted attempt, inspect `plan show` and confirm the old executor
+stopped. An `applied` phase can retry output collection with
+`plan recover <run-id> --confirm-stopped`. An unknown outcome requires
+reviewing native state before explicitly using
+`--confirm-stopped --state-reviewed --replan`. These are operator assertions;
+the example does not fabricate a crash or automatically acknowledge recovery.
+See [execution recovery](../../docs/executions.md#recovery).
+
+## Executable verification and additional labs
+
+From the repository root, with Python 3 and the chosen runtime installed:
+
+```sh
+python3 examples/compelete/verify.py --terragraph ./terragraph
+python3 examples/compelete/verify.py --terragraph ./terragraph --mode all
+python3 examples/compelete/verify.py --terragraph ./terragraph --tofu --mode all
+```
+
+Each mode copies the example into a private temporary directory. It strips
+inherited AWS credentials and runtime argument/workspace overrides, logs
+commands locally, and removes successful copies. A failure retains its
+copy and logs at the printed path; `--keep` retains successful copies too.
+Tests do not modify your example state or configuration. Runtime binaries
+must already be installed; building Terragraph may separately need Go's
+dependencies. The native fixture execution requires no network access.
+
+| Mode | Exercises |
+|---|---|
+| `smoke` (default) | Validation, 63-node parallel bootstrap, idempotency, warmed plan, six unique environment VPCs, output/status, sensitive redaction/snapshots, exact leaf selection, runtime precondition, contract rejection, replacement refusal, saved leaf, production destroy refusal, reverse teardown |
+| `saved` | Fresh 12-frontier reviewed bootstrap, continuation, cancellation, pruning, teardown |
+| `native` | Scoped init, console, state list/show/pull/mv/rm, import, and archived native backup export, using only the organization fixture |
+| `vendor` | Local Git upstream, pinned commit and source subdirectory, nested group leaves, custom vendor directory/manifest, exclusions, one-leaf fetch, skip, forced refresh, apply/destroy |
+| `all` | All four modes, each with a fresh copy |
+
+The vendoring lab creates a temporary `git::file://...//modules/queue?ref=...`
+source. It exercises actual fetching while remaining offline. Its package
+metadata and qualified `alpha.queue`/`beta.queue` copies are checked. It
+never rewrites the checked-in blueprint with a machine-specific source.
+Git is needed only for this lab.
+
+Native import of `terraform_data` restores its ID without fixture values.
+Outputs tolerate that temporary absence; reapply the imported leaf before
+running any consumers. The native lab verifies that reconciliation step.
+
+## Coverage boundary and production adaptation
+
+| Terragraph capability | Coverage here |
+|---|---|
+| Directory loading, nested groups, exports, fan-out, literal inputs, source reuse | Main 63-node graph |
+| Scalar/multi-input data edges and node/group ordering | Main graph |
+| Strict type/nullability/sensitivity contracts | Every main-graph data connection |
+| Per-instance env and leaf overrides | Environment/account `env`, nested platform `env`, system-pool override |
+| State and `TF_DATA_DIR` isolation, temporary tfvars, local process lock | Real execution, with state/source checks in verifier |
+| Terraform/OpenTofu fallback selection | `--tofu` in a fresh copy |
+| Named runtime default and node/use selection | Manual recipe below; declaration `version` is documentation only |
+| `safe`, `all`, `none`, parallelism, changed/unchanged behavior | Main graph and policy walkthrough |
+| Snapshots, redacted and explicit sensitive output, status, JSON, DOT | Main graph and smoke assertions; fallback may be stale and cannot supply withheld credentials |
+| Execution records, saved/retained plans, continuation, cancellation, pruning | Local store and saved-plan walkthrough/lab |
+| Native init, console, import, state operations, backup export | Disposable native lab |
+| Git vendoring, subdirectory packages, exclusions, custom paths, forced refresh | Disposable vendor lab |
+| Recovery, interruption, stale locks, editor intelligence | Linked operational documentation; not simulated failure claims |
+| Remote backends, `use.backend_config`, S3 graph lock, S3 execution storage, `force-unlock` | Require a separate real-backend adaptation; intentionally absent from the credential-free run |
+
+For a named-runtime experiment in a **fresh disposable copy**, add a
+`runtimes.hcl` with a root default:
+
+```hcl
+runtime "primary" {
+  binary  = "terraform"
+  version = ">= 1.4.0"
+  default = true
+}
+```
+
+An explicit `runtime = runtime.primary` on a root node or environment use
+demonstrates the selection syntax; leaf choice wins over nested use, then
+root default, then CLI fallback. A root default takes precedence over
+`--tofu`. To mix runtimes, use separate source copies and states; sharing
+one source across different runtimes produces a provider-lockfile warning.
+Do not change runtimes underneath retained plans.
+
+A production adaptation must author real provider/backend configuration
+in its roots and independently implement and review every simulated AWS
+control. Terragraph does not generate that configuration. AWS credentials
+would come from each executor's role/environment, rather than fictional
+account IDs passed as module values.
+
+For shared state, give every leaf and environment a distinct backend
+address. `use.backend_config` can supply common bucket/region defaults, but
+one inherited `key` would be shared by every leaf: Terragraph does not
+interpolate qualified names into it. Repeated groups also need separate
+instance namespaces. Migrating current local state is a separate operation.
+
+An S3 graph lock requires every node to use a supported remote backend,
+so simply adding `lock` to this local example is invalid. S3 execution
+storage also requires that graph lock and its own dedicated prefix,
+separate from state and the lock object. Provision those resources and
+permissions outside this example and configure every executor identically.
+Do not treat a fixture-only `AWS_REGION` or resource-policy string as working
+authentication, enforcement, or validated production infrastructure.
+
+See [backend and lock rules](../../docs/blueprint.md),
+[remote graph locking](../../docs/execution-model.md#graph-remote-lock),
+[execution storage](../../docs/executions.md),
+[node operations](../../docs/node-operations.md), and
+[editor intelligence](../../docs/intellisense.md) for the remaining
+operational constraints. The fixture avoids cloud blast radius and tests
+orchestration behavior; AWS integration still needs its own validation.

--- a/examples/compelete/blueprint.hcl
+++ b/examples/compelete/blueprint.hcl
@@ -1,0 +1,119 @@
+# Load this directory, not this file alone: contracts, environments, and settings are siblings.
+node "organization" {
+  source = "./modules/organization"
+  vars = {
+    organization = {
+      tenant      = "acme"
+      namespace   = "commerce-platform"
+      region      = "ap-northeast-2"
+      region_code = "ane2"
+      domain      = "commerce.example.invalid"
+      tags        = { Owner = "platform-team", CostCenter = "commerce" }
+    }
+  }
+}
+use "account" {
+  as     = "security"
+  source = "./groups/account"
+  vars   = { account = { account_id = "111111111111", name = "security", stage = "common" } }
+  env    = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true" }
+}
+use "account" {
+  as     = "network"
+  source = "./groups/account"
+  vars   = { account = { account_id = "222222222222", name = "network", stage = "common" } }
+  env    = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true" }
+}
+use "account" {
+  as     = "shared"
+  source = "./groups/account"
+  vars   = { account = { account_id = "333333333333", name = "shared", stage = "common" } }
+  env    = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true" }
+}
+node "audit" { source = "./modules/audit" }
+node "hub" {
+  source = "./modules/vpc"
+  vars   = { network_config = { purpose = "hub", cidr = "10.0.0.0/16" } }
+}
+node "transit" { source = "./modules/transit" }
+node "shared_services" {
+  source = "./modules/shared-services"
+}
+node "landscape" {
+  source = "./modules/landscape"
+  # These are local fixtures; all permits teardown of this disposable catalog.
+  approve = "all"
+}
+edge {
+  from = node.organization.output.organization
+  to   = use.security.input.organization
+}
+
+edge {
+  from = node.organization
+  to   = use.network
+  input "organization" {
+    from = output.organization
+  }
+}
+
+edge {
+  from = node.organization
+  to   = use.shared
+  input "organization" {
+    from = output.organization
+  }
+}
+
+edge {
+  from = use.security
+  to   = node.audit
+  input "context" {
+    from = output.context
+  }
+}
+
+edge {
+  from = use.network
+  to   = node.hub
+  input "context" {
+    from = output.context
+  }
+}
+
+edge {
+  from = use.network
+  to   = node.transit
+  input "context" {
+    from = output.context
+  }
+}
+
+edge {
+  from = node.hub
+  to   = node.transit
+  input "network" {
+    from = output.network
+  }
+}
+
+edge {
+  from = use.shared
+  to   = node.shared_services
+  input "context" {
+    from = output.context
+  }
+}
+
+edge {
+  from = node.audit
+  to   = node.shared_services
+  input "telemetry" {
+    from = output.telemetry
+  }
+}
+
+edge {
+  from = node.organization.output.dns_zone
+  to   = node.shared_services.input.domain
+}

--- a/examples/compelete/contracts.hcl
+++ b/examples/compelete/contracts.hcl
@@ -1,0 +1,490 @@
+# Every data-edge port has a declaration; actual value invariants live in fixture preconditions.
+
+producer "./modules/organization" {
+  output "dns_zone" {
+    type      = "string"
+    nullable  = false
+    sensitive = false
+  }
+  output "organization" {
+    type      = "object({tenant = string, namespace = string, region = string, region_code = string, domain = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/organization" {
+  input "organization" {
+    type      = "object({tenant = string, namespace = string, region = string, region_code = string, domain = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/account" {
+  output "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/account" {
+  input "organization" {
+    type      = "object({tenant = string, namespace = string, region = string, region_code = string, domain = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "account" {
+    type      = "object({account_id = string, name = string, stage = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+
+
+producer "./modules/audit" {
+  output "telemetry" {
+    type      = "object({archive_bucket_arn = string, kms_key_arn = string, endpoint = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/audit" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/vpc" {
+  output "network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/vpc" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "network_config" {
+    type      = "object({purpose = string, cidr = string, availability_zones = optional(list(string)), nat_gateways = optional(number)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/transit" {
+  output "transit" {
+    type      = "object({id = string, owner_account_id = string, region = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/transit" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/shared-services" {
+  output "registry" {
+    type      = "object({repository_url = string, owner_account_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  output "dns_zone" {
+    type      = "string"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/shared-services" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "telemetry" {
+    type      = "object({archive_bucket_arn = string, kms_key_arn = string, endpoint = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "domain" {
+    type      = "string"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/connectivity" {
+  output "connectivity" {
+    type      = "object({apps_vpc_id = string, data_vpc_id = string, account_id = string, route_domain = string, transit_gateway_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/connectivity" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "apps_network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "data_network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "transit" {
+    type      = "object({id = string, owner_account_id = string, region = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/eks" {
+  output "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/eks" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "telemetry" {
+    type      = "object({archive_bucket_arn = string, kms_key_arn = string, endpoint = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster_config" {
+    type      = "object({version = string, private_endpoint = optional(bool)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/node-pool" {
+  output "pool" {
+    type      = "object({name = string, cluster_name = string, desired_size = number, capacity_type = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/node-pool" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "pool_config" {
+    type      = "object({name = string, capacity_type = string, min_size = number, desired_size = number, max_size = number})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/addons" {
+  output "addons" {
+    type      = "object({cluster_name = string, controllers = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/addons" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "telemetry" {
+    type      = "object({archive_bucket_arn = string, kms_key_arn = string, endpoint = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/database" {
+  output "database" {
+    type      = "object({endpoint = string, port = number, name = string, account_id = string, vpc_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  output "credentials" {
+    type      = "object({username = string, password = string})"
+    nullable  = false
+    sensitive = true
+  }
+}
+
+consumer "./modules/database" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "data_config" {
+    type      = "object({multi_az = bool, backup_retention_days = number, cache_nodes = number})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/cache" {
+  output "cache" {
+    type      = "object({endpoint = string, port = number, account_id = string, vpc_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/cache" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "network" {
+    type      = "object({id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "data_config" {
+    type      = "object({multi_az = bool, backup_retention_days = number, cache_nodes = number})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/queue" {
+  output "queue" {
+    type      = "object({arn = string, url = string, account_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/queue" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/pod-identity" {
+  output "identity" {
+    type      = "object({role_arn = string, namespace = string, service_account = string, account_id = string, cluster_name = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/pod-identity" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "queue" {
+    type      = "object({arn = string, url = string, account_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "service_config" {
+    type      = "object({name = string, image_tag = string, replicas = number})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/workload" {
+  output "service" {
+    type      = "object({name = string, url = string, image = string, replicas = number, account_id = string, cluster_name = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/workload" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "addons" {
+    type      = "object({cluster_name = string, controllers = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "connectivity" {
+    type      = "object({apps_vpc_id = string, data_vpc_id = string, account_id = string, route_domain = string, transit_gateway_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "database" {
+    type      = "object({endpoint = string, port = number, name = string, account_id = string, vpc_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "credentials" {
+    type      = "object({username = string, password = string})"
+    nullable  = false
+    sensitive = true
+  }
+  input "cache" {
+    type      = "object({endpoint = string, port = number, account_id = string, vpc_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "queue" {
+    type      = "object({arn = string, url = string, account_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "identity" {
+    type      = "object({role_arn = string, namespace = string, service_account = string, account_id = string, cluster_name = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "registry" {
+    type      = "object({repository_url = string, owner_account_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "dns_zone" {
+    type      = "string"
+    nullable  = false
+    sensitive = false
+  }
+  input "service_config" {
+    type      = "object({name = string, image_tag = string, replicas = number})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/release" {
+  output "release" {
+    type      = "object({stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/release" {
+  input "context" {
+    type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "cluster" {
+    type      = "object({name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "connectivity" {
+    type      = "object({apps_vpc_id = string, data_vpc_id = string, account_id = string, route_domain = string, transit_gateway_id = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "checkout" {
+    type      = "object({name = string, url = string, image = string, replicas = number, account_id = string, cluster_name = string})"
+    nullable  = false
+    sensitive = false
+  }
+  input "payments" {
+    type      = "object({name = string, url = string, image = string, replicas = number, account_id = string, cluster_name = string})"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+producer "./modules/landscape" {
+  output "environments" {
+    type      = "map(object({stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string)}))"
+    nullable  = false
+    sensitive = false
+  }
+  output "summary" {
+    type      = "string"
+    nullable  = false
+    sensitive = false
+  }
+}
+
+consumer "./modules/landscape" {
+  input "dev" {
+    type      = "object({stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "stg" {
+    type      = "object({stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+  input "prd" {
+    type      = "object({stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string)})"
+    nullable  = false
+    sensitive = false
+  }
+}

--- a/examples/compelete/environments.hcl
+++ b/examples/compelete/environments.hcl
@@ -1,0 +1,178 @@
+use "environment" {
+  as     = "dev"
+  source = "./groups/environment"
+  env    = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true", TF_INPUT = "0" }
+  vars = {
+    account             = { account_id = "444444444444", name = "workloads-dev", stage = "dev" }
+    apps_config         = { purpose = "apps", cidr = "10.16.0.0/16", nat_gateways = 1 }
+    data_network_config = { purpose = "data", cidr = "10.17.0.0/16" }
+    cluster_config      = { version = "1.34" }
+    pool_config         = { name = "workloads", capacity_type = "SPOT", min_size = 2, desired_size = 2, max_size = 6 }
+    data_config         = { multi_az = false, backup_retention_days = 1, cache_nodes = 1 }
+    checkout_config     = { name = "checkout", image_tag = "v1.0.0", replicas = 1 }
+    payments_config     = { name = "payments", image_tag = "v1.0.0", replicas = 1 }
+  }
+}
+
+edge {
+  from = node.organization
+  to   = use.dev
+  input "organization" {
+    from = output.organization
+  }
+}
+
+edge {
+  from = node.transit
+  to   = use.dev
+  input "transit" {
+    from = output.transit
+  }
+}
+
+edge {
+  from = node.audit
+  to   = use.dev
+  input "telemetry" {
+    from = output.telemetry
+  }
+}
+
+edge {
+  from = node.shared_services
+  to   = use.dev
+  input "registry" {
+    from = output.registry
+  }
+  input "dns_zone" {
+    from = output.dns_zone
+  }
+}
+
+edge {
+  from = use.dev
+  to   = node.landscape
+  input "dev" {
+    from = output.release
+  }
+}
+
+use "environment" {
+  as     = "stg"
+  source = "./groups/environment"
+  env    = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true", TF_INPUT = "0" }
+  vars = {
+    account             = { account_id = "555555555555", name = "workloads-stg", stage = "stg" }
+    apps_config         = { purpose = "apps", cidr = "10.32.0.0/16", nat_gateways = 1 }
+    data_network_config = { purpose = "data", cidr = "10.33.0.0/16" }
+    cluster_config      = { version = "1.34" }
+    pool_config         = { name = "workloads", capacity_type = "ON_DEMAND", min_size = 2, desired_size = 2, max_size = 6 }
+    data_config         = { multi_az = true, backup_retention_days = 7, cache_nodes = 2 }
+    checkout_config     = { name = "checkout", image_tag = "v1.0.0", replicas = 2 }
+    payments_config     = { name = "payments", image_tag = "v1.0.0", replicas = 2 }
+  }
+}
+
+edge {
+  from = node.organization
+  to   = use.stg
+  input "organization" {
+    from = output.organization
+  }
+}
+
+edge {
+  from = node.transit
+  to   = use.stg
+  input "transit" {
+    from = output.transit
+  }
+}
+
+edge {
+  from = node.audit
+  to   = use.stg
+  input "telemetry" {
+    from = output.telemetry
+  }
+}
+
+edge {
+  from = node.shared_services
+  to   = use.stg
+  input "registry" {
+    from = output.registry
+  }
+  input "dns_zone" {
+    from = output.dns_zone
+  }
+}
+
+edge {
+  from = use.stg
+  to   = node.landscape
+  input "stg" {
+    from = output.release
+  }
+}
+
+use "environment" {
+  as = "prd"
+  # A standing production policy cannot be widened by --approve or --auto-approve.
+  approve = "safe"
+  source  = "./groups/environment"
+  env     = { AWS_REGION = "ap-northeast-2", AWS_EC2_METADATA_DISABLED = "true", TF_INPUT = "0" }
+  vars = {
+    account             = { account_id = "666666666666", name = "workloads-prd", stage = "prd" }
+    apps_config         = { purpose = "apps", cidr = "10.48.0.0/16", nat_gateways = 3 }
+    data_network_config = { purpose = "data", cidr = "10.49.0.0/16" }
+    cluster_config      = { version = "1.34" }
+    pool_config         = { name = "workloads", capacity_type = "ON_DEMAND", min_size = 2, desired_size = 4, max_size = 12 }
+    data_config         = { multi_az = true, backup_retention_days = 35, cache_nodes = 3 }
+    checkout_config     = { name = "checkout", image_tag = "v1.0.0", replicas = 3 }
+    payments_config     = { name = "payments", image_tag = "v1.0.0", replicas = 3 }
+  }
+}
+
+edge {
+  from = node.organization
+  to   = use.prd
+  input "organization" {
+    from = output.organization
+  }
+}
+
+edge {
+  from = node.transit
+  to   = use.prd
+  input "transit" {
+    from = output.transit
+  }
+}
+
+edge {
+  from = node.audit
+  to   = use.prd
+  input "telemetry" {
+    from = output.telemetry
+  }
+}
+
+edge {
+  from = node.shared_services
+  to   = use.prd
+  input "registry" {
+    from = output.registry
+  }
+  input "dns_zone" {
+    from = output.dns_zone
+  }
+}
+
+edge {
+  from = use.prd
+  to   = node.landscape
+  input "prd" {
+    from = output.release
+  }
+}

--- a/examples/compelete/groups/account/group.hcl
+++ b/examples/compelete/groups/account/group.hcl
@@ -1,0 +1,47 @@
+group "account" {
+  node "identity" {
+    source = "../../modules/account"
+
+  }
+
+  node "guardrails" {
+    source = "../../modules/guardrails"
+
+  }
+
+  edge {
+    from = node.identity
+    to   = node.guardrails
+    input "context" {
+      from = output.context
+    }
+  }
+
+  export {
+    input "organization" {
+      to = node.identity.input.organization
+    }
+    input "account" {
+      to = node.identity.input.account
+    }
+    output "context" {
+      from = node.guardrails.output.context
+    }
+  }
+
+  producer "../../modules/guardrails" {
+    output "context" {
+      type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+      nullable  = false
+      sensitive = false
+    }
+  }
+
+  consumer "../../modules/guardrails" {
+    input "context" {
+      type      = "object({account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string)})"
+      nullable  = false
+      sensitive = false
+    }
+  }
+}

--- a/examples/compelete/groups/data/group.hcl
+++ b/examples/compelete/groups/data/group.hcl
@@ -1,0 +1,40 @@
+group "data" {
+  node "database" {
+    source = "../../modules/database"
+
+  }
+
+  node "cache" {
+    source = "../../modules/cache"
+
+  }
+
+  node "queue" {
+    source = "../../modules/queue"
+
+  }
+
+  export {
+    input "context" {
+      to = [node.database.input.context, node.cache.input.context, node.queue.input.context]
+    }
+    input "network" {
+      to = [node.database.input.network, node.cache.input.network]
+    }
+    input "data_config" {
+      to = [node.database.input.data_config, node.cache.input.data_config]
+    }
+    output "database" {
+      from = node.database.output.database
+    }
+    output "credentials" {
+      from = node.database.output.credentials
+    }
+    output "cache" {
+      from = node.cache.output.cache
+    }
+    output "queue" {
+      from = node.queue.output.queue
+    }
+  }
+}

--- a/examples/compelete/groups/eks/group.hcl
+++ b/examples/compelete/groups/eks/group.hcl
@@ -1,0 +1,82 @@
+group "eks" {
+  node "cluster" {
+    source = "../../modules/eks"
+
+  }
+
+  node "system" {
+    env    = { TF_INPUT = "false" }
+    source = "../../modules/node-pool"
+    vars   = { pool_config = { name = "system", capacity_type = "ON_DEMAND", min_size = 2, desired_size = 2, max_size = 3 } }
+  }
+
+  node "workloads" {
+    source = "../../modules/node-pool"
+
+  }
+
+  node "addons" {
+    source = "../../modules/addons"
+
+  }
+
+  edge {
+    from = node.cluster
+    to   = node.system
+    input "cluster" {
+      from = output.cluster
+    }
+  }
+
+  edge {
+    from = node.cluster
+    to   = node.workloads
+    input "cluster" {
+      from = output.cluster
+    }
+  }
+
+  edge {
+    from = node.cluster
+    to   = node.addons
+    input "cluster" {
+      from = output.cluster
+    }
+  }
+
+  # Ordering edges wait for node pools without inventing an input on the add-on module.
+
+  edge {
+    from = node.system
+    to   = node.addons
+  }
+
+  edge {
+    from = node.workloads
+    to   = node.addons
+  }
+
+  export {
+    input "context" {
+      to = [node.cluster.input.context, node.system.input.context, node.workloads.input.context, node.addons.input.context]
+    }
+    input "network" {
+      to = node.cluster.input.network
+    }
+    input "telemetry" {
+      to = [node.cluster.input.telemetry, node.addons.input.telemetry]
+    }
+    input "cluster_config" {
+      to = node.cluster.input.cluster_config
+    }
+    input "pool_config" {
+      to = node.workloads.input.pool_config
+    }
+    output "cluster" {
+      from = node.cluster.output.cluster
+    }
+    output "addons" {
+      from = node.addons.output.addons
+    }
+  }
+}

--- a/examples/compelete/groups/environment/group.hcl
+++ b/examples/compelete/groups/environment/group.hcl
@@ -1,0 +1,262 @@
+group "environment" {
+  use "account" {
+    as     = "account"
+    source = "../account"
+
+  }
+
+  use "network" {
+    as     = "network"
+    source = "../network"
+
+  }
+
+  use "eks" {
+    as     = "platform"
+    source = "../eks"
+    env    = { TF_INPUT = "0" }
+  }
+
+  use "data" {
+    as     = "data"
+    source = "../data"
+
+  }
+
+  use "service" {
+    as     = "checkout"
+    source = "../service"
+
+  }
+
+  use "service" {
+    as     = "payments"
+    source = "../service"
+
+  }
+
+  node "release" {
+    source = "../../modules/release"
+
+  }
+
+  edge {
+    from = use.account
+    to   = use.network
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.account
+    to   = use.platform
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.account
+    to   = use.data
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.account
+    to   = use.checkout
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.account
+    to   = use.payments
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.account
+    to   = node.release
+    input "context" {
+      from = output.context
+    }
+  }
+
+  edge {
+    from = use.network
+    to   = use.platform
+    input "network" {
+      from = output.apps_network
+    }
+  }
+
+  edge {
+    from = use.network
+    to   = use.data
+    input "network" {
+      from = output.data_network
+    }
+  }
+
+  # Group ordering waits for TGW routing even though EKS only consumes the apps VPC.
+
+  edge {
+    from = use.network
+    to   = use.platform
+  }
+
+  edge {
+    from = use.platform
+    to   = use.checkout
+    input "cluster" {
+      from = output.cluster
+    }
+    input "addons" {
+      from = output.addons
+    }
+  }
+
+  edge {
+    from = use.network
+    to   = use.checkout
+    input "connectivity" {
+      from = output.connectivity
+    }
+  }
+
+  edge {
+    from = use.data
+    to   = use.checkout
+    input "database" {
+      from = output.database
+    }
+    input "credentials" {
+      from = output.credentials
+    }
+    input "cache" {
+      from = output.cache
+    }
+    input "queue" {
+      from = output.queue
+    }
+  }
+
+  edge {
+    from = use.platform
+    to   = use.payments
+    input "cluster" {
+      from = output.cluster
+    }
+    input "addons" {
+      from = output.addons
+    }
+  }
+
+  edge {
+    from = use.network
+    to   = use.payments
+    input "connectivity" {
+      from = output.connectivity
+    }
+  }
+
+  edge {
+    from = use.data
+    to   = use.payments
+    input "database" {
+      from = output.database
+    }
+    input "credentials" {
+      from = output.credentials
+    }
+    input "cache" {
+      from = output.cache
+    }
+    input "queue" {
+      from = output.queue
+    }
+  }
+
+  edge {
+    from = use.platform
+    to   = node.release
+    input "cluster" {
+      from = output.cluster
+    }
+  }
+
+  edge {
+    from = use.network
+    to   = node.release
+    input "connectivity" {
+      from = output.connectivity
+    }
+  }
+
+  edge {
+    from = use.checkout
+    to   = node.release
+    input "checkout" {
+      from = output.service
+    }
+  }
+
+  edge {
+    from = use.payments
+    to   = node.release
+    input "payments" {
+      from = output.service
+    }
+  }
+
+  export {
+    input "organization" {
+      to = use.account.input.organization
+    }
+    input "account" {
+      to = use.account.input.account
+    }
+    input "apps_config" {
+      to = use.network.input.apps_config
+    }
+    input "data_network_config" {
+      to = use.network.input.data_config
+    }
+    input "transit" {
+      to = use.network.input.transit
+    }
+    input "cluster_config" {
+      to = use.platform.input.cluster_config
+    }
+    input "pool_config" {
+      to = use.platform.input.pool_config
+    }
+    input "data_config" {
+      to = use.data.input.data_config
+    }
+    input "telemetry" {
+      to = use.platform.input.telemetry
+    }
+    input "registry" {
+      to = [use.checkout.input.registry, use.payments.input.registry]
+    }
+    input "dns_zone" {
+      to = [use.checkout.input.dns_zone, use.payments.input.dns_zone]
+    }
+    input "checkout_config" {
+      to = use.checkout.input.service_config
+    }
+    input "payments_config" {
+      to = use.payments.input.service_config
+    }
+    output "release" {
+      from = node.release.output.release
+    }
+  }
+}

--- a/examples/compelete/groups/network/group.hcl
+++ b/examples/compelete/groups/network/group.hcl
@@ -1,0 +1,56 @@
+group "network" {
+  node "apps" {
+    source = "../../modules/vpc"
+
+  }
+
+  node "data" {
+    source = "../../modules/vpc"
+
+  }
+
+  node "connectivity" {
+    source = "../../modules/connectivity"
+
+  }
+
+  edge {
+    from = node.apps
+    to   = node.connectivity
+    input "apps_network" {
+      from = output.network
+    }
+  }
+
+  edge {
+    from = node.data
+    to   = node.connectivity
+    input "data_network" {
+      from = output.network
+    }
+  }
+
+  export {
+    input "context" {
+      to = [node.apps.input.context, node.data.input.context, node.connectivity.input.context]
+    }
+    input "apps_config" {
+      to = node.apps.input.network_config
+    }
+    input "data_config" {
+      to = node.data.input.network_config
+    }
+    input "transit" {
+      to = node.connectivity.input.transit
+    }
+    output "apps_network" {
+      from = node.apps.output.network
+    }
+    output "data_network" {
+      from = node.data.output.network
+    }
+    output "connectivity" {
+      from = node.connectivity.output.connectivity
+    }
+  }
+}

--- a/examples/compelete/groups/service/group.hcl
+++ b/examples/compelete/groups/service/group.hcl
@@ -1,0 +1,58 @@
+group "service" {
+  node "identity" {
+    source = "../../modules/pod-identity"
+
+  }
+
+  node "deployment" {
+    source = "../../modules/workload"
+
+  }
+
+  edge {
+    from = node.identity
+    to   = node.deployment
+    input "identity" {
+      from = output.identity
+    }
+  }
+
+  export {
+    input "context" {
+      to = [node.identity.input.context, node.deployment.input.context]
+    }
+    input "cluster" {
+      to = [node.identity.input.cluster, node.deployment.input.cluster]
+    }
+    input "addons" {
+      to = node.deployment.input.addons
+    }
+    input "connectivity" {
+      to = node.deployment.input.connectivity
+    }
+    input "database" {
+      to = node.deployment.input.database
+    }
+    input "credentials" {
+      to = node.deployment.input.credentials
+    }
+    input "cache" {
+      to = node.deployment.input.cache
+    }
+    input "queue" {
+      to = [node.identity.input.queue, node.deployment.input.queue]
+    }
+    input "registry" {
+      to = node.deployment.input.registry
+    }
+    input "dns_zone" {
+      to = node.deployment.input.dns_zone
+    }
+    input "service_config" {
+      to = [node.identity.input.service_config, node.deployment.input.service_config]
+    }
+    output "service" {
+      from = node.deployment.output.service
+    }
+  }
+}

--- a/examples/compelete/modules/account/.terraform.lock.hcl
+++ b/examples/compelete/modules/account/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/account/main.tf
+++ b/examples/compelete/modules/account/main.tf
@@ -1,0 +1,24 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    context = {
+      account_id   = var.account.account_id
+      account_name = var.account.name
+      tenant       = var.organization.tenant
+      namespace    = var.organization.namespace
+      stage        = var.account.stage
+      region       = var.organization.region
+      region_code  = var.organization.region_code
+      tags = merge(var.organization.tags, {
+        Namespace   = var.organization.namespace
+        Tenant      = var.organization.tenant
+        Environment = var.organization.region_code
+        Stage       = var.account.stage
+        Account     = var.account.name
+        ManagedBy   = "terragraph-fixture"
+      })
+    }
+    execution_role_arn = "arn:aws:iam::${var.account.account_id}:role/${var.organization.tenant}-gbl-role-${var.account.stage}-terraform"
+  }
+
+}

--- a/examples/compelete/modules/account/outputs.tf
+++ b/examples/compelete/modules/account/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "context" {
+  description = "Simulated context recorded by the local fixture."
+  value       = try(terraform_data.this.output.context, null)
+}

--- a/examples/compelete/modules/account/variables.tf
+++ b/examples/compelete/modules/account/variables.tf
@@ -1,0 +1,16 @@
+variable "organization" {
+  description = "Organization for the local account fixture."
+  type        = object({ tenant = string, namespace = string, region = string, region_code = string, domain = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "account" {
+  description = "Account for the local account fixture."
+  type        = object({ account_id = string, name = string, stage = string })
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account.account_id)) && contains(["common", "dev", "stg", "prd"], var.account.stage)
+    error_message = "Use a fictional 12-digit account ID and stage common, dev, stg, or prd."
+  }
+}

--- a/examples/compelete/modules/account/versions.tf
+++ b/examples/compelete/modules/account/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/addons/.terraform.lock.hcl
+++ b/examples/compelete/modules/addons/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/addons/main.tf
+++ b/examples/compelete/modules/addons/main.tf
@@ -1,0 +1,18 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    addons = {
+      cluster_name = var.cluster.name
+      controllers  = ["vpc-cni", "coredns", "kube-proxy", "ebs-csi", "pod-identity-agent", "aws-load-balancer-controller", "external-dns", "external-secrets", "opentelemetry"]
+    }
+    telemetry_endpoint = var.telemetry.endpoint
+    tags               = var.context.tags
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.cluster.account_id
+      error_message = "Cluster belongs to another account; connect this environment's cluster export."
+    }
+  }
+}

--- a/examples/compelete/modules/addons/outputs.tf
+++ b/examples/compelete/modules/addons/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "addons" {
+  description = "Simulated addons recorded by the local fixture."
+  value       = try(terraform_data.this.output.addons, null)
+}

--- a/examples/compelete/modules/addons/variables.tf
+++ b/examples/compelete/modules/addons/variables.tf
@@ -1,0 +1,17 @@
+variable "context" {
+  description = "Context for the local addons fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "cluster" {
+  description = "Cluster for the local addons fixture."
+  type        = object({ name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string })
+  nullable    = false
+}
+
+variable "telemetry" {
+  description = "Telemetry for the local addons fixture."
+  type        = object({ archive_bucket_arn = string, kms_key_arn = string, endpoint = string })
+  nullable    = false
+}

--- a/examples/compelete/modules/addons/versions.tf
+++ b/examples/compelete/modules/addons/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/audit/.terraform.lock.hcl
+++ b/examples/compelete/modules/audit/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/audit/main.tf
+++ b/examples/compelete/modules/audit/main.tf
@@ -1,0 +1,17 @@
+locals {
+  prefix = "${var.context.tenant}-${var.context.region_code}"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    telemetry = {
+      archive_bucket_arn = "arn:aws:s3:::${local.prefix}-s3-common-audit-${var.context.account_id}"
+      kms_key_arn        = "arn:aws:kms:${var.context.region}:${var.context.account_id}:key/00000000-0000-4000-8000-000000000001"
+      endpoint           = "https://telemetry.example.invalid"
+    }
+    retention_days = 365
+    tags           = merge(var.context.tags, { Name = "${local.prefix}-s3-common-audit-${var.context.account_id}", Attributes = "audit" })
+  }
+
+}

--- a/examples/compelete/modules/audit/outputs.tf
+++ b/examples/compelete/modules/audit/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "telemetry" {
+  description = "Simulated telemetry recorded by the local fixture."
+  value       = try(terraform_data.this.output.telemetry, null)
+}

--- a/examples/compelete/modules/audit/variables.tf
+++ b/examples/compelete/modules/audit/variables.tf
@@ -1,0 +1,5 @@
+variable "context" {
+  description = "Context for the local audit fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/audit/versions.tf
+++ b/examples/compelete/modules/audit/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/cache/.terraform.lock.hcl
+++ b/examples/compelete/modules/cache/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/cache/main.tf
+++ b/examples/compelete/modules/cache/main.tf
@@ -1,0 +1,27 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    cache = {
+      endpoint   = "${var.context.tenant}-${var.context.stage}.cache.example.invalid"
+      port       = 6379
+      account_id = var.context.account_id
+      vpc_id     = var.network.id
+    }
+    nodes              = var.data_config.cache_nodes
+    transit_encryption = true
+    at_rest_encryption = true
+    private_subnet_ids = var.network.private_subnet_ids
+    tags               = var.context.tags
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.network.account_id && var.context.region == var.network.region
+      error_message = "Network belongs to another account or region; connect this environment's network export."
+    }
+    precondition {
+      condition     = var.context.stage != "prd" || var.data_config.cache_nodes >= 2
+      error_message = "Production cache needs at least two nodes; increase data_config.cache_nodes."
+    }
+  }
+}

--- a/examples/compelete/modules/cache/outputs.tf
+++ b/examples/compelete/modules/cache/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "cache" {
+  description = "Simulated cache recorded by the local fixture."
+  value       = try(terraform_data.this.output.cache, null)
+}

--- a/examples/compelete/modules/cache/variables.tf
+++ b/examples/compelete/modules/cache/variables.tf
@@ -1,0 +1,17 @@
+variable "context" {
+  description = "Context for the local cache fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "network" {
+  description = "Network for the local cache fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}
+
+variable "data_config" {
+  description = "Data config for the local cache fixture."
+  type        = object({ multi_az = bool, backup_retention_days = number, cache_nodes = number })
+  nullable    = false
+}

--- a/examples/compelete/modules/cache/versions.tf
+++ b/examples/compelete/modules/cache/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/connectivity/.terraform.lock.hcl
+++ b/examples/compelete/modules/connectivity/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/connectivity/main.tf
+++ b/examples/compelete/modules/connectivity/main.tf
@@ -1,0 +1,34 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    connectivity = {
+      apps_vpc_id        = var.apps_network.id
+      data_vpc_id        = var.data_network.id
+      account_id         = var.context.account_id
+      route_domain       = var.context.stage
+      transit_gateway_id = var.transit.id
+    }
+    attachments = [var.apps_network.id, var.data_network.id]
+    routes = {
+      apps_to_data = var.data_network.cidr
+      data_to_apps = var.apps_network.cidr
+    }
+    cross_environment_routes = []
+    share_owner_account_id   = var.transit.owner_account_id
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.apps_network.account_id && var.context.account_id == var.data_network.account_id
+      error_message = "Both VPCs must belong to this account; connect the local apps and data networks."
+    }
+    precondition {
+      condition     = var.context.region == var.transit.region && var.apps_network.region == var.data_network.region
+      error_message = "Transit and VPC regions must agree; select the regional transit export."
+    }
+    precondition {
+      condition     = var.apps_network.id != var.data_network.id && var.apps_network.cidr != var.data_network.cidr
+      error_message = "Use separate apps and data VPCs with non-overlapping CIDRs; correct the network inputs."
+    }
+  }
+}

--- a/examples/compelete/modules/connectivity/outputs.tf
+++ b/examples/compelete/modules/connectivity/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "connectivity" {
+  description = "Simulated connectivity recorded by the local fixture."
+  value       = try(terraform_data.this.output.connectivity, null)
+}

--- a/examples/compelete/modules/connectivity/variables.tf
+++ b/examples/compelete/modules/connectivity/variables.tf
@@ -1,0 +1,23 @@
+variable "context" {
+  description = "Context for the local connectivity fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "apps_network" {
+  description = "Apps network for the local connectivity fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}
+
+variable "data_network" {
+  description = "Data network for the local connectivity fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}
+
+variable "transit" {
+  description = "Transit for the local connectivity fixture."
+  type        = object({ id = string, owner_account_id = string, region = string })
+  nullable    = false
+}

--- a/examples/compelete/modules/connectivity/versions.tf
+++ b/examples/compelete/modules/connectivity/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/database/.terraform.lock.hcl
+++ b/examples/compelete/modules/database/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/database/main.tf
+++ b/examples/compelete/modules/database/main.tf
@@ -1,0 +1,38 @@
+locals {
+  prefix = "${var.context.tenant}-${var.context.region_code}"
+  name   = "${local.prefix}-rds-${var.context.stage}-commerce"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    database = {
+      endpoint   = "${local.name}.rds.example.invalid"
+      port       = 5432
+      name       = "commerce"
+      account_id = var.context.account_id
+      vpc_id     = var.network.id
+    }
+    credentials = {
+      username = "fixture_app"
+      password = "fixture-only-${var.context.stage}-not-a-real-password"
+    }
+    private_subnet_ids    = var.network.private_subnet_ids
+    multi_az              = var.data_config.multi_az
+    backup_retention_days = var.data_config.backup_retention_days
+    encrypted             = true
+    publicly_accessible   = false
+    tags                  = merge(var.context.tags, { Name = local.name, Attributes = "commerce" })
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.network.account_id && var.context.region == var.network.region
+      error_message = "Network belongs to another account or region; connect this environment's network export."
+    }
+    precondition {
+      condition     = var.context.stage != "prd" || (var.data_config.multi_az && var.data_config.backup_retention_days >= 7)
+      error_message = "Production database requires multi-AZ and at least seven backup days; update data_config."
+    }
+  }
+}

--- a/examples/compelete/modules/database/outputs.tf
+++ b/examples/compelete/modules/database/outputs.tf
@@ -1,0 +1,11 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "database" {
+  description = "Simulated database recorded by the local fixture."
+  value       = try(terraform_data.this.output.database, null)
+}
+
+output "credentials" {
+  description = "Simulated credentials recorded by the local fixture."
+  value       = try(terraform_data.this.output.credentials, null)
+  sensitive   = true
+}

--- a/examples/compelete/modules/database/variables.tf
+++ b/examples/compelete/modules/database/variables.tf
@@ -1,0 +1,22 @@
+variable "context" {
+  description = "Context for the local database fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "network" {
+  description = "Network for the local database fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}
+
+variable "data_config" {
+  description = "Data config for the local database fixture."
+  type        = object({ multi_az = bool, backup_retention_days = number, cache_nodes = number })
+  nullable    = false
+
+  validation {
+    condition     = var.data_config.backup_retention_days >= 1 && var.data_config.backup_retention_days <= 35 && var.data_config.cache_nodes >= 1
+    error_message = "Use 1-35 backup days and at least one cache node."
+  }
+}

--- a/examples/compelete/modules/database/versions.tf
+++ b/examples/compelete/modules/database/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/eks/.terraform.lock.hcl
+++ b/examples/compelete/modules/eks/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/eks/main.tf
+++ b/examples/compelete/modules/eks/main.tf
@@ -1,0 +1,36 @@
+locals {
+  prefix = "${var.context.tenant}-${var.context.region_code}"
+  name   = "${local.prefix}-eks-${var.context.stage}-commerce"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    cluster = {
+      name              = local.name
+      arn               = "arn:aws:eks:${var.context.region}:${var.context.account_id}:cluster/${local.name}"
+      endpoint          = "https://${local.name}.eks.example.invalid"
+      oidc_provider_arn = "arn:aws:iam::${var.context.account_id}:oidc-provider/oidc.eks.${var.context.region}.amazonaws.com/id/${upper(substr(sha256(local.name), 0, 32))}"
+      account_id        = var.context.account_id
+      vpc_id            = var.network.id
+      version           = var.cluster_config.version
+    }
+    private_subnet_ids         = var.network.private_subnet_ids
+    endpoint_private_access    = var.cluster_config.private_endpoint
+    endpoint_public_access     = !var.cluster_config.private_endpoint
+    secrets_encryption_key_arn = var.telemetry.kms_key_arn
+    control_plane_logs         = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+    tags                       = merge(var.context.tags, { Name = local.name, Attributes = "commerce" })
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.network.account_id && var.context.region == var.network.region
+      error_message = "Network belongs to another account or region; connect this environment's network export."
+    }
+    precondition {
+      condition     = var.context.stage != "prd" || var.cluster_config.private_endpoint
+      error_message = "Production clusters require private endpoints; set cluster_config.private_endpoint to true."
+    }
+  }
+}

--- a/examples/compelete/modules/eks/outputs.tf
+++ b/examples/compelete/modules/eks/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "cluster" {
+  description = "Simulated cluster recorded by the local fixture."
+  value       = try(terraform_data.this.output.cluster, null)
+}

--- a/examples/compelete/modules/eks/variables.tf
+++ b/examples/compelete/modules/eks/variables.tf
@@ -1,0 +1,23 @@
+variable "context" {
+  description = "Context for the local eks fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "network" {
+  description = "Network for the local eks fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}
+
+variable "telemetry" {
+  description = "Telemetry for the local eks fixture."
+  type        = object({ archive_bucket_arn = string, kms_key_arn = string, endpoint = string })
+  nullable    = false
+}
+
+variable "cluster_config" {
+  description = "Cluster config for the local eks fixture."
+  type        = object({ version = string, private_endpoint = optional(bool, true) })
+  nullable    = false
+}

--- a/examples/compelete/modules/eks/versions.tf
+++ b/examples/compelete/modules/eks/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/guardrails/.terraform.lock.hcl
+++ b/examples/compelete/modules/guardrails/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/guardrails/main.tf
+++ b/examples/compelete/modules/guardrails/main.tf
@@ -1,0 +1,15 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    context = var.context
+    controls = {
+      cloudtrail          = true
+      config_recorder     = true
+      guardduty           = true
+      deny_public_buckets = true
+      require_encryption  = true
+      allowed_regions     = [var.context.region]
+    }
+  }
+
+}

--- a/examples/compelete/modules/guardrails/outputs.tf
+++ b/examples/compelete/modules/guardrails/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "context" {
+  description = "Simulated context recorded by the local fixture."
+  value       = try(terraform_data.this.output.context, null)
+}

--- a/examples/compelete/modules/guardrails/variables.tf
+++ b/examples/compelete/modules/guardrails/variables.tf
@@ -1,0 +1,5 @@
+variable "context" {
+  description = "Context for the local guardrails fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/guardrails/versions.tf
+++ b/examples/compelete/modules/guardrails/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/landscape/.terraform.lock.hcl
+++ b/examples/compelete/modules/landscape/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/landscape/main.tf
+++ b/examples/compelete/modules/landscape/main.tf
@@ -1,0 +1,15 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    environments = { dev = var.dev, stg = var.stg, prd = var.prd }
+    summary      = "3 environments, 6 application endpoints; all infrastructure is simulated locally"
+
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(distinct([var.dev.account_id, var.stg.account_id, var.prd.account_id])) == 3
+      error_message = "Use a separate account for dev, stg, and prd; correct the environment account IDs."
+    }
+  }
+}

--- a/examples/compelete/modules/landscape/outputs.tf
+++ b/examples/compelete/modules/landscape/outputs.tf
@@ -1,0 +1,10 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "environments" {
+  description = "Simulated environments recorded by the local fixture."
+  value       = try(terraform_data.this.output.environments, null)
+}
+
+output "summary" {
+  description = "Simulated summary recorded by the local fixture."
+  value       = try(terraform_data.this.output.summary, null)
+}

--- a/examples/compelete/modules/landscape/variables.tf
+++ b/examples/compelete/modules/landscape/variables.tf
@@ -1,0 +1,17 @@
+variable "dev" {
+  description = "Dev for the local landscape fixture."
+  type        = object({ stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string) })
+  nullable    = false
+}
+
+variable "stg" {
+  description = "Stg for the local landscape fixture."
+  type        = object({ stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string) })
+  nullable    = false
+}
+
+variable "prd" {
+  description = "Prd for the local landscape fixture."
+  type        = object({ stage = string, account_id = string, cluster_name = string, apps_vpc_id = string, data_vpc_id = string, services = list(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/landscape/versions.tf
+++ b/examples/compelete/modules/landscape/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/node-pool/.terraform.lock.hcl
+++ b/examples/compelete/modules/node-pool/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/node-pool/main.tf
+++ b/examples/compelete/modules/node-pool/main.tf
@@ -1,0 +1,21 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    pool = {
+      name          = "${var.cluster.name}-${var.pool_config.name}"
+      cluster_name  = var.cluster.name
+      desired_size  = var.pool_config.desired_size
+      capacity_type = var.pool_config.capacity_type
+    }
+    scaling        = { min = var.pool_config.min_size, max = var.pool_config.max_size }
+    instance_types = ["m7i.large", "m7a.large"]
+    tags           = merge(var.context.tags, { Name = "${var.cluster.name}-${var.pool_config.name}", Attributes = var.pool_config.name })
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.cluster.account_id
+      error_message = "Cluster belongs to another account; connect this environment's cluster export."
+    }
+  }
+}

--- a/examples/compelete/modules/node-pool/outputs.tf
+++ b/examples/compelete/modules/node-pool/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "pool" {
+  description = "Simulated pool recorded by the local fixture."
+  value       = try(terraform_data.this.output.pool, null)
+}

--- a/examples/compelete/modules/node-pool/variables.tf
+++ b/examples/compelete/modules/node-pool/variables.tf
@@ -1,0 +1,22 @@
+variable "context" {
+  description = "Context for the local node-pool fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "cluster" {
+  description = "Cluster for the local node-pool fixture."
+  type        = object({ name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string })
+  nullable    = false
+}
+
+variable "pool_config" {
+  description = "Pool config for the local node-pool fixture."
+  type        = object({ name = string, capacity_type = string, min_size = number, desired_size = number, max_size = number })
+  nullable    = false
+
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT"], var.pool_config.capacity_type) && var.pool_config.min_size >= 1 && var.pool_config.min_size <= var.pool_config.desired_size && var.pool_config.desired_size <= var.pool_config.max_size
+    error_message = "Use ON_DEMAND or SPOT and require 1 <= min_size <= desired_size <= max_size."
+  }
+}

--- a/examples/compelete/modules/node-pool/versions.tf
+++ b/examples/compelete/modules/node-pool/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/organization/.terraform.lock.hcl
+++ b/examples/compelete/modules/organization/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/organization/main.tf
+++ b/examples/compelete/modules/organization/main.tf
@@ -1,0 +1,8 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    organization = var.organization
+    dns_zone     = var.organization.domain
+  }
+
+}

--- a/examples/compelete/modules/organization/outputs.tf
+++ b/examples/compelete/modules/organization/outputs.tf
@@ -1,0 +1,10 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "organization" {
+  description = "Simulated organization recorded by the local fixture."
+  value       = try(terraform_data.this.output.organization, null)
+}
+
+output "dns_zone" {
+  description = "Reserved DNS suffix for simulated application endpoints."
+  value       = try(terraform_data.this.output.dns_zone, null)
+}

--- a/examples/compelete/modules/organization/variables.tf
+++ b/examples/compelete/modules/organization/variables.tf
@@ -1,0 +1,5 @@
+variable "organization" {
+  description = "Organization for the local organization fixture."
+  type        = object({ tenant = string, namespace = string, region = string, region_code = string, domain = string, tags = map(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/organization/versions.tf
+++ b/examples/compelete/modules/organization/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/pod-identity/.terraform.lock.hcl
+++ b/examples/compelete/modules/pod-identity/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/pod-identity/main.tf
+++ b/examples/compelete/modules/pod-identity/main.tf
@@ -1,0 +1,31 @@
+locals {
+  prefix = "${var.context.tenant}-${var.context.region_code}"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    identity = {
+      role_arn        = "arn:aws:iam::${var.context.account_id}:role/${local.prefix}-role-${var.context.stage}-eks-${var.service_config.name}"
+      namespace       = var.service_config.name
+      service_account = var.service_config.name
+      account_id      = var.context.account_id
+      cluster_name    = var.cluster.name
+    }
+    trust_service   = "pods.eks.amazonaws.com"
+    allowed_actions = var.service_config.name == "checkout" ? ["sqs:SendMessage"] : ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+    queue_arn       = var.queue.arn
+    tags            = merge(var.context.tags, { Name = "${local.prefix}-role-${var.context.stage}-eks-${var.service_config.name}", Attributes = var.service_config.name })
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.cluster.account_id
+      error_message = "Cluster belongs to another account; connect this environment's cluster export."
+    }
+    precondition {
+      condition     = var.queue.account_id == var.context.account_id
+      error_message = "Queue belongs to another account; connect the environment queue."
+    }
+  }
+}

--- a/examples/compelete/modules/pod-identity/outputs.tf
+++ b/examples/compelete/modules/pod-identity/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "identity" {
+  description = "Simulated identity recorded by the local fixture."
+  value       = try(terraform_data.this.output.identity, null)
+}

--- a/examples/compelete/modules/pod-identity/variables.tf
+++ b/examples/compelete/modules/pod-identity/variables.tf
@@ -1,0 +1,23 @@
+variable "context" {
+  description = "Context for the local pod-identity fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "cluster" {
+  description = "Cluster for the local pod-identity fixture."
+  type        = object({ name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string })
+  nullable    = false
+}
+
+variable "queue" {
+  description = "Queue for the local pod-identity fixture."
+  type        = object({ arn = string, url = string, account_id = string })
+  nullable    = false
+}
+
+variable "service_config" {
+  description = "Service config for the local pod-identity fixture."
+  type        = object({ name = string, image_tag = string, replicas = number })
+  nullable    = false
+}

--- a/examples/compelete/modules/pod-identity/versions.tf
+++ b/examples/compelete/modules/pod-identity/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/queue/.terraform.lock.hcl
+++ b/examples/compelete/modules/queue/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/queue/main.tf
+++ b/examples/compelete/modules/queue/main.tf
@@ -1,0 +1,19 @@
+locals {
+  prefix = "${var.context.tenant}-${var.context.region_code}"
+  name   = "${local.prefix}-sqs-${var.context.stage}-orders"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    queue = {
+      arn        = "arn:aws:sqs:${var.context.region}:${var.context.account_id}:${local.name}"
+      url        = "https://sqs.${var.context.region}.amazonaws.com/${var.context.account_id}/${local.name}"
+      account_id = var.context.account_id
+    }
+    dead_letter_queue = "${local.name}-dlq"
+    max_receive_count = 5
+    tags              = merge(var.context.tags, { Name = local.name, Attributes = "orders" })
+  }
+
+}

--- a/examples/compelete/modules/queue/outputs.tf
+++ b/examples/compelete/modules/queue/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "queue" {
+  description = "Simulated queue recorded by the local fixture."
+  value       = try(terraform_data.this.output.queue, null)
+}

--- a/examples/compelete/modules/queue/variables.tf
+++ b/examples/compelete/modules/queue/variables.tf
@@ -1,0 +1,5 @@
+variable "context" {
+  description = "Context for the local queue fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/queue/versions.tf
+++ b/examples/compelete/modules/queue/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/release/.terraform.lock.hcl
+++ b/examples/compelete/modules/release/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/release/main.tf
+++ b/examples/compelete/modules/release/main.tf
@@ -1,0 +1,20 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    release = {
+      stage        = var.context.stage
+      account_id   = var.context.account_id
+      cluster_name = var.cluster.name
+      apps_vpc_id  = var.connectivity.apps_vpc_id
+      data_vpc_id  = var.connectivity.data_vpc_id
+      services     = [var.checkout.url, var.payments.url]
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.checkout.account_id == var.context.account_id && var.payments.account_id == var.context.account_id && var.checkout.cluster_name == var.cluster.name && var.payments.cluster_name == var.cluster.name
+      error_message = "Both applications must be released into this account and cluster; correct the service exports."
+    }
+  }
+}

--- a/examples/compelete/modules/release/outputs.tf
+++ b/examples/compelete/modules/release/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "release" {
+  description = "Simulated release recorded by the local fixture."
+  value       = try(terraform_data.this.output.release, null)
+}

--- a/examples/compelete/modules/release/variables.tf
+++ b/examples/compelete/modules/release/variables.tf
@@ -1,0 +1,29 @@
+variable "context" {
+  description = "Context for the local release fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "cluster" {
+  description = "Cluster for the local release fixture."
+  type        = object({ name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string })
+  nullable    = false
+}
+
+variable "connectivity" {
+  description = "Connectivity for the local release fixture."
+  type        = object({ apps_vpc_id = string, data_vpc_id = string, account_id = string, route_domain = string, transit_gateway_id = string })
+  nullable    = false
+}
+
+variable "checkout" {
+  description = "Checkout for the local release fixture."
+  type        = object({ name = string, url = string, image = string, replicas = number, account_id = string, cluster_name = string })
+  nullable    = false
+}
+
+variable "payments" {
+  description = "Payments for the local release fixture."
+  type        = object({ name = string, url = string, image = string, replicas = number, account_id = string, cluster_name = string })
+  nullable    = false
+}

--- a/examples/compelete/modules/release/versions.tf
+++ b/examples/compelete/modules/release/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/shared-services/.terraform.lock.hcl
+++ b/examples/compelete/modules/shared-services/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/shared-services/main.tf
+++ b/examples/compelete/modules/shared-services/main.tf
@@ -1,0 +1,15 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    registry = {
+      repository_url   = "${var.context.account_id}.dkr.ecr.${var.context.region}.amazonaws.com/commerce"
+      owner_account_id = var.context.account_id
+    }
+    dns_zone             = var.domain
+    image_tag_mutability = "IMMUTABLE"
+    cross_account_pull   = ["dev", "stg", "prd"]
+    audit_archive_arn    = var.telemetry.archive_bucket_arn
+    tags                 = var.context.tags
+  }
+
+}

--- a/examples/compelete/modules/shared-services/outputs.tf
+++ b/examples/compelete/modules/shared-services/outputs.tf
@@ -1,0 +1,10 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "registry" {
+  description = "Simulated registry recorded by the local fixture."
+  value       = try(terraform_data.this.output.registry, null)
+}
+
+output "dns_zone" {
+  description = "Simulated dns zone recorded by the local fixture."
+  value       = try(terraform_data.this.output.dns_zone, null)
+}

--- a/examples/compelete/modules/shared-services/variables.tf
+++ b/examples/compelete/modules/shared-services/variables.tf
@@ -1,0 +1,17 @@
+variable "context" {
+  description = "Context for the local shared-services fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "telemetry" {
+  description = "Telemetry for the local shared-services fixture."
+  type        = object({ archive_bucket_arn = string, kms_key_arn = string, endpoint = string })
+  nullable    = false
+}
+
+variable "domain" {
+  description = "Domain for the local shared-services fixture."
+  type        = string
+  nullable    = false
+}

--- a/examples/compelete/modules/shared-services/versions.tf
+++ b/examples/compelete/modules/shared-services/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/transit/.terraform.lock.hcl
+++ b/examples/compelete/modules/transit/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/transit/main.tf
+++ b/examples/compelete/modules/transit/main.tf
@@ -1,0 +1,22 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    transit = {
+      id               = "tgw-${substr(sha256(var.network.id), 0, 17)}"
+      owner_account_id = var.context.account_id
+      region           = var.context.region
+    }
+    hub_vpc_id                      = var.network.id
+    ram_principals                  = ["organization"]
+    default_route_table_association = false
+    default_route_table_propagation = false
+    route_domains                   = ["dev", "stg", "prd"]
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.network.account_id && var.context.region == var.network.region
+      error_message = "Network belongs to another account or region; connect this environment's network export."
+    }
+  }
+}

--- a/examples/compelete/modules/transit/outputs.tf
+++ b/examples/compelete/modules/transit/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "transit" {
+  description = "Simulated transit recorded by the local fixture."
+  value       = try(terraform_data.this.output.transit, null)
+}

--- a/examples/compelete/modules/transit/variables.tf
+++ b/examples/compelete/modules/transit/variables.tf
@@ -1,0 +1,11 @@
+variable "context" {
+  description = "Context for the local transit fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "network" {
+  description = "Network for the local transit fixture."
+  type        = object({ id = string, account_id = string, region = string, cidr = string, private_subnet_ids = list(string), private_subnet_cidrs = list(string) })
+  nullable    = false
+}

--- a/examples/compelete/modules/transit/versions.tf
+++ b/examples/compelete/modules/transit/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/vpc/.terraform.lock.hcl
+++ b/examples/compelete/modules/vpc/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/vpc/main.tf
+++ b/examples/compelete/modules/vpc/main.tf
@@ -1,0 +1,32 @@
+locals {
+  availability_zones = length(var.network_config.availability_zones) > 0 ? var.network_config.availability_zones : [for suffix in ["a", "b", "c"] : "${var.context.region}${suffix}"]
+  prefix             = "${var.context.tenant}-${var.context.region_code}"
+  name               = "${local.prefix}-vpc-${var.context.stage}-${var.network_config.purpose}"
+  identity           = "${var.context.account_id}-${local.name}"
+}
+
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    network = {
+      id                   = "vpc-${substr(sha256(local.identity), 0, 17)}"
+      account_id           = var.context.account_id
+      region               = var.context.region
+      cidr                 = var.network_config.cidr
+      private_subnet_ids   = [for az in local.availability_zones : "subnet-${substr(sha256("${local.identity}-${az}"), 0, 17)}"]
+      private_subnet_cidrs = [for index, az in local.availability_zones : cidrsubnet(var.network_config.cidr, 4, index)]
+    }
+    public_subnet_cidrs = var.network_config.nat_gateways > 0 ? [for index, az in local.availability_zones : cidrsubnet(var.network_config.cidr, 8, index + 128)] : []
+    nat_gateways        = var.network_config.nat_gateways
+    endpoints           = ["s3", "ecr.api", "ecr.dkr", "sts", "logs", "secretsmanager"]
+    tags                = merge(var.context.tags, { Name = local.name, Attributes = var.network_config.purpose })
+  }
+  triggers_replace = [var.network_config.cidr]
+
+  lifecycle {
+    precondition {
+      condition     = alltrue([for az in local.availability_zones : startswith(az, var.context.region)])
+      error_message = "Availability zones must belong to the account context region; correct network_config.availability_zones."
+    }
+  }
+}

--- a/examples/compelete/modules/vpc/outputs.tf
+++ b/examples/compelete/modules/vpc/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "network" {
+  description = "Simulated network recorded by the local fixture."
+  value       = try(terraform_data.this.output.network, null)
+}

--- a/examples/compelete/modules/vpc/variables.tf
+++ b/examples/compelete/modules/vpc/variables.tf
@@ -1,0 +1,16 @@
+variable "context" {
+  description = "Context for the local vpc fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "network_config" {
+  description = "Network config for the local vpc fixture."
+  type        = object({ purpose = string, cidr = string, availability_zones = optional(list(string), []), nat_gateways = optional(number, 0) })
+  nullable    = false
+
+  validation {
+    condition     = can(cidrsubnet(var.network_config.cidr, 8, 130)) && (length(var.network_config.availability_zones) == 0 || (length(var.network_config.availability_zones) >= 2 && length(var.network_config.availability_zones) <= 3)) && length(distinct(var.network_config.availability_zones)) == length(var.network_config.availability_zones) && contains([0, 1, length(var.network_config.availability_zones) == 0 ? 3 : length(var.network_config.availability_zones)], var.network_config.nat_gateways)
+    error_message = "Provide an IPv4 CIDR with room for subnets, two or three distinct AZs, and zero, one, or one NAT gateway per AZ."
+  }
+}

--- a/examples/compelete/modules/vpc/versions.tf
+++ b/examples/compelete/modules/vpc/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/modules/workload/.terraform.lock.hcl
+++ b/examples/compelete/modules/workload/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+# No external provider selections; this file enables Terragraph read-only backend preparation.

--- a/examples/compelete/modules/workload/main.tf
+++ b/examples/compelete/modules/workload/main.tf
@@ -1,0 +1,36 @@
+# Built-in state stores model apply-time outputs without providers, provisioners, or cloud access.
+resource "terraform_data" "this" {
+  input = {
+    service = {
+      name         = var.service_config.name
+      url          = "https://${var.service_config.name}.${var.context.stage}.${var.dns_zone}"
+      image        = "${var.registry.repository_url}/${var.service_config.name}:${var.service_config.image_tag}"
+      replicas     = var.service_config.replicas
+      account_id   = var.context.account_id
+      cluster_name = var.cluster.name
+    }
+    namespace            = var.identity.namespace
+    service_account      = var.identity.service_account
+    role_arn             = var.identity.role_arn
+    database_endpoint    = var.database.endpoint
+    database_credentials = var.credentials
+    cache_endpoint       = var.cache.endpoint
+    queue_url            = var.queue.url
+    tags                 = var.context.tags
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.context.account_id == var.cluster.account_id
+      error_message = "Cluster belongs to another account; connect this environment's cluster export."
+    }
+    precondition {
+      condition     = var.addons.cluster_name == var.cluster.name && var.identity.cluster_name == var.cluster.name && var.identity.account_id == var.context.account_id
+      error_message = "Add-ons and pod identity must target this cluster; correct the platform edges."
+    }
+    precondition {
+      condition     = var.connectivity.account_id == var.context.account_id && var.connectivity.apps_vpc_id == var.cluster.vpc_id && var.connectivity.data_vpc_id == var.database.vpc_id && var.cache.vpc_id == var.database.vpc_id && var.database.account_id == var.context.account_id && var.cache.account_id == var.context.account_id && var.queue.account_id == var.context.account_id
+      error_message = "Workload dependencies cross an account or VPC boundary; connect this environment's data and connectivity exports."
+    }
+  }
+}

--- a/examples/compelete/modules/workload/outputs.tf
+++ b/examples/compelete/modules/workload/outputs.tf
@@ -1,0 +1,5 @@
+# Native import records only an ID; apply must restore fixture values before consumers can run.
+output "service" {
+  description = "Simulated service recorded by the local fixture."
+  value       = try(terraform_data.this.output.service, null)
+}

--- a/examples/compelete/modules/workload/variables.tf
+++ b/examples/compelete/modules/workload/variables.tf
@@ -1,0 +1,77 @@
+variable "context" {
+  description = "Context for the local workload fixture."
+  type        = object({ account_id = string, account_name = string, tenant = string, namespace = string, stage = string, region = string, region_code = string, tags = map(string) })
+  nullable    = false
+}
+
+variable "cluster" {
+  description = "Cluster for the local workload fixture."
+  type        = object({ name = string, arn = string, endpoint = string, oidc_provider_arn = string, account_id = string, vpc_id = string, version = string })
+  nullable    = false
+}
+
+variable "addons" {
+  description = "Addons for the local workload fixture."
+  type        = object({ cluster_name = string, controllers = list(string) })
+  nullable    = false
+}
+
+variable "connectivity" {
+  description = "Connectivity for the local workload fixture."
+  type        = object({ apps_vpc_id = string, data_vpc_id = string, account_id = string, route_domain = string, transit_gateway_id = string })
+  nullable    = false
+}
+
+variable "database" {
+  description = "Database for the local workload fixture."
+  type        = object({ endpoint = string, port = number, name = string, account_id = string, vpc_id = string })
+  nullable    = false
+}
+
+variable "credentials" {
+  description = "Credentials for the local workload fixture."
+  type        = object({ username = string, password = string })
+  nullable    = false
+  sensitive   = true
+}
+
+variable "cache" {
+  description = "Cache for the local workload fixture."
+  type        = object({ endpoint = string, port = number, account_id = string, vpc_id = string })
+  nullable    = false
+}
+
+variable "queue" {
+  description = "Queue for the local workload fixture."
+  type        = object({ arn = string, url = string, account_id = string })
+  nullable    = false
+}
+
+variable "identity" {
+  description = "Identity for the local workload fixture."
+  type        = object({ role_arn = string, namespace = string, service_account = string, account_id = string, cluster_name = string })
+  nullable    = false
+}
+
+variable "registry" {
+  description = "Registry for the local workload fixture."
+  type        = object({ repository_url = string, owner_account_id = string })
+  nullable    = false
+}
+
+variable "dns_zone" {
+  description = "Dns zone for the local workload fixture."
+  type        = string
+  nullable    = false
+}
+
+variable "service_config" {
+  description = "Service config for the local workload fixture."
+  type        = object({ name = string, image_tag = string, replicas = number })
+  nullable    = false
+
+  validation {
+    condition     = contains(["checkout", "payments"], var.service_config.name) && var.service_config.replicas >= 1 && length(var.service_config.image_tag) > 0
+    error_message = "Use checkout or payments, at least one replica, and a nonempty immutable fixture image tag."
+  }
+}

--- a/examples/compelete/modules/workload/versions.tf
+++ b/examples/compelete/modules/workload/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  # An explicit local backend lets Terragraph isolate reused roots by qualified leaf name.
+  backend "local" {}
+}

--- a/examples/compelete/settings.hcl
+++ b/examples/compelete/settings.hcl
@@ -1,0 +1,8 @@
+# Runtime selection falls back to Terraform, or --tofu; named overrides are a separate lab.
+contracts { mode = "enforce" }
+snapshots {}
+tfvars { location = "workdir" }
+execution {
+  plan_ttl         = "2h"
+  record_retention = "168h"
+}

--- a/examples/compelete/verify.py
+++ b/examples/compelete/verify.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Exercise real Terragraph commands in disposable, credential-free fixture copies."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+SOURCE = Path(__file__).resolve().parent
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+class Lab:
+    def __init__(self, binary, tofu, name):
+        self.base = Path(tempfile.mkdtemp(prefix=f"terragraph-compelete-{name}-"))
+        self.root = self.base / "blueprint"
+        shutil.copytree(SOURCE, self.root, ignore=shutil.ignore_patterns(".terragraph", "__pycache__"))
+        self.command = [binary, "--blueprint", str(self.root)] + (["--tofu"] if tofu else [])
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith(("AWS_", "TF_VAR_", "TF_CLI_ARGS", "TF_LOG"))
+            and key not in ("TF_WORKSPACE", "TF_DATA_DIR")
+        }
+        self.env.update(TF_IN_AUTOMATION="1", CHECKPOINT_DISABLE="1", AWS_EC2_METADATA_DISABLED="true")
+        self.index = 0
+        print(f"{name}: {self.base}", flush=True)
+
+    def run(self, *args, expect=0, payload=True, stdin=None):
+        self.index += 1
+        command = self.command + list(args) + (["--output", "json"] if payload else [])
+        result = subprocess.run(command, env=self.env, text=True, input=stdin, capture_output=True)
+        log = self.base / f"{self.index:02d}-{args[0]}.log"
+        log.write_text(result.stdout + "\n" + result.stderr)
+        require((result.returncode == 0) if expect == 0 else (result.returncode != 0),
+                f"{' '.join(args)} exited {result.returncode}; inspect {log}")
+        print(f"  {' '.join(args)}: {'ok' if expect == 0 else 'refused as expected'}", flush=True)
+        if expect != 0:
+            return result.stdout + result.stderr
+        return json.loads(result.stdout) if payload else result.stdout
+
+    def allow_teardown(self):
+        path = self.root / "environments.hcl"
+        text = path.read_text()
+        require('approve = "safe"' in text, "production standing policy is missing")
+        path.write_text(text.replace('approve = "safe"', 'approve = "all"'))
+
+    def clean(self):
+        shutil.rmtree(self.base)
+
+
+def source_digest(root):
+    return {str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in root.rglob("*") if path.is_file() and ".terragraph" not in path.parts
+            and path.suffix in (".tf", ".hcl")}
+
+
+def smoke(lab):
+    digest = source_digest(lab.root)
+    validation = lab.run("validate")
+    require(validation == {"valid": True, "problems": []}, f"validation findings: {validation}")
+    levels = lab.run("graph")["levels"]
+    require(sum(map(len, levels)) == 63 and len(levels) == 12, "expected 63 leaves in 12 levels")
+    first = lab.run("apply", "--auto-approve", "--parallelism", "4")
+    require(len(first["nodes"]) == 63 and all(n["status"] == "applied" for n in first["nodes"]),
+            "bootstrap did not apply all 63 leaves")
+    second = lab.run("apply", "--auto-approve", "--parallelism", "4")
+    require(all(n["status"] == "unchanged" for n in second["nodes"]), "second apply is not idempotent")
+    lab.run("plan", "--parallelism", "4")
+    observation = lab.run("output", "--node", "landscape")
+    environments = observation["nodes"][0]["outputs"]["environments"]["value"]
+    require(set(environments) == {"dev", "stg", "prd"}, "missing environment in landscape")
+    require(len({value["account_id"] for value in environments.values()}) == 3, "environment accounts collide")
+    require(len({value[key] for value in environments.values() for key in ("apps_vpc_id", "data_vpc_id")}) == 6,
+            "environment VPC identities collide")
+    require(all(len(value["services"]) == 2 for value in environments.values()), "missing application endpoints")
+    require(len(list((lab.root / ".terragraph/state").glob("*.tfstate"))) == 63, "state paths are not isolated")
+    observed = lab.run("output", "--node", "dev.data.database")
+    secret = observed["nodes"][0]["outputs"]["credentials"]
+    require(secret["redacted"] and "value" not in secret, "sensitive output was disclosed")
+    snapshot = json.loads((lab.root / ".terragraph/outputs/dev.data.database.json").read_text())
+    require("credentials" in snapshot["withheld"], "sensitive snapshot output was not withheld")
+    require(all("fixture-only" not in p.read_text() for p in (lab.root / ".terragraph/outputs").glob("*.json")),
+            "snapshot contains fake credential bytes")
+    lab.run("status", "--node", "prd.platform.cluster")
+    scoped = lab.run("apply", "--node", "dev.checkout.deployment", "--auto-approve")
+    require([n["node"] for n in scoped["nodes"]] == ["dev.checkout.deployment"], "leaf selection expanded")
+    require(source_digest(lab.root) == digest, "execution modified fixture source files")
+    require(not list((lab.root / ".terragraph").rglob("*.tfplan")), "temporary plans were not removed")
+    require(not list((lab.root / ".terragraph/vars").glob("*.json")), "temporary input files were not removed")
+
+    # Matching type contracts do not replace actual-value checks inside the runtime.
+    inputs = lab.root / "environments.hcl"
+    original = inputs.read_text()
+    inputs.write_text(original.replace('version = "1.34"', 'version = "1.34", private_endpoint = false'))
+    lab.run("validate")
+    mismatch = lab.run("plan", "--node", "prd.platform.cluster", expect=1)
+    require("Production clusters require private endpoints" in mismatch, "runtime precondition did not reject public production access")
+    inputs.write_text(original)
+
+    # Contracts enforce declarations before any runtime subprocess is needed.
+    contracts = lab.root / "contracts.hcl"
+    original_contracts = contracts.read_text()
+    marker = 'consumer "./modules/workload"'
+    before, after = original_contracts.split(marker, 1)
+    start, remaining = after.split('input "credentials"', 1)
+    remaining = remaining.replace("sensitive = true", "sensitive = false", 1)
+    contracts.write_text(before + marker + start + 'input "credentials"' + remaining)
+    findings = lab.run("validate", expect=1)
+    require("C005" in findings and "C008" in findings, "sensitivity mismatch did not enforce contracts")
+    contracts.write_text(original_contracts)
+
+    # A CIDR edit is a replacement even though automatic confirmation was requested.
+    inputs.write_text(original.replace('10.16.0.0/16', '10.18.0.0/16'))
+    refusal = lab.run("apply", "--node", "dev.network.apps", "--auto-approve", expect=1)
+    require("approve" in refusal and "replace" in refusal, "safe policy did not reject VPC replacement")
+    inputs.write_text(original)
+
+    saved = lab.run("plan", "--save", "--node", "dev.checkout.deployment")
+    execution = saved["executions"][0]["id"]
+    lab.run("plan", "show", execution)
+    lab.run("apply", "--plan", execution, "--auto-approve")
+    consumed = lab.run("plan", "show", execution)
+    require(consumed["executions"][0]["status"] == "completed", "saved leaf did not complete")
+    lab.run("plan", "list")
+    blocked = lab.run("destroy", "--auto-approve", "--parallelism", "4", expect=1)
+    require("approve" in blocked, "standing production policy did not block teardown")
+    lab.allow_teardown()
+    destroyed = lab.run("destroy", "--auto-approve", "--parallelism", "4")
+    require(len(destroyed["nodes"]) == 63 and all(n["status"] == "destroyed" for n in destroyed["nodes"]),
+            "reverse-order teardown did not finish")
+
+
+def saved(lab):
+    record = lab.run("plan", "--save")["executions"][0]
+    execution = record["id"]
+    require([n["node"] for n in record["nodes"] if n.get("plan_id")] == ["organization"],
+            "fresh saved plan did not stop at the ready frontier")
+    rounds = 0
+    while record["status"] != "completed":
+        rounds += 1
+        require(rounds <= 12, "saved bootstrap exceeded the graph depth")
+        lab.run("plan", "show", execution)
+        lab.run("apply", "--plan", execution, "--auto-approve")
+        record = lab.run("plan", "show", execution)["executions"][0]
+        if record["status"] != "completed":
+            record = lab.run("plan", "--save", "--continue", execution)["executions"][0]
+    require(rounds == 12 and all(n["phase"] == "completed" for n in record["nodes"]),
+            "saved bootstrap did not complete every frontier")
+    cancel_id = lab.run("plan", "--save", "--node", "organization")["executions"][0]["id"]
+    lab.run("plan", "cancel", cancel_id)
+    lab.run("plan", "prune")
+    lab.allow_teardown()
+    lab.run("destroy", "--auto-approve", "--parallelism", "4")
+
+
+def native(lab):
+    lab.run("apply", "--node", "organization", "--auto-approve")
+    lab.run("run", "--node", "organization", "--", "init", payload=False)
+    listing = lab.run("run", "--node", "organization", "--", "state", "list", payload=False)
+    require("terraform_data.this" in listing, "native state list missed the fixture")
+    state = json.loads(lab.run("run", "--node", "organization", "--", "state", "pull", payload=False))
+    identity = state["resources"][0]["instances"][0]["attributes"]["id"]
+    lab.run("run", "--node", "organization", "--", "state", "show", "terraform_data.this", payload=False)
+    value = lab.run("run", "--node", "organization", "--", "console", payload=False,
+                    stdin="var.organization.tenant\n")
+    require('"acme"' in value, "console did not receive resolved vars")
+    lab.run("run", "--node", "organization", "--", "state", "mv", "terraform_data.this", "terraform_data.renamed", payload=False)
+    history = lab.run("plan", "list")["executions"]
+    backup_id = next(record["id"] for record in history if record["backup_available"])
+    backup = lab.run("plan", "show", backup_id, "--backup", payload=False)
+    require(identity in backup, "native backup did not preserve the previous resource")
+    lab.run("run", "--node", "organization", "--", "state", "mv", "terraform_data.renamed", "terraform_data.this", payload=False)
+    lab.run("run", "--node", "organization", "--", "state", "rm", "terraform_data.this", payload=False)
+    lab.run("run", "--node", "organization", "--", "import", "terraform_data.this", identity, payload=False)
+    lab.run("apply", "--node", "organization", "--auto-approve")
+    lab.run("destroy", "--node", "organization", "--auto-approve")
+
+
+def vendor(lab):
+    upstream = lab.base / "upstream"
+    shutil.copytree(lab.root / "modules/queue", upstream / "modules/queue")
+    (upstream / "modules/queue/README.md").write_text("Exclude this documentation when vendoring.\n")
+    for args in (("init", "-q"), ("add", "."),
+                 ("-c", "user.name=terragraph-fixture", "-c", "user.email=fixture@example.invalid",
+                  "-c", "commit.gpgsign=false", "commit", "-qm", "local fixture")):
+        subprocess.run(["git", "-C", str(upstream), *args], check=True, capture_output=True)
+    revision = subprocess.check_output(["git", "-C", str(upstream), "rev-parse", "HEAD"], text=True).strip()
+    source = "git::" + upstream.as_uri() + "//modules/queue?ref=" + revision
+    for path in lab.root.glob("*.hcl"):
+        path.unlink()
+    group_dir = lab.root / "groups/vendor-lab"
+    group_dir.mkdir()
+    (group_dir / "group.hcl").write_text('''group "vendor-lab" {
+  node "queue" { source = SOURCE }
+  export {
+    input "context" { to = node.queue.input.context }
+    output "queue" { from = node.queue.output.queue }
+  }
+}
+'''.replace("SOURCE", json.dumps(source)))
+    context = {"account_id": "444444444444", "account_name": "vendor-lab", "tenant": "acme",
+               "namespace": "commerce-platform", "stage": "dev", "region": "ap-northeast-2",
+               "region_code": "ane2", "tags": {}}
+    blueprint = 'vendor {\n  directory = "sources"\n  manifest_file = "sources.yaml"\n}\n'
+    for alias, stage in (("alpha", "dev"), ("beta", "stg")):
+        context["stage"] = stage
+        blueprint += 'use "vendor-lab" {\n as = "' + alias + '"\n source = "./groups/vendor-lab"\n vars = {context = ' + json.dumps(context) + '}\n}\n'
+    (lab.root / "blueprint.hcl").write_text(blueprint)
+    (lab.root / "sources.yaml").write_text(json.dumps({"modules": [
+        {"name": alias + ".queue", "source": source, "exclude": ["README.md"]}
+        for alias in ("alpha", "beta")]}))
+    lab.run("vendor", "--node", "alpha.queue")
+    lab.run("vendor")
+    lab.run("vendor", "--node", "alpha.queue", "--force")
+    for alias in ("alpha", "beta"):
+        package = lab.root / "sources" / (alias + ".queue")
+        require((package / ".terragraph-source.json").exists(), "source subdirectory metadata is missing")
+        require(not list(package.rglob("README.md")), "vendor exclusion did not remove documentation")
+        require(not list(package.rglob(".git")), "vendored package includes Git internals")
+    lab.run("validate")
+    lab.run("apply", "--auto-approve", "--parallelism", "2")
+    lab.run("destroy", "--auto-approve", "--parallelism", "2")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--terragraph", default="terragraph", help="built CLI path or command on PATH")
+    parser.add_argument("--tofu", action="store_true", help="use OpenTofu instead of Terraform in a fresh copy")
+    parser.add_argument("--mode", choices=("smoke", "saved", "native", "vendor", "all"), default="smoke")
+    parser.add_argument("--keep", action="store_true", help="retain successful lab copies and logs")
+    args = parser.parse_args()
+    binary = shutil.which(args.terragraph)
+    if binary is None:
+        parser.error("Terragraph binary not found; run make build and pass --terragraph ./terragraph")
+    for name in (("smoke", "saved", "native", "vendor") if args.mode == "all" else (args.mode,)):
+        lab = Lab(str(Path(binary).resolve()), args.tofu, name)
+        try:
+            globals()[name](lab)
+        except Exception:
+            print(f"FAILED: preserved fixture and logs at {lab.base}", flush=True)
+            raise
+        if not args.keep:
+            lab.clean()
+        print(f"{name}: passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/compelete/verify.py
+++ b/examples/compelete/verify.py
@@ -93,6 +93,17 @@ def smoke(lab):
     lab.run("status", "--node", "prd.platform.cluster")
     scoped = lab.run("apply", "--node", "dev.checkout.deployment", "--auto-approve")
     require([n["node"] for n in scoped["nodes"]] == ["dev.checkout.deployment"], "leaf selection expanded")
+    selection_args = ("--node", "dev.checkout.deployment", "--node", "dev.payments.deployment", "--downstream")
+    selected_graph = lab.run("graph", *selection_args)
+    selected_names = {"dev.checkout.deployment", "dev.payments.deployment", "dev.release", "landscape"}
+    require({name for level in selected_graph["levels"] for name in level} == selected_names,
+            "downstream selection did not union the two application seeds")
+    boundary_sources = {edge["from"]["node"] for edge in selected_graph["selection"]["boundary_edges"]}
+    require({"stg.release", "prd.release"} <= boundary_sources, "selection omitted external landscape inputs")
+    selected_apply = lab.run("apply", *selection_args, "--auto-approve", "--parallelism", "4")
+    require({node["node"] for node in selected_apply["nodes"]} == selected_names
+            and all(node["status"] == "unchanged" for node in selected_apply["nodes"]),
+            "selected apply expanded into other environments or skipped selected descendants")
     require(source_digest(lab.root) == digest, "execution modified fixture source files")
     require(not list((lab.root / ".terragraph").rglob("*.tfplan")), "temporary plans were not removed")
     require(not list((lab.root / ".terragraph/vars").glob("*.json")), "temporary input files were not removed")

--- a/internal/graph/compelete_example_test.go
+++ b/internal/graph/compelete_example_test.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+// TestBuild_CompeleteExample keeps the large runnable example fully contracted because validation alone permits uncovered data edges.
+func TestBuild_CompeleteExample(t *testing.T) {
+	dir, err := filepath.Abs(filepath.Join("..", "..", "examples", "compelete"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bp, err := blueprint.ParseDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := Build(bp, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.ContractMode = bp.ContractMode
+	if g.ContractMode != "enforce" {
+		t.Fatalf("contract mode = %q, want enforce", g.ContractMode)
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+	if len(g.Nodes) != 63 {
+		t.Fatalf("nodes = %d, want 63", len(g.Nodes))
+	}
+	for _, edge := range g.Edges {
+		if !edge.IsDataEdge() {
+			continue
+		}
+		producer := g.Contracts.Lookup(g.Nodes[edge.From.Node].Dir)
+		consumer := g.Contracts.Lookup(g.Nodes[edge.To.Node].Dir)
+		if producer == nil || consumer == nil {
+			t.Fatalf("edge %s -> %s has an uncontracted source", edge.From, edge.To)
+		}
+		for _, claim := range []blueprint.PortContract{producer.Producer[edge.From.Name], consumer.Consumer[edge.To.Name]} {
+			if claim.Type == "" || claim.Nullable == nil || *claim.Nullable || claim.Sensitive == nil {
+				t.Fatalf("edge %s -> %s claim = %+v, want typed non-null claim with explicit sensitivity", edge.From, edge.To, claim)
+			}
+		}
+	}
+	paths := make(map[string]string)
+	for name, node := range g.Nodes {
+		want := filepath.Join(dir, ".terragraph", "state", name+".tfstate")
+		if got := node.BackendConfig["path"]; got != want {
+			t.Fatalf("node %s state path = %q, want %q", name, got, want)
+		}
+		if other, exists := paths[want]; exists {
+			t.Fatalf("nodes %s and %s share state path %q", other, name, want)
+		}
+		paths[want] = name
+	}
+}


### PR DESCRIPTION
## Summary

This adds one runnable example that shows how Terragraph's DRY groups and contracts fit together in an AWS-style multi-account platform without needing cloud credentials or provider downloads.

- Add `examples/compelete` with six member accounts, seven VPCs, three EKS platforms, and six applications: 63 isolated root nodes composed from six reusable groups and eighteen built-in `terraform_data` fixtures.
- Enforce producer/consumer contracts on every data edge, including sensitive credentials; demonstrate parallel execution, snapshots, exact/downstream selection, approval policies, and isolated local state.
- Include disposable labs for a 12-frontier saved-plan bootstrap, scoped native operations and backups, and offline Git vendoring. A graph regression test guards complete contract coverage and isolated state paths.
- Document architecture, execution commands, teardown, and the limits of the simulation. S3 locking/storage and real AWS behavior are documented adaptation requirements, not claims of cloud integration coverage. The requested `compelete` directory spelling is preserved.

## Verification

- [x] `make check` passes locally, including race-enabled Go tests and VS Code integration tests.

```text
GOCACHE=/tmp/terragraph-compelete-go-cache make check
# 0 lint issues; docs/build/Go tests/VS Code checks passed, exit 0

# Terraform 1.5.7 on PATH
python3 examples/compelete/verify.py --terragraph ./terragraph --mode all
smoke: passed
saved: passed
native: passed
vendor: passed

# OpenTofu 1.11.0 on PATH
python3 examples/compelete/verify.py --terragraph ./terragraph --tofu --mode all
smoke: passed
saved: passed
native: passed
vendor: passed
```

The smoke lab asserts 63 initial applies, 63 unchanged nodes on the second apply, unique account/VPC/state identities, sensitive-output redaction, contract/runtime/policy refusals, four-node downstream selection with external boundary inputs, and reverse teardown.

## Checklist

- [x] Added a graph regression test and real-runtime verification labs.
- [x] Updated the example README, repository example index, and documentation index.

