### PR TITLE
feat: protect partial destroy scope

### DIFF
--- a/cmd/terragraph/cancellation_unix_test.go
+++ b/cmd/terragraph/cancellation_unix_test.go
@@ -311,7 +311,7 @@ func TestMain_CancellationInterruptsApprovalInput(t *testing.T) {
 
 func TestMain_CancellationInterruptsDestroyInput(t *testing.T) {
 	f := newCancellationFixture(t, "destroy")
-	cmd, done := startCancellationCLI(t, f, "destroy", "--node", "a")
+	cmd, done := startCancellationCLI(t, f, "destroy", "--node", "a", "--allow-orphan-destroy")
 	waitCancellationFile(t, filepath.Join(f.dir, "destroy-waiting"), "ready")
 	_ = cmd.Process.Signal(syscall.SIGTERM)
 	waitCancellationExit(t, done, true)
@@ -336,7 +336,7 @@ func TestMain_CancellationStopsLockWaiter(t *testing.T) {
 
 func TestMain_NormalDestroyDoesNotWaitForUnreadPipe(t *testing.T) {
 	f := newCancellationFixture(t, "destroy-no-read")
-	_, done := startCancellationCLI(t, f, "destroy", "--node", "a")
+	_, done := startCancellationCLI(t, f, "destroy", "--node", "a", "--allow-orphan-destroy")
 	waitCancellationExit(t, done, false)
 }
 
@@ -372,7 +372,11 @@ func TestMain_ApprovalInputFileAndPipe(t *testing.T) {
 						}
 					}
 					t.Cleanup(func() { _ = in.Close() })
-					_, done := startCancellationCLIWithInput(t, f, in, command, "--node", "a")
+					args := []string{command, "--node", "a"}
+					if command == "destroy" {
+						args = append(args, "--allow-orphan-destroy")
+					}
+					_, done := startCancellationCLIWithInput(t, f, in, args...)
 					waitCancellationExit(t, done, answer != "yes\n")
 				})
 			}

--- a/cmd/terragraph/pty_unix_test.go
+++ b/cmd/terragraph/pty_unix_test.go
@@ -25,6 +25,9 @@ func TestMain_ControllingTerminalApproval(t *testing.T) {
 				f.tty = true
 				master, slave := openCancellationPTY(t)
 				args := []string{command, "--node", "a"}
+				if command == "destroy" {
+					args = append(args, "--allow-orphan-destroy")
+				}
 				if answer == "\x03" {
 					args = []string{command}
 				}
@@ -63,7 +66,7 @@ func TestMain_ControllingTerminalUnreadNormalDestroy(t *testing.T) {
 	f := newCancellationFixture(t, "destroy-no-read")
 	f.tty = true
 	_, slave := openCancellationPTY(t)
-	_, done := startCancellationCLIWithInput(t, f, slave, "destroy", "--node", "a")
+	_, done := startCancellationCLIWithInput(t, f, slave, "destroy", "--node", "a", "--allow-orphan-destroy")
 	waitCancellationExit(t, done, false)
 }
 

--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -9,12 +9,13 @@ terragraph destroy [flags]
 ### Options
 
 ```
-      --auto-approve       skip interactive approval
-      --downstream         include all successors of --node across data and ordering edges
-  -h, --help               help for destroy
-      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
-      --output string      output format: text or json (default "text")
-      --parallelism int    max nodes to run concurrently within one execution level (default 1)
+      --allow-orphan-destroy   acknowledge consumers left outside the selected destroy scope
+      --auto-approve           skip interactive approval
+      --downstream             include all successors of --node across data and ordering edges
+  -h, --help                   help for destroy
+      --node stringArray       select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string          output format: text or json (default "text")
+      --parallelism int        max nodes to run concurrently within one execution level (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -29,13 +29,19 @@ A single `--node` without `--downstream` still selects only that leaf. Names are
 
 Membership is fixed before runtime calls. terragraph filters the original full-graph levels, removes empty levels, and numbers the remaining levels consecutively. It preserves alphabetical order within each level. It does not recompute a more parallel schedule after removing external dependencies. `destroy` uses the same membership with reversed levels. An unchanged upstream never skips a selected downstream node's fresh plan.
 
+Selected destroy also requires every declared transitive consumer to be selected. Use `--downstream` to include them, or explicitly acknowledge the incomplete scope with `--allow-orphan-destroy`; see [partial destroy protection](#partial-destroy-protection). Whole-graph destroy and plan/apply membership are unchanged.
+
 Selection limits execution, not validation or coordination: errors anywhere in the blueprint can block the run, and existing local/remote locks and unresolved-execution recovery barriers still apply. Per-node data directories, approval policies, failure handling, and the requirement for `--auto-approve` with concurrent apply/destroy are unchanged. A failure can follow successful changes to other selected nodes; selection provides no atomicity or automatic rollback.
 
 ### Dependencies outside the selection
 
 Unselected nodes never receive plan/apply/destroy calls. A selected consumer may read an unselected producer's existing output using the usual input-resolution path, including snapshot fallback only when already opted in and eligible. Runtime compatibility checks may also inspect selected nodes and their direct data producers. Missing outputs fail with the existing remedy; they do not expand selection. Saved planning and saved application retain their stricter requirement for live upstream outputs.
 
-Boundary edges preserve their original direction. Incoming data edges explain existing values a run may need; incoming ordering-only edges do not execute or verify completion of the external predecessor. Outgoing edges identify consumers that remain unselected and will not be updated by this invocation.
+Boundary edges preserve their original direction. Incoming data edges explain existing values a run may need; incoming ordering-only edges do not execute or verify completion of the external predecessor. Outgoing edges identify consumers that remain unselected and will not be updated by plan/apply. For destroy, these edges trigger the [partial destroy check](#partial-destroy-protection): consumers cannot be left outside the selected teardown without explicit acknowledgement.
+
+### Partial destroy protection
+
+A selected `destroy` refuses to remove a producer if any declared transitive consumer is outside the selection. Both data and ordering edges count. Inspect the boundary using `graph --node <leaf>` and include consumers with `destroy --node <leaf> --downstream`. To intentionally leave them behind, pass `--allow-orphan-destroy`; this acknowledges scope only and does not bypass node approval policy, interactive confirmation, runtime checks, or execution recovery. The default whole-graph destroy is unchanged. The check runs before runtime calls or a new execution record and reports `incomplete_destroy_scope` through the existing structured diagnostics. It does not inspect Terraform state or discover undeclared consumers.
 
 ### Selection output and compatibility
 
@@ -422,7 +428,3 @@ never automatic replay. Contract meaning and mode participate in retained-plan
 bindings. Review JSON exposes independent conditions through `review.contracts`.
 Known null is reconstructed only from the same successful plan, never from a
 missing live output. See the contracts reference for restart and recovery limits.
-
-### Partial destroy protection
-
-A selected `destroy` refuses to remove a producer if any declared transitive consumer is outside the selection. Both data and ordering edges count. Inspect the boundary using `graph --node <leaf>` and include consumers with `destroy --node <leaf> --downstream`. To intentionally leave them behind, pass `--allow-orphan-destroy`; this acknowledges scope only and does not bypass node approval policy, interactive confirmation, runtime checks, or execution recovery. The default whole-graph destroy is unchanged. The check runs before runtime calls or a new execution record and reports `incomplete_destroy_scope` through the existing structured diagnostics. It does not inspect Terraform state or discover undeclared consumers.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -422,3 +422,7 @@ never automatic replay. Contract meaning and mode participate in retained-plan
 bindings. Review JSON exposes independent conditions through `review.contracts`.
 Known null is reconstructed only from the same successful plan, never from a
 missing live output. See the contracts reference for restart and recovery limits.
+
+### Partial destroy protection
+
+A selected `destroy` refuses to remove a producer if any declared transitive consumer is outside the selection. Both data and ordering edges count. Inspect the boundary using `graph --node <leaf>` and include consumers with `destroy --node <leaf> --downstream`. To intentionally leave them behind, pass `--allow-orphan-destroy`; this acknowledges scope only and does not bypass node approval policy, interactive confirmation, runtime checks, or execution recovery. The default whole-graph destroy is unchanged. The check runs before runtime calls or a new execution record and reports `incomplete_destroy_scope` through the existing structured diagnostics. It does not inspect Terraform state or discover undeclared consumers.

--- a/editors/vscode/.vscode-test
+++ b/editors/vscode/.vscode-test
@@ -1,0 +1,1 @@
+../../../trevally/editors/vscode/.vscode-test

--- a/editors/vscode/.vscode-test
+++ b/editors/vscode/.vscode-test
@@ -1,1 +1,0 @@
-../../../trevally/editors/vscode/.vscode-test

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -418,6 +418,7 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf func() *slog.Logger) *cobra.Command {
 	var selection selectionFlags
 	var autoApprove bool
+	var allowOrphanDestroy bool
 	var parallelism int
 	var output string
 	cmd := &cobra.Command{
@@ -447,11 +448,13 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 			var scope *selectionDTO
 			opts := selection.options(cmd, output, &scope)
 			opts.AutoApprove, opts.Parallelism = autoApprove, parallelism
+			opts.AllowOrphanDestroy = allowOrphanDestroy
 			runs, err := e.Destroy(opts)
 			return finishRun(cmd, output, runs, err, scope)
 		},
 	}
 	selection.add(cmd)
+	cmd.Flags().BoolVar(&allowOrphanDestroy, "allow-orphan-destroy", false, "acknowledge consumers left outside the selected destroy scope")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
 	cmd.Flags().StringVar(&output, "output", "text", "output format: text or json")

--- a/internal/cli/selection_test.go
+++ b/internal/cli/selection_test.go
@@ -80,3 +80,13 @@ func TestSelection_SavedOverridesRejectedBeforeLoad(t *testing.T) {
 		}
 	}
 }
+
+func TestDestroy_PartialScopeReportsStructuredDiagnostic(t *testing.T) {
+	out, _, err := runCmd(t, "destroy", "--node", "vpc", "--auto-approve", "--output", "json")
+	if err == nil || !strings.Contains(err.Error(), "--downstream") {
+		t.Fatalf("got = %s, %v, want partial scope refusal", out, err)
+	}
+	if !strings.Contains(out, `"code":"incomplete_destroy_scope"`) || !strings.Contains(out, "checkout.nodegroup") {
+		t.Fatalf("got = %s, want structured diagnostic listing transitive consumers", out)
+	}
+}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+
+	"github.com/cloudfluent/terragraph/internal/graph"
 
 	"github.com/cloudfluent/terragraph/internal/blueprint"
 	"github.com/cloudfluent/terragraph/internal/exec"
@@ -19,6 +22,9 @@ func (e *Engine) Destroy(opts Options) (result RunResult, resultErr error) {
 		return result, selectionErr
 	}
 	opts.announceSelection(true)
+	if err := e.checkDestroyScope(opts); err != nil {
+		return result, err
+	}
 
 	// Same reason Apply refuses it: concurrent nodes have their output buffered and flushed a node at a time, so terraform's confirmation prompt would be invisible until long after the answer was needed. Checked before taking the run lock, so an unrunnable combination fails immediately instead of after waiting for whatever else holds it.
 	if !opts.AutoApprove && opts.parallelism() > 1 {
@@ -179,4 +185,29 @@ func (e *Engine) destroyContractPlan(name string, r *exec.Runner, session *execu
 		return session.fail(name, "indeterminate", fmt.Errorf("destroy: %w", err))
 	}
 	return session.transition(name, "completed", "", "")
+}
+
+// checkDestroyScope refuses to remove producers while declared consumers remain outside the selected teardown.
+func (e *Engine) checkDestroyScope(opts Options) error {
+	if opts.selection == nil || opts.AllowOrphanDestroy {
+		return nil
+	}
+	all, err := graph.Select(e.Graph, opts.selection.Names(), true)
+	if err != nil {
+		return err
+	}
+	selected := map[string]bool{}
+	for _, name := range opts.selection.Names() {
+		selected[name] = true
+	}
+	var outside []string
+	for _, name := range all.Names() {
+		if !selected[name] {
+			outside = append(outside, name)
+		}
+	}
+	if len(outside) == 0 {
+		return nil
+	}
+	return WithDiagnostic(fmt.Errorf("destroy: selected nodes have outside consumers %s; include them with --downstream or acknowledge with --allow-orphan-destroy", strings.Join(outside, ", ")), Diagnostic{Code: "incomplete_destroy_scope", Category: "arguments", Phase: "selection", Subject: "selection", Remedy: "include consumers with --downstream or acknowledge with --allow-orphan-destroy"})
 }

--- a/internal/engine/destroy_scope_test.go
+++ b/internal/engine/destroy_scope_test.go
@@ -1,0 +1,42 @@
+package engine
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudfluent/terragraph/internal/exec"
+)
+
+func TestDestroyScope_RequiresConsumersOrAcknowledgement(t *testing.T) {
+	e, err := Load(filepath.Join("..", "..", "examples", "group", "blueprint.hcl"), exec.Terraform, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts, err := e.resolveSelection(Options{Nodes: []string{"vpc"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.checkDestroyScope(opts); err == nil || !strings.Contains(err.Error(), "checkout.nodegroup") {
+		t.Fatalf("got = %v, want transitive consumer refusal", err)
+	}
+	opts.AllowOrphanDestroy = true
+	if err := e.checkDestroyScope(opts); err != nil {
+		t.Fatal(err)
+	}
+	opts, err = e.resolveSelection(Options{Nodes: []string{"vpc"}, Downstream: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.checkDestroyScope(opts); err != nil {
+		t.Fatal(err)
+	}
+	opts, err = e.resolveSelection(Options{Nodes: []string{"checkout.nodegroup"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.checkDestroyScope(opts); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -18,6 +18,8 @@ import (
 type Options struct {
 	// RetainPlan persists optional plan artifacts without pausing ordinary apply.
 	RetainPlan bool
+	// AllowOrphanDestroy acknowledges declared consumers left outside a destructive selection.
+	AllowOrphanDestroy bool
 	// Nodes is nil for the whole graph; a non-nil empty list must never silently broaden execution.
 	Nodes []string
 	// Downstream follows both data and ordering dependencies so consumers cannot be omitted by edge kind.


### PR DESCRIPTION
Protect selected destroy runs from leaving declared consumers behind. The check follows both data and ordering dependencies, reports transitive outside consumers through the existing `incomplete_destroy_scope` diagnostic, and suggests `--downstream` or explicit `--allow-orphan-destroy` acknowledgement.

Independent follow-up to #95, based on main. The default whole-graph destroy and the existing execution journal/recovery flow are unchanged. Acknowledgement only bypasses this scope check; approval policy and runtime checks still apply. Graph scope inspection remains the existing inspection surface. The primary selection and boundary-edge sections document the refusal and link directly to its limits. This intentionally changes partial-destroy behavior; it cannot discover undeclared consumers or infer infrastructure state.

Validation on macOS with Go 1.27.1:
```text
$ make check
0 issues.
ok  	github.com/cloudfluent/terragraph/internal/engine	(cached)
ok  	github.com/cloudfluent/terragraph/internal/exec	(cached)
PASS native contracts: type completion, inherited type hover, unsaved type diagnostics
Exit code:   0
```
Fixture tests cover transitive outside consumers, complete downstream selection, leaf-only teardown, explicit acknowledgement, and structured JSON errors. Existing terminal/file/pipe approval tests explicitly acknowledge their intentionally partial teardown, preserving their original input and cancellation assertions. No infrastructure was changed.
