### PR TITLE
docs: explain DRY backend configuration in guides and examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ For your own modules, start with [nodes, edges, and literal inputs](blueprint.md
 |---|---|
 | Connect modules, supply inputs, or choose runtimes and environments | [Blueprint](blueprint.md) |
 | Reuse a set of connected modules | [Groups](groups.md) and the [group example](../examples/group) |
+| Keep backend configuration DRY and give each leaf its own state address | [Shared backend settings](blueprint.md#keeping-backend-configuration-dry) and the [group before/after example](../examples/group#keeping-backend-configuration-dry) |
 | Check producer and consumer declarations | [Contracts](contracts.md) |
 | Bring Git sources into version control and update them | [Vendoring](vendoring.md) |
 | Preview a graph, control changes, run in CI, or recover from failure | [Execution model](execution-model.md) |

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -134,13 +134,22 @@ This gives the default workspace a different state file for each node. A module 
 
 An explicit relative local-backend `backend_config.path` is passed through unchanged. For example, with `source = "./modules/vpc"`, `path = ".terragraph/state/vpc.tfstate"` places default-workspace state under `modules/vpc/.terragraph/state/`. `terragraph validate` warns about this relative path. Omit `backend_config.path` to use the automatic absolute path above, or supply an absolute path outside the module directory when choosing a custom location.
 
-Use `backend_config` for remote backend fields such as `bucket`, `key`, `region`, and `profile`, or for an explicit local path. Entries are passed to `terraform init` as `-backend-config` options. A non-empty map requires a `backend` block in the module; it is invalid with no backend block or with a `cloud` block. A group's [`use.backend_config`](groups.md#isolating-state-for-an-instance) can supply shared defaults.
+## Keeping backend configuration DRY
 
-An optional `backend_address` object on a `node` or `use` generates a missing S3 `key` from literal prefix and file-name fields:
+Declare shared backend settings once per group instance instead of repeating them on every leaf. `use.backend_config` supplies common settings such as bucket, region, and profile; `use.backend_address` can also generate a distinct S3 key for each leaf. Adding a leaf to the group then inherits the settings and receives its own generated key without another backend configuration map.
+
+Each module still declares its backend type inside its own `terraform` block, for example `backend "s3" {}`. Terragraph injects the resolved settings through `terraform init -backend-config=key=value`; it never generates or edits a `.tf` backend block. The bucket and other backend infrastructure must already exist.
+
+Use `backend_config` for explicit backend fields, including an existing remote key or local path. A non-empty map requires a `backend` block in the module; it is invalid with no backend block or with a `cloud` block. Shared settings inherit through nested `use` blocks, and node settings take precedence. See [group inheritance](groups.md#keeping-backend-configuration-dry) and the [before/after example](../examples/group#keeping-backend-configuration-dry).
+
+### Generating per-leaf S3 keys
+
+For a group of modules declaring `backend "s3"`, combine shared configuration and optional address generation at the instance:
 
 ```hcl
-node "database" {
-  source = "./modules/database"
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
   backend_config = {
     bucket = "example-state"
     region = "ap-northeast-2"
@@ -152,7 +161,7 @@ node "database" {
 }
 ```
 
-For a module declaring `backend "s3"`, this produces `prod/database/terraform.tfstate`. Only `s3_key_prefix` and `s3_key_name` are supported; both are optional, but at least one must be present to enable generation. The construction is `[prefix/]<qualified-leaf>/<file-name>`, where the qualified leaf directory is always included automatically. Values are literal strings, with no placeholder substitution, functions, or references to other nodes.
+Leaves named `cluster` and `nodegroup` receive `prod/checkout.cluster/terraform.tfstate` and `prod/checkout.nodegroup/terraform.tfstate` from this one declaration. The same `backend_address` object can be set on an individual `node` when it needs its own rule. Only `s3_key_prefix` and `s3_key_name` are supported; both are optional, but at least one must be present to enable generation. The construction is `[prefix/]<qualified-leaf>/<file-name>`, where the qualified leaf directory is always included automatically. Values are literal strings, with no placeholder substitution, functions, or references to other nodes.
 
 | Field | Default when generation is enabled | Meaning |
 |---|---|---|

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -104,7 +104,11 @@ The value reaches every leaf named by the export, including through nested group
 
 For local state, the group's modules can declare `backend "local" {}`. When no explicit `backend_config.path` is set, terragraph supplies a unique default-workspace path per qualified leaf, such as `.terragraph/state/checkout.cluster.tfstate` and `.terragraph/state/payments.cluster.tfstate`, under the root blueprint directory. See [module reuse](blueprint.md#reusing-the-same-module-across-instances) for explicit paths, workspaces, and migration considerations.
 
-For remote state, `use.backend_config` supplies defaults to every node in the instance:
+### Keeping backend configuration DRY
+
+Keep environment-specific backend settings at the `use` site so every leaf in the group can inherit them. For S3, combine `use.backend_config` for shared bucket, region, and profile settings with `use.backend_address` for distinct leaf keys. This removes both the repeated settings and the need to author a key for each new leaf.
+
+Each module declares a compatible backend type, such as `backend "s3" {}` inside its `terraform` block. Terragraph passes the resolved settings as `terraform init -backend-config` options, without writing backend configuration files. For modules declaring S3 backends:
 
 ```hcl
 use "eks-service" {
@@ -115,21 +119,6 @@ use "eks-service" {
     profile = "prod"
     region  = "ap-northeast-2"
   }
-}
-```
-
-Each module must declare a compatible backend. An inner `use` overrides inherited keys, and a node's own keys win. Use shared fields such as `bucket`, `profile`, and `region` here, and give each leaf a distinct state address. A single `key` on `use` is inherited by every leaf; terragraph does not interpolate the instance or leaf name into it. When reusing the group, separate the instances' addresses, for example with different buckets or the optional S3 generation rule below.
-
-For modules declaring `backend "s3"`, add `backend_address` to a `use` to generate keys only for leaves without explicit keys:
-
-```hcl
-use "eks-service" {
-  as     = "checkout"
-  source = "./groups/eks-service"
-  backend_config = {
-    bucket = "tfstate"
-    region = "ap-northeast-2"
-  }
   backend_address = {
     s3_key_prefix = "prod"
     s3_key_name   = "terraform.tfstate"
@@ -139,9 +128,11 @@ use "eks-service" {
 
 This generates `prod/checkout.cluster/terraform.tfstate` and `prod/checkout.nodegroup/terraform.tfstate`. Another instance named `payments` can use the same bucket and rule; its keys contain `payments.cluster` and `payments.nodegroup`. Nested instances include their full leaf name, such as `prod/checkout.inner.database/terraform.tfstate`. Select `dev` as the prefix to use a different environment namespace.
 
+The shared `backend_config` entries also cascade through nested groups: an inner `use` overrides inherited entries, and a node's own entries win. A new leaf needs only its module source and normal inputs to inherit this backend setup. See the [group example's before/after comparison](../examples/group#keeping-backend-configuration-dry) for the configuration this replaces.
+
 The prefix and file name inherit independently through nested `use` blocks. For example, a leaf can declare `backend_address = { s3_key_name = "state.json" }` to keep the instance's `prod` prefix while changing its file name. An empty prefix clears an inherited prefix; `backend_address = {}` stops generation for that scope, while descendants can opt in again. Without an inherited or explicit file name, generation uses `terraform.tfstate`.
 
-Explicit `backend_config.key` values, including inherited keys, and keys declared in module backend blocks always take precedence. A leaf can retain `backend_config = { key = "legacy/database.tfstate" }` while its siblings use generated addresses. Inheriting the same explicit key across multiple leaves is still checked for collisions, not rewritten. Other backend types keep their existing behavior. See [backend address generation](blueprint.md#reusing-the-same-module-across-instances) for the full scope, field rules, and validation limits.
+Explicit `backend_config.key` values, including inherited keys, and keys declared in module backend blocks always take precedence. A leaf can retain `backend_config = { key = "legacy/database.tfstate" }` while its siblings use generated addresses. Inheriting the same explicit key across multiple leaves is still checked for collisions, not rewritten. Shared `use.backend_config` settings work with other compatible backend types too, while address generation currently supports S3 only. See [backend address generation](blueprint.md#generating-per-leaf-s3-keys) for the full scope, field rules, and validation limits.
 
 Changing an instance name, leaf name, prefix, or file name can change generated state addresses. No state migration is performed; use explicit keys to retain existing locations when restructuring groups.
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -140,7 +140,7 @@ once inside the EKS group. Account context flows from applied outputs,
 so it does not need to be copied into every leaf's `vars`.
 
 Blueprint `vars` supports literal data, without functions, locals, variable
-references, loops, or interpolation of node names into backend keys. The
+references, or loops. The
 three `use "environment"` declarations and their external edges remain
 explicit. Naming, AZ defaults, and subnet calculations belong in the local
 fixtures. Adding `qa` means adding an instance, unique CIDRs/account data,
@@ -158,6 +158,12 @@ same VPC source. Modules declare `backend "local" {}` so Terragraph can
 supply an absolute path. Module sources remain unchanged by execution.
 Group and leaf names are state addresses: renaming a leaf is a migration
 decision, not a cosmetic edit.
+
+For a production S3 adaptation, backend configuration can be DRY too:
+declare bucket and region once per environment `use`, then generate a
+distinct key for every nested leaf with `backend_address`. The local
+fixtures do not exercise this S3 path; see [Keeping production backend
+configuration DRY](#keeping-production-backend-configuration-dry) below.
 
 ## Contracts and actual values
 
@@ -341,7 +347,7 @@ running any consumers. The native lab verifies that reconciliation step.
 | Native init, console, import, state operations, backup export | Disposable native lab |
 | Git vendoring, subdirectory packages, exclusions, custom paths, forced refresh | Disposable vendor lab |
 | Recovery, interruption, stale locks, editor intelligence | Linked operational documentation; not simulated failure claims |
-| Remote backends, `use.backend_config`, S3 graph lock, S3 execution storage, `force-unlock` | Require a separate real-backend adaptation; intentionally absent from the credential-free run |
+| Remote backends, DRY backend settings and S3 key generation, S3 graph lock, S3 execution storage, `force-unlock` | Require a separate real-backend adaptation; backend configuration recipe below, intentionally absent from the credential-free run |
 
 For a named-runtime experiment in a **fresh disposable copy**, add a
 `runtimes.hcl` with a root default:
@@ -361,17 +367,51 @@ root default, then CLI fallback. A root default takes precedence over
 one source across different runtimes produces a provider-lockfile warning.
 Do not change runtimes underneath retained plans.
 
-A production adaptation must author real provider/backend configuration
+### Keeping production backend configuration DRY
+
+A production adaptation must declare real providers and backend types
 in its roots and independently implement and review every simulated AWS
-control. Terragraph does not generate that configuration. AWS credentials
+control. Terragraph does not generate those declarations. AWS credentials
 would come from each executor's role/environment, rather than fictional
 account IDs passed as module values.
 
-For shared state, give every leaf and environment a distinct backend
-address. `use.backend_config` can supply common bucket/region defaults, but
-one inherited `key` would be shared by every leaf: Terragraph does not
-interpolate qualified names into it. Repeated groups also need separate
-instance namespaces. Migrating current local state is a separate operation.
+Once the adapted roots declare `backend "s3" {}` inside their `terraform`
+blocks, keep backend settings at the environment boundary instead of
+copying a bucket, region, and individual key into every leaf. Add these
+attributes to the selected `use "environment"` in `environments.hcl`,
+retaining its existing `as`, `source`, `env`, and `vars`:
+
+```hcl
+backend_config = {
+  bucket = "example-state"
+  region = "ap-northeast-2"
+}
+backend_address = {
+  s3_key_prefix = "landscape"
+  s3_key_name   = "terraform.tfstate"
+}
+```
+
+For `as = "prd"`, this single declaration reaches all S3 leaves inside
+that environment's nested groups. For example, the generated keys include
+`landscape/prd.network.apps/terraform.tfstate` and
+`landscape/prd.data.database/terraform.tfstate`. The `dev` and `stg`
+instances can use the same bucket and prefix because their qualified leaf
+names differ. Nodes outside those environment instances have their own
+configuration scopes.
+
+`use.backend_config` injects the shared values as `terraform init
+-backend-config` options, and `backend_address` supplies only missing S3
+keys. Adding another leaf inside an environment therefore needs no new
+backend map. A node can override shared settings or preserve an existing
+location with an explicit `backend_config.key`; it takes precedence over
+generation. Do not use a single inherited explicit `key` to isolate
+several leaves, because it gives them the same address. See [the group
+before/after example](../group#keeping-backend-configuration-dry).
+
+This recipe does not migrate the example's existing local state. Plan
+that migration separately, and retain explicit keys when changing names
+or namespaces should not change an existing state location.
 
 An S3 graph lock requires every node to use a supported remote backend,
 so simply adding `lock` to this local example is invalid. S3 execution

--- a/examples/group/README.md
+++ b/examples/group/README.md
@@ -12,19 +12,69 @@ go run ../../cmd/terragraph apply --auto-approve
 ls modules/nodegroup/*.txt   # one file per instance, named after that instance's cluster_id
 ```
 
-For an S3-backed version of this group, after its modules declare `backend "s3"`, each `use` can share a bucket while generating separate leaf keys:
+## Keeping backend configuration DRY
+
+For an S3-backed adaptation, declare shared backend settings once per group instance and let terragraph derive a distinct key for each leaf. This keeps bucket and region values out of the reusable group's nodes and removes the need to write a key for every new leaf.
+
+Each module must first declare `backend "s3" {}` inside its own `terraform` block. Terragraph injects the resolved values through `terraform init -backend-config` options; it does not generate or edit the modules' backend blocks. The checked-in example uses local state and needs no AWS credentials, so the following is an S3 adaptation, not part of its default run. The excerpts focus on backend settings; retain the example's existing variables, edges, and exports.
+
+**Before: repeat settings on each leaf.** Inside `group "eks-service"`, configuring the `checkout` instance explicitly would repeat bucket and region, with a different key for each node:
 
 ```hcl
-backend_config = {
-  bucket = "example-state"
-  region = "ap-northeast-2"
+node "cluster" {
+  source = "../../modules/cluster"
+  backend_config = {
+    bucket = "example-state"
+    region = "ap-northeast-2"
+    key    = "prod/checkout.cluster/terraform.tfstate"
+  }
 }
-backend_address = {
-  s3_key_prefix = "prod"
-  s3_key_name   = "terraform.tfstate"
+node "nodegroup" {
+  source = "../../modules/nodegroup"
+  backend_config = {
+    bucket = "example-state"
+    region = "ap-northeast-2"
+    key    = "prod/checkout.nodegroup/terraform.tfstate"
+  }
 }
 ```
 
-Place these attributes inside both `use` blocks. The cluster keys become `prod/checkout.cluster/terraform.tfstate` and `prod/payments.cluster/terraform.tfstate`; nodegroup keys use their corresponding qualified leaf directories. A group node can set `backend_address = { s3_key_name = "state.json" }` while inheriting the prefix, or keep an existing location with `backend_config = { key = "legacy/cluster.tfstate" }`. Explicit keys still need to be distinct across instances sharing the same state namespace.
+Those fixed keys also tie the reusable group to `checkout`; a second instance needs different addresses.
 
-The checked-in example continues to use local state and needs no AWS credentials. S3 generation fields have no effect on local backends. Renaming an instance or changing the generation fields can change S3 state locations; terragraph does not migrate them automatically.
+**After: supply shared settings at the instance.** The group's nodes keep only their sources and normal inputs, as in the checked-in group:
+
+```hcl
+node "cluster" { source = "../../modules/cluster" }
+node "nodegroup" { source = "../../modules/nodegroup" }
+```
+
+Configure the backend once on the `use` in `blueprint.hcl`:
+
+```hcl
+use "eks-service" {
+  as     = "checkout"
+  source = "./groups/eks-service"
+  vars   = { cluster_name = "checkout" }
+  backend_config = {
+    bucket = "example-state"
+    region = "ap-northeast-2"
+  }
+  backend_address = {
+    s3_key_prefix = "prod"
+    s3_key_name   = "terraform.tfstate"
+  }
+}
+```
+
+The generated keys match the explicit `checkout` addresses above. Put the same shared settings on the existing `payments` use and its qualified leaf names automatically produce separate keys:
+
+| Leaf | Generated S3 key |
+|---|---|
+| `checkout.cluster` | `prod/checkout.cluster/terraform.tfstate` |
+| `checkout.nodegroup` | `prod/checkout.nodegroup/terraform.tfstate` |
+| `payments.cluster` | `prod/payments.cluster/terraform.tfstate` |
+| `payments.nodegroup` | `prod/payments.nodegroup/terraform.tfstate` |
+
+Adding another S3-backed leaf to the group requires no additional bucket/region map or hand-written key. A leaf can set `backend_address = { s3_key_name = "state.json" }` while inheriting the prefix, or preserve an existing location with `backend_config = { key = "legacy/cluster.tfstate" }`. Explicit keys win and still need to be distinct across instances sharing the same state namespace. Use `backend_address = {}` to stop inherited generation for a scope.
+
+Shared `use.backend_config` settings also work with other compatible backend types; automatic key generation currently supports S3 only. S3 generation fields have no effect on this example's local backends. Moving existing local state to S3, renaming an instance, or changing the generated address requires a separate migration decision. See [shared backend configuration](../../docs/blueprint.md#keeping-backend-configuration-dry) for inheritance and address precedence.


### PR DESCRIPTION
## Summary

The backend guides now explain how declaring shared settings once per group instance removes repeated bucket, region, and leaf-key configuration.

- Add a DRY backend configuration entry to the documentation index and dedicated sections in the blueprint and group guides.
- Show the group example before and after moving repeated leaf settings into `use.backend_config` and `use.backend_address`, including the resulting state keys.
- Explain environment-level inheritance for a production S3 adaptation of the complete example, while preserving its credential-free local execution instructions.

The root README remains unchanged. This documentation follow-up to #114 clarifies the benefit of the feature introduced for #113; it does not change runtime behavior.

## Verification

```text
$ make check > /private/tmp/terragraph-docs-backend-dry-check.log 2>&1
# Completed with exit code 0. Selected log output:
0 issues.
PASS backend address: prefix and name completion, unsaved diagnostics and repair
Exit code:   0

$ git diff --check
# No output; exit code 0.

$ git diff --exit-code origin/main -- README.md
# No output; exit code 0.
```

A local Python check resolved relative links and heading anchors in all five changed documents:

```text
Checked 65 local documentation links
All target files and heading anchors exist
```

- [x] `make check` passes locally (fmt, lint, docs, build, test, and VS Code integration tests)

## Checklist

- [x] Tests added or updated for the behavior change — not applicable; documentation only, with the existing suite passing
- [x] `docs/*.md` updated if this changes blueprint semantics, CLI flags, or an example's output (see [CONTRIBUTING.md](../CONTRIBUTING.md)) — guides and examples updated without changing runtime semantics

**PR title, not this body, becomes the commit message on `main` (squash-merge).** It's checked in CI and must follow [Conventional Commits](https://www.conventionalcommits.org/): `type: summary`, e.g. `fix: correct incremental-apply cache key`. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the allowed types.
