### PR TITLE
docs: highlight AI agent friendliness in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Split infrastructure into independent Terraform modules and you lose the one thi
 
 terragraph closes that gap without any of the three tradeoffs. Every root module stays completely standalone, with its own backend, providers, and resources, and no reference to any other module. A separate file declares the **wiring**: which output feeds which input. terragraph reads that file, works out the dependency order, and passes the real values through automatically as it applies each module, with no generated code and no shared state.
 
+That same clarity is central to terragraph's goal of making infrastructure easier and safer for AI agents to manage. Agent friendliness is part of the design from the start, as agents take on more infrastructure work.
+
 ## Install
 
 macOS via Homebrew:


### PR DESCRIPTION
AI agents are taking on more infrastructure work, so the README now briefly identifies making that work easier and safer as a design goal. The introduction keeps its original explanation of independent modules and explicit wiring, with one short paragraph added before Install.

Validation: `git diff --check` produced no output, and `make check` passed, including Go race tests and VS Code integration tests. Selected output:

```text
$ make check
0 issues.
ok  	github.com/cloudfluent/terragraph/internal/engine	(cached)
All matched files use Prettier code style!
PASS native contracts: type completion, inherited type hover, unsaved type diagnostics
PASS components.hcl: completion metadata, definition, unsaved diagnostics
Exit code:   0
```
