### PR TITLE
feat: add optional S3 state address generation

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -136,6 +136,37 @@ An explicit relative local-backend `backend_config.path` is passed through uncha
 
 Use `backend_config` for remote backend fields such as `bucket`, `key`, `region`, and `profile`, or for an explicit local path. Entries are passed to `terraform init` as `-backend-config` options. A non-empty map requires a `backend` block in the module; it is invalid with no backend block or with a `cloud` block. A group's [`use.backend_config`](groups.md#isolating-state-for-an-instance) can supply shared defaults.
 
+An optional `backend_address` object on a `node` or `use` generates a missing S3 `key` from literal prefix and file-name fields:
+
+```hcl
+node "database" {
+  source = "./modules/database"
+  backend_config = {
+    bucket = "example-state"
+    region = "ap-northeast-2"
+  }
+  backend_address = {
+    s3_key_prefix = "prod"
+    s3_key_name   = "terraform.tfstate"
+  }
+}
+```
+
+For a module declaring `backend "s3"`, this produces `prod/database/terraform.tfstate`. Only `s3_key_prefix` and `s3_key_name` are supported; both are optional, but at least one must be present to enable generation. The construction is `[prefix/]<qualified-leaf>/<file-name>`, where the qualified leaf directory is always included automatically. Values are literal strings, with no placeholder substitution, functions, or references to other nodes.
+
+| Field | Default when generation is enabled | Meaning |
+|---|---|---|
+| `s3_key_prefix` | Empty | Literal object-key prefix, such as `prod` or `prod/team`. A trailing `/` can supply the separator before the leaf directory. |
+| `s3_key_name` | `terraform.tfstate` | Non-empty file name inside each leaf directory. `/`, `\`, `.` and `..` are not accepted as path separators or directory names. |
+
+Omitting `backend_address` inherits the enclosing `use` rule. Fields merge independently: an inner `use` overrides an outer one, and a node's fields win. Setting `s3_key_prefix = ""` clears an inherited prefix while retaining an inherited file name. Setting `backend_address = {}` disables inherited generation for that scope; a descendant may enable it again with either field.
+
+Generation runs only after existing `backend_config` inheritance is resolved, and only if `key` is absent both from that configuration and from the module's backend block. An explicit key always wins, including an inherited key or a module key whose value cannot be evaluated statically. Empty explicit keys are passed through rather than repaired. If the module cannot be inspected enough to establish key absence, terragraph requires an explicit key or disabling generation. Changing only `s3_key_name` never replaces an explicit `backend_config.key`.
+
+This convenience currently generates only the S3 `key` field. Other backend types ignore these generation fields and keep their existing configuration, including local default paths. The rule does not select a backend type or configure a bucket, credentials, workspaces, or locking. Existing static collision checks apply to generated and explicit addresses alike; inheriting one explicit key across several leaves can still be a collision. These checks retain their existing limitations for unknown backend settings and namespaces.
+
+Renaming a node or group instance, moving a leaf into a different group, or changing the selected prefix or file name can change its generated state address. Terragraph does not migrate state automatically. Preserve an existing location by setting its exact `backend_config.key` before adopting or changing a generation rule. Merely renaming a group's declaration without changing instance names or its leaf structure does not change the qualified leaf names.
+
 Validation rejects identical backend configuration maps on a shared source, known shared local state paths, and known shared S3 state addresses. It also rejects node names that collide on the filesystem, including case differences on a case-insensitive volume. These checks use statically known settings, including explicit `TF_WORKSPACE` values; they cannot resolve all backend expressions, external configuration, or credential-dependent namespaces. Warnings about unverified separation require checking the paths or backend namespaces yourself. Set distinct addresses and explicit region/endpoint settings where needed; a different profile alone does not establish a different state address.
 
 Every node receives a separate `TF_DATA_DIR` for Terraform's backend metadata, even when sources are not shared. The module's `.terraform.lock.hcl` is still shared by nodes using the same directory. Validation warns when those nodes select different runtime binaries; use separate source copies or the same runtime to avoid provider lock file conflicts.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -118,7 +118,32 @@ use "eks-service" {
 }
 ```
 
-Each module must declare a compatible backend. An inner `use` overrides inherited keys, and a node's own keys win. Use shared fields such as `bucket`, `profile`, and `region` here, and give each leaf a distinct state address. A single `key` on `use` is inherited by every leaf; terragraph does not interpolate the instance or leaf name into it. When reusing the group, also separate the instances' backend namespaces, for example with different buckets.
+Each module must declare a compatible backend. An inner `use` overrides inherited keys, and a node's own keys win. Use shared fields such as `bucket`, `profile`, and `region` here, and give each leaf a distinct state address. A single `key` on `use` is inherited by every leaf; terragraph does not interpolate the instance or leaf name into it. When reusing the group, separate the instances' addresses, for example with different buckets or the optional S3 generation rule below.
+
+For modules declaring `backend "s3"`, add `backend_address` to a `use` to generate keys only for leaves without explicit keys:
+
+```hcl
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  backend_config = {
+    bucket = "tfstate"
+    region = "ap-northeast-2"
+  }
+  backend_address = {
+    s3_key_prefix = "prod"
+    s3_key_name   = "terraform.tfstate"
+  }
+}
+```
+
+This generates `prod/checkout.cluster/terraform.tfstate` and `prod/checkout.nodegroup/terraform.tfstate`. Another instance named `payments` can use the same bucket and rule; its keys contain `payments.cluster` and `payments.nodegroup`. Nested instances include their full leaf name, such as `prod/checkout.inner.database/terraform.tfstate`. Select `dev` as the prefix to use a different environment namespace.
+
+The prefix and file name inherit independently through nested `use` blocks. For example, a leaf can declare `backend_address = { s3_key_name = "state.json" }` to keep the instance's `prod` prefix while changing its file name. An empty prefix clears an inherited prefix; `backend_address = {}` stops generation for that scope, while descendants can opt in again. Without an inherited or explicit file name, generation uses `terraform.tfstate`.
+
+Explicit `backend_config.key` values, including inherited keys, and keys declared in module backend blocks always take precedence. A leaf can retain `backend_config = { key = "legacy/database.tfstate" }` while its siblings use generated addresses. Inheriting the same explicit key across multiple leaves is still checked for collisions, not rewritten. Other backend types keep their existing behavior. See [backend address generation](blueprint.md#reusing-the-same-module-across-instances) for the full scope, field rules, and validation limits.
+
+Changing an instance name, leaf name, prefix, or file name can change generated state addresses. No state migration is performed; use explicit keys to retain existing locations when restructuring groups.
 
 ## Choosing a runtime for an instance
 

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -171,10 +171,59 @@ async function checkContractEditing(root: string): Promise<void> {
   );
 }
 
+async function checkBackendAddressEditing(root: string): Promise<void> {
+  const dir = path.join(root, "backend-address");
+  await fs.mkdir(path.join(dir, "module"), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "module", "main.tf"),
+    'output "id" { value = "x" }\n',
+  );
+  const uri = vscode.Uri.file(path.join(dir, "blueprint.hcl"));
+  const initial =
+    'node "app" {\n source = "./module"\n backend_address = {\n  s3_key_\n }\n}\n';
+  await fs.writeFile(uri.fsPath, initial);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+  await eventually("backend address prefix and name completions", async () => {
+    const completions =
+      await vscode.commands.executeCommand<vscode.CompletionList>(
+        "vscode.executeCompletionItemProvider",
+        uri,
+        document.positionAt(initial.indexOf("s3_key_") + "s3_key_".length),
+      );
+    return ["s3_key_prefix", "s3_key_name"].every((name) =>
+      completions?.items.some((item) => item.label === name),
+    );
+  });
+  const invalid = initial.replace(
+    "s3_key_",
+    's3_key_name = "../shared.tfstate"',
+  );
+  await replace(document, invalid);
+  await eventually("backend address file name diagnostic", () =>
+    vscode.languages
+      .getDiagnostics(uri)
+      .some(
+        (diagnostic) =>
+          diagnostic.source === "terragraph" &&
+          diagnostic.message.includes("backend_address.s3_key_name"),
+      ),
+  );
+  await replace(document, invalid.replace("../shared.tfstate", "state.json"));
+  await eventually(
+    "backend address repaired",
+    () => vscode.languages.getDiagnostics(uri).length === 0,
+  );
+  console.log(
+    "PASS backend address: prefix and name completion, unsaved diagnostics and repair",
+  );
+}
+
 export async function run(): Promise<void> {
   const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(root, "test workspace is required");
   await checkContractEditing(root);
+  await checkBackendAddressEditing(root);
   for (const [filename, group] of [
     ["blueprint.hcl", false],
     ["group.hcl", true],

--- a/examples/group/README.md
+++ b/examples/group/README.md
@@ -11,3 +11,20 @@ go run ../../cmd/terragraph graph
 go run ../../cmd/terragraph apply --auto-approve
 ls modules/nodegroup/*.txt   # one file per instance, named after that instance's cluster_id
 ```
+
+For an S3-backed version of this group, after its modules declare `backend "s3"`, each `use` can share a bucket while generating separate leaf keys:
+
+```hcl
+backend_config = {
+  bucket = "example-state"
+  region = "ap-northeast-2"
+}
+backend_address = {
+  s3_key_prefix = "prod"
+  s3_key_name   = "terraform.tfstate"
+}
+```
+
+Place these attributes inside both `use` blocks. The cluster keys become `prod/checkout.cluster/terraform.tfstate` and `prod/payments.cluster/terraform.tfstate`; nodegroup keys use their corresponding qualified leaf directories. A group node can set `backend_address = { s3_key_name = "state.json" }` while inheriting the prefix, or keep an existing location with `backend_config = { key = "legacy/cluster.tfstate" }`. Explicit keys still need to be distinct across instances sharing the same state namespace.
+
+The checked-in example continues to use local state and needs no AWS credentials. S3 generation fields have no effect on local backends. Renaming an instance or changing the generation fields can change S3 state locations; terragraph does not migrate them automatically.

--- a/internal/blueprint/backend_address.go
+++ b/internal/blueprint/backend_address.go
@@ -1,0 +1,31 @@
+package blueprint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+// ParseBackendAddress preserves an empty object as an explicit opt-out instead of conflating it with an absent, inherited rule.
+func ParseBackendAddress(attr *hcl.Attribute) (map[string]string, error) {
+	if attr == nil {
+		return nil, nil
+	}
+	fields, err := parseStringMapAttr(attr, "backend_address")
+	if err != nil {
+		return nil, fmt.Errorf("%w; use { s3_key_prefix = \"prod\" } or {} to disable generation", err)
+	}
+	for key, value := range fields {
+		switch key {
+		case "s3_key_prefix":
+		case "s3_key_name":
+			if value == "" || value == "." || value == ".." || strings.ContainsAny(value, `/\`) {
+				return nil, fmt.Errorf("%s: backend_address.s3_key_name: must be a non-empty file name without path separators, not . or ..; use \"terraform.tfstate\" and put directories in s3_key_prefix", attr.Range)
+			}
+		default:
+			return nil, fmt.Errorf("%s: backend_address.%s: unsupported field; use s3_key_prefix and s3_key_name for S3 key generation", attr.Range, key)
+		}
+	}
+	return fields, nil
+}

--- a/internal/blueprint/backend_address_test.go
+++ b/internal/blueprint/backend_address_test.go
@@ -1,0 +1,74 @@
+package blueprint
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseFile_BackendAddressScopes(t *testing.T) {
+	bp, err := ParseFile(writeTemp(t, `
+node "generated" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod", s3_key_name = "state.json" }
+}
+node "inherited" { source = "./module" }
+node "disabled" {
+  source = "./module"
+  backend_address = {}
+}
+use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_address = { s3_key_prefix = "dev" }
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bp.Nodes[0].BackendAddress["s3_key_prefix"]; got != "prod" {
+		t.Fatalf("pattern = %q, want %q", got, "prod")
+	}
+	if bp.Nodes[1].BackendAddress != nil || bp.Nodes[2].BackendAddress == nil || bp.Nodes[2].BackendAddress["s3_key_prefix"] != "" {
+		t.Fatalf("rules = %+v, want distinct inherited and disabled rules", bp.Nodes)
+	}
+	if got := bp.Uses[0].BackendAddress["s3_key_prefix"]; got != "dev" {
+		t.Fatalf("pattern = %q, want %q", got, "dev")
+	}
+}
+
+func TestParseFile_BackendAddressRejectsInvalidRules(t *testing.T) {
+	for _, tc := range []struct{ name, rule, want string }{
+		{"null", `null`, "map/object"},
+		{"scalar", `"prod"`, "map/object"},
+		{"list", `[]`, "map/object"},
+		{"unknown backend", `{ gcs_prefix = "prod" }`, "unsupported field"},
+		{"old pattern", `{ s3_key = "prod/{node}" }`, "unsupported field"},
+		{"null prefix", `{ s3_key_prefix = null }`, "must not be null"},
+		{"null name", `{ s3_key_name = null }`, "must not be null"},
+		{"empty name", `{ s3_key_name = "" }`, "non-empty file name"},
+		{"directory name", `{ s3_key_name = "nested/state" }`, "without path separators"},
+		{"windows directory name", `{ s3_key_name = "nested\\state" }`, "without path separators"},
+		{"parent name", `{ s3_key_name = ".." }`, "not . or .."},
+		{"current name", `{ s3_key_name = "." }`, "not . or .."},
+		{"interpolation", `{ s3_key_prefix = "${node.name}" }`, "literal map"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseFile(writeTemp(t, fmt.Sprintf("node \"app\" {\n source = \"./module\"\n backend_address = %s\n}\n", tc.rule)))
+			if err == nil || !strings.Contains(err.Error(), "node.app:") || !strings.Contains(err.Error(), "backend_address") || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want node address diagnostic containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseFile_BackendAddressUseErrorNamesInstance(t *testing.T) {
+	_, err := ParseFile(writeTemp(t, `use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_address = { s3_key_name = "" }
+}`))
+	if err == nil || !strings.Contains(err.Error(), "use.checkout:") {
+		t.Fatalf("error = %v, want use.checkout address diagnostic", err)
+	}
+}

--- a/internal/blueprint/parse.go
+++ b/internal/blueprint/parse.go
@@ -77,6 +77,7 @@ var nodeSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "source", Required: true},
 		{Name: "backend_config", Required: false},
+		{Name: "backend_address", Required: false},
 		{Name: "vars", Required: false},
 		{Name: "runtime", Required: false},
 		{Name: "env", Required: false},
@@ -118,6 +119,7 @@ var useSchema = &hcl.BodySchema{
 		{Name: "vars", Required: false},
 		{Name: "approve", Required: false},
 		{Name: "backend_config", Required: false},
+		{Name: "backend_address", Required: false},
 	},
 }
 
@@ -745,14 +747,20 @@ func parseNodeBlock(block *hcl.Block) (Node, error) {
 		return Node{}, err
 	}
 
+	backendAddress, err := ParseBackendAddress(content.Attributes["backend_address"])
+	if err != nil {
+		return Node{}, fmt.Errorf("node.%s: %w", block.Labels[0], err)
+	}
+
 	return Node{
-		Name:          block.Labels[0],
-		Source:        val.AsString(),
-		BackendConfig: backendConfig,
-		Vars:          vars,
-		Runtime:       runtime,
-		Env:           env,
-		Approve:       approve,
+		Name:           block.Labels[0],
+		Source:         val.AsString(),
+		BackendConfig:  backendConfig,
+		BackendAddress: backendAddress,
+		Vars:           vars,
+		Runtime:        runtime,
+		Env:            env,
+		Approve:        approve,
 	}, nil
 }
 
@@ -1206,15 +1214,21 @@ func parseUseBlock(block *hcl.Block) (Use, error) {
 		}
 	}
 
+	backendAddress, err := ParseBackendAddress(content.Attributes["backend_address"])
+	if err != nil {
+		return Use{}, fmt.Errorf("use.%s: %w", asVal.AsString(), err)
+	}
+
 	return Use{
-		GroupName:     block.Labels[0],
-		As:            asVal.AsString(),
-		Source:        sourceVal.AsString(),
-		Runtime:       runtime,
-		Env:           env,
-		Vars:          vars,
-		Approve:       approve,
-		BackendConfig: backendConfig,
+		GroupName:      block.Labels[0],
+		As:             asVal.AsString(),
+		Source:         sourceVal.AsString(),
+		Runtime:        runtime,
+		Env:            env,
+		Vars:           vars,
+		Approve:        approve,
+		BackendConfig:  backendConfig,
+		BackendAddress: backendAddress,
 	}, nil
 }
 

--- a/internal/blueprint/types.go
+++ b/internal/blueprint/types.go
@@ -60,7 +60,9 @@ type Node struct {
 	Name          string
 	Source        string
 	BackendConfig map[string]string
-	Vars          map[string]any
+	// BackendAddress is nil to inherit; an empty rule disables inherited generation without removing explicit backend settings.
+	BackendAddress map[string]string
+	Vars           map[string]any
 	// Runtime is the name of a `runtime` block this node explicitly selects (e.g. "tofu" for `runtime = runtime.tofu`), or "" if unset. An unset Runtime doesn't necessarily mean "the built-in terraform default": it may still inherit a runtime from an enclosing Use.Runtime override, or from the blueprint's own default-marked runtime block; see graph.Node.Runtime for the fully resolved value and engine.Engine.runtimeFor for where CLI/built-in fallback is applied on top of that.
 	Runtime string
 	// Env is optional and sets extra environment variables the node's terraform/tofu subprocess runs with (e.g. AWS_PROFILE, AWS_REGION for a per-account/per-region provider configuration), keyed by variable name. Unlike Runtime (a single, replace-on-override choice), Env cascades by merging: a node's own Env entries win key-by-key over whatever an enclosing Use.Env contributed, rather than discarding the rest of it. See graph.Node.Env for the fully merged result an enclosing chain of Use.Env overrides plus this node's own Env produces.
@@ -100,8 +102,10 @@ type Use struct {
 	Vars map[string]any
 	// Approve, if set, becomes the approve level for every node this instantiation expands to, unless that node sets its own. Like Runtime, only the instantiation site can set this and a group definition has no equivalent: how much of a reusable group may be changed unattended is a fact about where it is deployed, not about the group.
 	Approve Approve
-	// BackendConfig, if set, is merged into every node this instantiation expands to, the same way Env merges: leaf keys win. Instantiation-site fact (bucket, profile, region). Do not invent a remote key from the instance name.
+	// BackendConfig merges beneath leaf keys; shared explicit addresses must remain intact even when BackendAddress selects generation.
 	BackendConfig map[string]string
+	// BackendAddress merges prefix and file-name fields beneath leaf choices; an empty object stops inherited generation.
+	BackendAddress map[string]string
 }
 
 // ExportInput is one input port a group exposes to the outside. To may list more than one internal target: a single exposed value sometimes needs to fan out to several internal nodes that each independently need it, and, unlike execution ordering (which is inferable from the internal graph's shape), there is no way to infer that fan-out from structure alone, so the group author must declare it explicitly.

--- a/internal/cli/backend_address_unix_test.go
+++ b/internal/cli/backend_address_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPlan_BackendAddressReachesInit(t *testing.T) {
+	bp := writeRunFixture(t)
+	dir := filepath.Dir(bp)
+	logPath := filepath.Join(dir, "backend-init.log")
+	t.Setenv("TG_ADDRESS_LOG", logPath)
+	writeFixtureFile(t, filepath.Join(dir, "terraform-fake"), `#!/bin/sh
+if [ "$1" = init ]; then printf '%s\t%s\n' "$TF_DATA_DIR" "$*" >> "$TG_ADDRESS_LOG"; fi
+if [ "$1" = show ]; then printf '%s\n' '{"format_version":"1.2","resource_changes":[]}'; fi
+exit 0
+`)
+	modulePath := filepath.Join(dir, "remote", "main.tf")
+	moduleBody := "terraform {\n backend \"s3\" {}\n}\n"
+	writeFixtureFile(t, modulePath, moduleBody)
+	writeFixtureFile(t, filepath.Join(dir, "group", "group.hcl"), `group "service" {
+  node "app" {
+    source = "../remote"
+    backend_address = { s3_key_name = "state.json" }
+  }
+  node "legacy" {
+    source = "../remote"
+    backend_config = { key = "legacy.tfstate" }
+  }
+}`)
+	writeFixtureFile(t, bp, fmt.Sprintf(`runtime "custom" {
+  binary = %q
+  default = true
+}
+use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_config = { bucket = "fixture-only", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod" }
+}
+`, filepath.Join(dir, "terraform-fake")))
+	if _, _, err := runCmdAt(t, bp, "plan"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("init calls = %q, want two calls", data)
+	}
+	for _, line := range lines {
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) != 2 {
+			t.Fatalf("init observation = %q, want data dir and arguments", line)
+		}
+		name := filepath.Base(fields[0])
+		key, exists := map[string]string{"checkout.app": "prod/checkout.app/state.json", "checkout.legacy": "legacy.tfstate"}[name]
+		if !exists || fields[0] != filepath.Join(dir, ".terragraph", "tfdata", name) || !strings.Contains(fields[1], "-backend-config=key="+key+" ") {
+			t.Fatalf("init observation = %q, want isolated node data dir and key %q", line, key)
+		}
+		if !strings.Contains(fields[1], "-backend-config=bucket=fixture-only") || strings.Contains(fields[1], "s3_key_") {
+			t.Fatalf("init arguments = %q, want resolved backend settings only", fields[1])
+		}
+	}
+	if data, err := os.ReadFile(modulePath); err != nil || string(data) != moduleBody {
+		t.Fatalf("module contents = %q, error = %v, want unchanged source", data, err)
+	}
+}

--- a/internal/graph/backend_address.go
+++ b/internal/graph/backend_address.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+	"github.com/cloudfluent/terragraph/internal/module"
+)
+
+// mergeBackendAddress lets a leaf change its file name without losing the instance prefix, while {} stops inherited generation.
+func mergeBackendAddress(base, override map[string]string) map[string]string {
+	if override != nil && len(override) == 0 {
+		return override
+	}
+	return mergeEnv(base, override)
+}
+
+// fillBackendAddress runs after inheritance and qualification so explicit addresses survive and repeated groups cannot share generated keys.
+func fillBackendAddress(n *blueprint.Node, schema *module.Schema) error {
+	if len(n.BackendAddress) == 0 || schema == nil || schema.Backend != "s3" {
+		return nil
+	}
+	if _, explicit := n.BackendConfig["key"]; explicit {
+		return nil
+	}
+	if _, explicit := schema.BackendConfig["key"]; explicit || schema.BackendAttributes["key"] {
+		return nil
+	}
+	if schema.BackendAttributes == nil {
+		return fmt.Errorf("node.%s.backend_address: cannot establish whether the module declares a key; set backend_config.key explicitly or disable generation with backend_address = {}", n.Name)
+	}
+	if n.BackendConfig == nil {
+		n.BackendConfig = make(map[string]string)
+	}
+	name := n.BackendAddress["s3_key_name"]
+	if name == "" {
+		name = "terraform.tfstate"
+	}
+	// S3 keys use literal forward slashes on every OS; filesystem path cleaning would silently change the selected namespace.
+	key := n.Name + "/" + name
+	if prefix := n.BackendAddress["s3_key_prefix"]; prefix != "" {
+		key = strings.TrimSuffix(prefix, "/") + "/" + key
+	}
+	n.BackendConfig["key"] = key
+	return nil
+}

--- a/internal/graph/backend_address_test.go
+++ b/internal/graph/backend_address_test.go
@@ -1,0 +1,369 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+func TestBuild_BackendAddressQualifiedLeavesAndExceptions(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "group", "group.hcl"), `group "service" {
+  node "cluster" { source = "../module" }
+  node "database" {
+    source = "../module"
+    backend_config = { key = "legacy/database.tfstate" }
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `
+use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_config = { bucket = "checkout", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod" }
+}
+use "service" {
+  as = "payments"
+  source = "./group"
+  backend_config = { bucket = "payments", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "dev" }
+}
+node "standalone" {
+  source = "./module"
+  backend_config = { bucket = "standalone", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod" }
+}
+`)
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, buildGraph := range []func(*blueprint.Blueprint, string, ...string) (*Graph, error){Build, Build, BuildObservation} {
+		g, err := buildGraph(bp, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name, want := range map[string]string{
+			"checkout.cluster":  "prod/checkout.cluster/terraform.tfstate",
+			"payments.cluster":  "dev/payments.cluster/terraform.tfstate",
+			"checkout.database": "legacy/database.tfstate",
+			"payments.database": "legacy/database.tfstate",
+			"standalone":        "prod/standalone/terraform.tfstate",
+		} {
+			if got := g.Nodes[name].BackendConfig["key"]; got != want {
+				t.Fatalf("node.%s key = %q, want %q", name, got, want)
+			}
+		}
+		if problems := Validate(g); len(problems) != 0 {
+			t.Fatalf("problems = %v, want none", problems)
+		}
+	}
+}
+
+func TestBuild_BackendAddressNestedOverridesAndOptOut(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeBackendModule(t, filepath.Join(root, "disabled-module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "inner", "group.hcl"), `group "inner" {
+  node "inherited" { source = "../module" }
+  node "override" {
+    source = "../module"
+    backend_config = { bucket = "node-bucket" }
+    backend_address = { s3_key_prefix = "node" }
+  }
+  node "filename" {
+    source = "../module"
+    backend_address = { s3_key_name = "state.json" }
+  }
+  node "unprefixed" {
+    source = "../module"
+    backend_address = { s3_key_prefix = "" }
+  }
+  node "disabled" {
+    source = "../disabled-module"
+    backend_address = {}
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "outer", "group.hcl"), `group "outer" {
+  use "inner" {
+    as = "default"
+    source = "../inner"
+  }
+  use "inner" {
+    as = "override"
+    source = "../inner"
+    backend_config = { bucket = "inner-bucket" }
+    backend_address = { s3_key_prefix = "inner" }
+  }
+  use "inner" {
+    as = "disabled"
+    source = "../inner"
+    backend_config = { bucket = "disabled-bucket" }
+    backend_address = {}
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `use "outer" {
+  as = "prod"
+  source = "./outer"
+  backend_config = { bucket = "outer-bucket", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "outer", s3_key_name = "custom.tfstate" }
+}`)
+	g := parseAndBuild(t, root)
+	for name, want := range map[string]string{
+		"prod.default.inherited":   "outer/prod.default.inherited/custom.tfstate",
+		"prod.override.inherited":  "inner/prod.override.inherited/custom.tfstate",
+		"prod.default.override":    "node/prod.default.override/custom.tfstate",
+		"prod.override.override":   "node/prod.override.override/custom.tfstate",
+		"prod.disabled.override":   "node/prod.disabled.override/terraform.tfstate",
+		"prod.default.filename":    "outer/prod.default.filename/state.json",
+		"prod.override.filename":   "inner/prod.override.filename/state.json",
+		"prod.disabled.filename":   "prod.disabled.filename/state.json",
+		"prod.default.unprefixed":  "prod.default.unprefixed/custom.tfstate",
+		"prod.disabled.unprefixed": "prod.disabled.unprefixed/terraform.tfstate",
+	} {
+		if got := g.Nodes[name].BackendConfig["key"]; got != want {
+			t.Fatalf("node.%s key = %q, want %q", name, got, want)
+		}
+	}
+	for _, name := range []string{"prod.default.disabled", "prod.override.disabled", "prod.disabled.inherited", "prod.disabled.disabled"} {
+		if key, exists := g.Nodes[name].BackendConfig["key"]; exists {
+			t.Fatalf("node.%s key = %q, want no generated key", name, key)
+		}
+	}
+	for name, bucket := range map[string]string{"prod.default.inherited": "outer-bucket", "prod.override.inherited": "inner-bucket", "prod.override.override": "node-bucket"} {
+		cfg := g.Nodes[name].BackendConfig
+		if cfg["bucket"] != bucket || cfg["region"] != "ap-northeast-2" {
+			t.Fatalf("node.%s config = %v, want bucket %q and inherited region", name, cfg, bucket)
+		}
+	}
+}
+
+func TestBuild_BackendAddressDoesNotRepairInheritedCollision(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "group", "group.hcl"), `group "service" {
+  node "a" {
+    source = "../module"
+    backend_config = { profile = "first" }
+  }
+  node "b" {
+    source = "../module"
+    backend_config = { profile = "second" }
+    backend_address = { s3_key_prefix = "override" }
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_config = { bucket = "shared", key = "shared.tfstate", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+	if err := parseAndBuildErr(t, root); err == nil || !strings.Contains(err.Error(), "same s3 state") {
+		t.Fatalf("error = %v, want inherited state collision despite different profiles", err)
+	}
+}
+
+func TestValidate_BackendAddressGeneratedExplicitCollision(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "generated"), s3Backend)
+	writeBackendModule(t, filepath.Join(root, "explicit"), `terraform {
+  backend "s3" {
+    bucket = "shared"
+    key = "prod/generated/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "generated" {
+  source = "./generated"
+  backend_config = { bucket = "shared", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod" }
+}
+node "explicit" { source = "./explicit" }
+`)
+	if problems := Validate(parseAndBuild(t, root)); !hasErrorContaining(problems, "same s3 state") {
+		t.Fatalf("problems = %v, want generated/explicit state collision", problems)
+	}
+}
+
+func TestValidate_BackendAddressGeneratedKeysStayDistinct(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "a" {
+  source = "./module"
+  backend_config = { bucket = "shared", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod", s3_key_name = "state.json" }
+}
+node "ab" {
+  source = "./module"
+  backend_config = { bucket = "shared", region = "ap-northeast-2" }
+  backend_address = { s3_key_prefix = "prod/", s3_key_name = "state.json" }
+}
+`)
+	g := parseAndBuild(t, root)
+	for _, name := range []string{"a", "ab"} {
+		if got, want := g.Nodes[name].BackendConfig["key"], "prod/"+name+"/state.json"; got != want {
+			t.Fatalf("node.%s key = %q, want %q", name, got, want)
+		}
+	}
+	if problems := Validate(g); len(problems) != 0 {
+		t.Fatalf("problems = %v, want no generated/generated collision", problems)
+	}
+}
+
+func TestBuild_BackendAddressPreservesModuleKeys(t *testing.T) {
+	for _, key := range []string{`"legacy.tfstate"`, `var.state_key`, `""`} {
+		t.Run(key, func(t *testing.T) {
+			root := t.TempDir()
+			writeBackendModule(t, filepath.Join(root, "module"), fmt.Sprintf("terraform {\n backend \"s3\" { key = %s }\n}\n", key))
+			writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+			if got, exists := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; exists {
+				t.Fatalf("init override = %q, want module key %s preserved", got, key)
+			}
+		})
+	}
+}
+
+func TestBuild_BackendAddressPreservesEmptyExplicitKey(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_config = { key = "" }
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+	if got, exists := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; !exists || got != "" {
+		t.Fatalf("key = %q, exists = %v, want unchanged empty explicit key", got, exists)
+	}
+}
+
+func TestBuild_BackendAddressUnknownNonAddressDoesNotBlockGeneration(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), `terraform {
+  backend "s3" {
+    endpoints = { s3 = "https://example.invalid" }
+  }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+	if got := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; got != "prod/app/terraform.tfstate" {
+		t.Fatalf("key = %q, want %q", got, "prod/app/terraform.tfstate")
+	}
+}
+
+func TestBuild_BackendAddressOtherBackendsUnchanged(t *testing.T) {
+	for _, backend := range []string{"local", "gcs", "azurerm", "http", "remote", "cloud", ""} {
+		t.Run(backend, func(t *testing.T) {
+			root := t.TempDir()
+			body := ""
+			if backend == "cloud" {
+				body = cloudBackend
+			} else if backend != "" {
+				body = fmt.Sprintf("terraform {\n backend %q {}\n}\n", backend)
+			}
+			writeBackendModule(t, filepath.Join(root, "module"), body)
+			writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+			cfg := parseAndBuild(t, root).Nodes["app"].BackendConfig
+			if backend == "local" {
+				if want := filepath.Join(root, ".terragraph", "state", "app.tfstate"); len(cfg) != 1 || cfg["path"] != want {
+					t.Fatalf("config = %v, want unchanged local path %q", cfg, want)
+				}
+			} else if len(cfg) != 0 {
+				t.Fatalf("config = %v, want no generated address for %q", cfg, backend)
+			}
+		})
+	}
+}
+
+func TestBuild_BackendAddressRespectsEffectiveModuleOverride(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), `terraform {
+  backend "s3" { key = var.discarded }
+}`)
+	writeFixtureFile(t, filepath.Join(root, "module", "override.tf"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+	if got := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; got != "prod/app/terraform.tfstate" {
+		t.Fatalf("key = %q, want generation after the override removes the old key", got)
+	}
+	writeFixtureFile(t, filepath.Join(root, "module", "override.tf"), `terraform {
+  backend "s3" { key = var.existing }
+}`)
+	if got, exists := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; exists {
+		t.Fatalf("init key override = %q, want effective module expression preserved", got)
+	}
+}
+
+func TestBuild_BackendAddressPreservesJSONModuleKey(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "module", "main.tf.json"), `{"terraform":{"backend":{"s3":{"key":"${var.state_key}"}}}}`)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`)
+	if got, exists := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; exists {
+		t.Fatalf("init key override = %q, want JSON module expression preserved", got)
+	}
+}
+
+func TestBuild_BackendAddressUnreadableAttributesRequireExplicitKey(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), `terraform {
+  backend "s3" {
+    unexpected {}
+  }
+}`)
+	body := `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod" }
+}`
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), body)
+	if err := parseAndBuildErr(t, root); err == nil || !strings.Contains(err.Error(), "cannot establish whether") || !strings.Contains(err.Error(), "set backend_config.key") {
+		t.Fatalf("error = %v, want unresolved key presence with remedy", err)
+	}
+	bp, err := blueprint.ParseFile(filepath.Join(root, "blueprint.hcl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := BuildObservation(bp, root)
+	if err != nil || g == nil || g.Nodes["app"].ObservationError == nil {
+		t.Fatalf("observation graph = %v, error = %v, want per-node observation failure", g, err)
+	}
+	if key, exists := g.Nodes["app"].BackendConfig["key"]; exists {
+		t.Fatalf("observed key = %q, want no guessed address", key)
+	}
+}
+
+func TestBuild_BackendAddressPrefixIsLiteral(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" {
+  source = "./module"
+  backend_address = { s3_key_prefix = "prod//{literal}", s3_key_name = "state.json" }
+}`)
+	if got := parseAndBuild(t, root).Nodes["app"].BackendConfig["key"]; got != "prod//{literal}/app/state.json" {
+		t.Fatalf("key = %q, want literal prefix without interpolation or path cleaning", got)
+	}
+}
+
+func TestBuild_BackendAddressIsOptIn(t *testing.T) {
+	root := t.TempDir()
+	writeBackendModule(t, filepath.Join(root, "module"), s3Backend)
+	writeFixtureFile(t, filepath.Join(root, "blueprint.hcl"), `node "app" { source = "./module" }`)
+	if cfg := parseAndBuild(t, root).Nodes["app"].BackendConfig; len(cfg) != 0 {
+		t.Fatalf("config = %v, want no generated key without a rule", cfg)
+	}
+}

--- a/internal/graph/build.go
+++ b/internal/graph/build.go
@@ -42,7 +42,7 @@ type Graph struct {
 	Snapshots bool
 }
 
-// cloneNode returns a value copy of n with its BackendConfig/Vars/Env maps deep-copied. n.Nodes for a group instantiation come from a group definition that resolveContext.parseGroupDir may hand back to more than one `use` site (see loadGroupDef); without this, every instance of the same group would share the exact same underlying BackendConfig/Vars/Env map objects, since a plain struct copy only copies the map header, not its contents.
+// cloneNode deep-copies node maps because cached group definitions otherwise let one instance's resolved settings mutate every other instance.
 func cloneNode(n blueprint.Node) blueprint.Node {
 	if n.BackendConfig != nil {
 		clone := make(map[string]string, len(n.BackendConfig))
@@ -50,6 +50,13 @@ func cloneNode(n blueprint.Node) blueprint.Node {
 			clone[k] = v
 		}
 		n.BackendConfig = clone
+	}
+	if n.BackendAddress != nil {
+		clone := make(map[string]string, len(n.BackendAddress))
+		for k, v := range n.BackendAddress {
+			clone[k] = v
+		}
+		n.BackendAddress = clone
 	}
 	if n.Vars != nil {
 		clone := make(map[string]any, len(n.Vars))
@@ -101,7 +108,7 @@ func buildRoot(bp *blueprint.Blueprint, baseDir string, observation bool, cliBin
 	if rt, ok := bp.DefaultRuntime(); ok {
 		fallback = rt.Binary
 	}
-	g, _, err := build(bp, baseDir, "", nil, nil, nil, "", &resolveContext{observation: observation, rootDir: baseDir, rootVendorDir: filepath.Join(baseDir, bp.VendorDirectory()), fallbackBinary: fallback})
+	g, _, err := build(bp, baseDir, "", nil, nil, nil, nil, "", &resolveContext{observation: observation, rootDir: baseDir, rootVendorDir: filepath.Join(baseDir, bp.VendorDirectory()), fallbackBinary: fallback})
 	if g != nil {
 		g.Lock = bp.Lock
 		g.Snapshots = bp.Snapshots != nil && bp.Snapshots.Enabled
@@ -125,7 +132,7 @@ func fillLocalBackendPath(cfg map[string]string, schema *module.Schema, rootDir,
 }
 
 // build resolves bp into a Graph, also returning this scope's own use instances (keyed by their unqualified `as` name), needed by a caller that is itself resolving a group's Export, since an export mapping may reference either a plain internal node or one of this same group's own use instances (see resolveExportEndpoint). ambient is the runtime, if any, this whole scope inherits from the `use` block that instantiated it (nil at the top level, or when that use set none): it becomes a node's Runtime when the node names no blueprint.Node.Runtime of its own, and it cascades unchanged into a nested use's own recursive build unless that nested use sets its own override (see the loop below). ambientEnv is the analogous inherited environment, except it merges rather than replaces at every layer (see mergeEnv). ambientBackendConfig is the analogous inherited backend_config, merged the same way.
-func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (*Graph, map[string]useInfo, error) {
+func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig, ambientAddress map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (*Graph, map[string]useInfo, error) {
 	g := &Graph{
 		Nodes: make(map[string]*Node),
 		Out:   make(map[string][]string),
@@ -179,7 +186,15 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 		}
 		qn := cloneNode(n)
 		qn.Name = qualify(n.Name)
-		qn.BackendConfig = fillLocalBackendPath(mergeEnv(ambientBackendConfig, qn.BackendConfig), schema, rc.rootDir, qn.Name)
+		qn.BackendAddress = mergeBackendAddress(ambientAddress, qn.BackendAddress)
+		qn.BackendConfig = mergeEnv(ambientBackendConfig, qn.BackendConfig)
+		if err := fillBackendAddress(&qn, schema); err != nil {
+			if !rc.observation {
+				return nil, nil, err
+			}
+			observationError = err
+		}
+		qn.BackendConfig = fillLocalBackendPath(qn.BackendConfig, schema, rc.rootDir, qn.Name)
 
 		env := mergeEnv(ambientEnv, n.Env)
 
@@ -201,12 +216,13 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 		}
 		nextAmbientEnv := mergeEnv(ambientEnv, u.Env)
 		nextAmbientBackend := mergeEnv(ambientBackendConfig, u.BackendConfig)
+		nextAmbientAddress := mergeBackendAddress(ambientAddress, u.BackendAddress)
 		nextAmbientApprove := ambientApprove
 		if u.Approve != "" {
 			nextAmbientApprove = u.Approve
 		}
 
-		info, internal, err := resolveUse(u, baseDir, qualify(u.As), nextAmbient, nextAmbientEnv, nextAmbientBackend, nextAmbientApprove, rc)
+		info, internal, err := resolveUse(u, baseDir, qualify(u.As), nextAmbient, nextAmbientEnv, nextAmbientBackend, nextAmbientAddress, nextAmbientApprove, rc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("use %q as %q: %w", u.GroupName, u.As, err)
 		}
@@ -247,7 +263,7 @@ func build(bp *blueprint.Blueprint, baseDir, namespace string, ambient *blueprin
 }
 
 // resolveUse loads and builds the group instantiated by u (recursing through the group's own nested `use` blocks, if any), validates it, and returns both its expanded internal graph (nodes already namespaced under instancePrefix, ready to splice into the caller's graph) and a useInfo describing how the caller's edges should resolve references to this instance. ambient is u's own resolved runtime override, if any (already merged with whatever u itself inherited from further out), the new default every node inside this instance inherits unless it names its own; ambientEnv is the analogous already-merged environment; ambientBackendConfig is the analogous already-merged backend_config.
-func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (useInfo, *Graph, error) {
+func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient *blueprint.Runtime, ambientEnv, ambientBackendConfig, ambientAddress map[string]string, ambientApprove blueprint.Approve, rc *resolveContext) (useInfo, *Graph, error) {
 	groupDir := filepath.Join(referencingDir, u.Source)
 
 	pop, err := rc.push(groupDir, u.GroupName)
@@ -262,7 +278,7 @@ func resolveUse(u blueprint.Use, referencingDir, instancePrefix string, ambient 
 
 	// def.Nodes/Uses may reference a runtime by name (blueprint.Node.Runtime / blueprint.Use.Runtime); those names resolve against groupRuntimes, the `runtime` blocks declared in this same group source directory, never against whatever the outer scope that wrote u happens to have declared (see blueprint.validateRuntimes, which already enforced this scoping at parse time).
 	innerBP := &blueprint.Blueprint{Nodes: def.Nodes, Edges: def.Edges, Uses: def.Uses, Runtimes: groupRuntimes, Vendor: groupVendor}
-	internal, innerUses, err := build(innerBP, groupDir, instancePrefix, ambient, ambientEnv, ambientBackendConfig, ambientApprove, rc)
+	internal, innerUses, err := build(innerBP, groupDir, instancePrefix, ambient, ambientEnv, ambientBackendConfig, ambientAddress, ambientApprove, rc)
 	if err != nil {
 		return useInfo{}, nil, err
 	}

--- a/internal/language/backend_address.go
+++ b/internal/language/backend_address.go
@@ -1,0 +1,29 @@
+package language
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/cloudfluent/terragraph/internal/blueprint"
+)
+
+// backendAddressDiagnostics reuses execution's parser so incomplete editor documents cannot acquire a different address-rule language.
+func backendAddressDiagnostics(body *hclsyntax.Body) []Diagnostic {
+	var result []Diagnostic
+	for _, block := range body.Blocks {
+		if block.Type == "group" {
+			result = append(result, backendAddressDiagnostics(block.Body)...)
+		}
+		if block.Type != "node" && block.Type != "use" {
+			continue
+		}
+		attr := block.Body.Attributes["backend_address"]
+		if attr == nil {
+			continue
+		}
+		if _, err := blueprint.ParseBackendAddress(attr.AsHCLAttribute()); err != nil {
+			rng := attr.Expr.Range()
+			result = append(result, Diagnostic{Start: rng.Start.Byte, End: rng.End.Byte, Message: err.Error()})
+		}
+	}
+	return result
+}

--- a/internal/language/backend_address_test.go
+++ b/internal/language/backend_address_test.go
@@ -1,0 +1,70 @@
+package language
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceComplete_BackendAddressFields(t *testing.T) {
+	for _, body := range []string{
+		"node \"app\" {\n backend_address = {\n  __CURSOR__\n }\n}",
+		"use \"service\" {\n backend_address = {\n  __CURSOR__\n }\n}",
+		"group \"service\" {\n node \"app\" {\n backend_address = {\n __CURSOR__\n }\n }\n}",
+	} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "blueprint.hcl")
+		text, offset := cursor(body, "__CURSOR__")
+		ws := NewWorkspace(dir)
+		ws.SetDocument(path, []byte(text))
+		items := ws.Complete(context.Background(), path, offset)
+		if len(items) != 2 || !contains(items, "s3_key_prefix") || !contains(items, "s3_key_name") {
+			t.Fatalf("completion = %#v, want prefix and file name fields", items)
+		}
+		for _, item := range items {
+			if !strings.Contains(item.Insert, " = ") || item.Documentation == "" {
+				t.Fatalf("completion = %#v, want insertable assignment and documentation", item)
+			}
+		}
+	}
+}
+
+func TestWorkspaceDiagnose_BackendAddressUsesParserAndRepairs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "group.hcl")
+	writeFile(t, filepath.Join(dir, "module", "main.tf"), `output "id" { value = "x" }`)
+	text := `group "service" {
+  node "app" {
+    source = "./module"
+    backend_address = { s3_key_name = "../shared.tfstate" }
+  }
+}`
+	ws := NewWorkspace(dir)
+	ws.SetDocument(path, []byte(text))
+	diagnostics := ws.Diagnose(context.Background(), path)
+	if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].Message, "backend_address.s3_key_name") {
+		t.Fatalf("diagnostics = %v, want invalid file name diagnostic", diagnostics)
+	}
+	if got := text[diagnostics[0].Start:diagnostics[0].End]; got != `{ s3_key_name = "../shared.tfstate" }` {
+		t.Fatalf("diagnostic range = %q, want address object", got)
+	}
+	ws.SetDocument(path, []byte(strings.ReplaceAll(text, "../shared.tfstate", "state.json")))
+	if got := ws.Diagnose(context.Background(), path); len(got) != 0 {
+		t.Fatalf("diagnostics = %v, want none after repair", got)
+	}
+}
+
+func TestWorkspaceDiagnose_BackendAddressUseRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blueprint.hcl")
+	ws := NewWorkspace(dir)
+	ws.SetDocument(path, []byte(`use "service" {
+  as = "checkout"
+  source = "./group"
+  backend_address = { key = "prod" }
+}`))
+	if got := ws.Diagnose(context.Background(), path); len(got) != 1 || !strings.Contains(got[0].Message, "unsupported field") {
+		t.Fatalf("diagnostics = %v, want unsupported address field", got)
+	}
+}

--- a/internal/language/workspace.go
+++ b/internal/language/workspace.go
@@ -97,6 +97,9 @@ func (w *Workspace) Complete(_ context.Context, path string, offset int) []Compl
 		p, _ := varsPortsAt(model, text, offset)
 		return propertyCompletions(p, fragment, start, offset)
 	}
+	if objectAttribute == "backend_address" && !strings.Contains(fragment, ".") {
+		return contextCompletions([]string{"backend_address"}, fragment, start, offset)
+	}
 	if insideObject {
 		return nil
 	}
@@ -424,11 +427,16 @@ var completionSchemas = map[string][]attributeSpec{
 	"producer.output": contractPortSchema,
 	"consumer.input":  contractPortSchema,
 	"snapshots":       {},
+	"backend_address": {
+		{name: "s3_key_prefix", insert: "s3_key_prefix = \"prod\"", detail: "optional string", documentation: "Literal prefix before the qualified leaf directory. Empty means no prefix; explicit keys win."},
+		{name: "s3_key_name", insert: "s3_key_name = \"terraform.tfstate\"", detail: "optional string", documentation: "File name within each qualified leaf directory; defaults to terraform.tfstate. Inherits independently of the prefix."},
+	},
 	"node": {
 		{name: "source", insert: "source = \"\"", detail: "required string", documentation: "Path or remote source of the Terraform or OpenTofu module."},
 		{name: "vars", insert: "vars = {\n}", detail: "object", documentation: "Literal Terraform input values. Use an edge for another node's output."},
 		{name: "env", insert: "env = {\n}", detail: "map(string)", documentation: "Extra environment variables for this module's Terraform or OpenTofu process."},
 		{name: "runtime", insert: "runtime = runtime.", detail: "runtime reference", documentation: "Selects a declared runtime for this node."},
+		{name: "backend_address", insert: "backend_address = {\n  s3_key_prefix = \"prod\"\n}", detail: "object", documentation: "Optional S3 key generation. Inherits when omitted; {} disables it. Explicit addresses win."},
 		{name: "backend_config", insert: "backend_config = {\n}", detail: "map(string)", documentation: "Backend configuration passed to terraform init."},
 		{name: "approve", insert: "approve = \"\"", detail: "optional string", documentation: "How much of this node's plan may be applied: \"none\", \"safe\" (create/update, the default), or \"all\" (adds replace/delete)."},
 	},
@@ -448,6 +456,7 @@ var completionSchemas = map[string][]attributeSpec{
 	"use": {
 		{name: "as", insert: "as = \"\"", detail: "required string", documentation: "Namespace used to refer to this group instance."},
 		{name: "source", insert: "source = \"\"", detail: "required string", documentation: "Local path or remote source containing the group."},
+		{name: "backend_address", insert: "backend_address = {\n  s3_key_prefix = \"prod\"\n}", detail: "object", documentation: "Optional S3 key generation. Inherits when omitted; {} disables it. Explicit addresses win."},
 		{name: "backend_config", insert: "backend_config = {\n}", detail: "map(string)", documentation: "Backend configuration merged onto every node this instance expands to. Leaf keys win."},
 		{name: "runtime", insert: "runtime = runtime.", detail: "runtime reference", documentation: "Default runtime for nodes expanded from this group."},
 		{name: "env", insert: "env = {\n}", detail: "map(string)", documentation: "Environment variables inherited by nodes expanded from this group."},
@@ -705,6 +714,7 @@ func (w *Workspace) Diagnose(_ context.Context, path string) []Diagnostic {
 		return nil
 	}
 	diagnostics := contractDiagnostics(body)
+	diagnostics = append(diagnostics, backendAddressDiagnostics(body)...)
 	walkAttributes(body, func(attr *hclsyntax.Attribute) {
 		scope := model.at(text, attr.Range().Start.Byte)
 		for _, traversal := range attr.Expr.Variables() {

--- a/internal/module/inspect.go
+++ b/internal/module/inspect.go
@@ -53,6 +53,8 @@ type Schema struct {
 	Backend string
 	// BackendConfig contains known scalar backend attributes; explicit blueprint backend_config entries override them.
 	BackendConfig map[string]string
+	// BackendAttributes retains declaration presence even for unevaluable values; nil means absence cannot be established safely.
+	BackendAttributes map[string]bool
 	// BackendConfigKnown prevents an unevaluable address from being mistaken for an omitted default.
 	BackendConfigKnown bool
 	// comparison retains exact defaults and complete backend declarations only to reject ambiguous runtime selection.
@@ -169,6 +171,7 @@ func inspectDeclarations(schema *Schema, files []moduleFile) {
 				if selected.override {
 					schema.Backend = ""
 					schema.BackendConfig = nil
+					schema.BackendAttributes = nil
 					schema.BackendConfigKnown = true
 					cloud = false
 					delete(schema.comparison, "backend")
@@ -183,6 +186,13 @@ func inspectDeclarations(schema *Schema, files []moduleFile) {
 				schema.BackendConfig = make(map[string]string)
 				schema.BackendConfigKnown = true
 				attrs, attrDiags := b.Body.JustAttributes()
+				schema.BackendAttributes = nil
+				if !attrDiags.HasErrors() {
+					schema.BackendAttributes = make(map[string]bool, len(attrs))
+					for name := range attrs {
+						schema.BackendAttributes[name] = true
+					}
+				}
 				schema.comparison["backend"] = bodyIdentity(b.Body, src)
 				if attrDiags.HasErrors() {
 					schema.BackendConfigKnown = false


### PR DESCRIPTION
## Summary

A group can now share an S3 bucket and key prefix while each leaf gets its own state key, without changing explicitly configured state locations.

Add optional `backend_address` settings to `node` and `use`:

```hcl
backend_address = {
  s3_key_prefix = "prod"
  s3_key_name   = "terraform.tfstate"
}
```

For `checkout.cluster`, this generates `prod/checkout.cluster/terraform.tfstate`. The qualified leaf directory is always included; prefix and file name are literal values with no placeholder substitution.

- Prefix and file name inherit independently through nested groups. An empty prefix clears the inherited prefix, and `backend_address = {}` disables inherited generation.
- Explicit keys from node/use configuration or module backend declarations take precedence, including module expressions that cannot be evaluated statically. Existing collision checks still apply, and different profiles do not establish separate state addresses.
- Generation supports S3 keys only. Other backends and existing local default paths retain their behavior. Renaming a leaf or instance, or changing the generated address components, does not migrate state automatically.
- Update reference documentation, the group example, and VS Code completion and diagnostics.

Fixes #113.

## Verification

Regression tests cover repeated and nested groups, independent prefix/name inheritance, opt-out and re-enabling, explicit address preservation, collisions, module overrides and JSON declarations, literal prefixes, and unchanged behavior for other backends. The CLI test captures `init` arguments, verifies `prod/checkout.app/state.json` alongside the preserved `legacy.tfstate`, checks isolated node data directories, and confirms the module source is unchanged.

Commands run locally, with selected output:

```text
$ go test -race ./internal/graph -run BackendAddress
ok  	github.com/cloudfluent/terragraph/internal/graph	1.620s

$ make check
...
0 issues.
...
ok  	github.com/cloudfluent/terragraph/internal/cli	31.022s
ok  	github.com/cloudfluent/terragraph/internal/engine	82.807s
ok  	github.com/cloudfluent/terragraph/internal/graph	3.141s
...
All matched files use Prettier code style!
...
PASS backend address: prefix and name completion, unsaved diagnostics and repair
...
Exit code:   0
```

- [x] `make check` passes locally (fmt, lint, docs, build, test, and VS Code integration tests)

## Checklist

- [x] Tests added or updated for the behavior change
- [x] `docs/*.md` updated if this changes blueprint semantics, CLI flags, or an example's output (see [CONTRIBUTING.md](../CONTRIBUTING.md))

**PR title, not this body, becomes the commit message on `main` (squash-merge).** It's checked in CI and must follow [Conventional Commits](https://www.conventionalcommits.org/): `type: summary`, e.g. `fix: correct incremental-apply cache key`. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the allowed types.
