### PR TITLE
feat: retry failed output reads without replaying mutations

### DIFF
--- a/docs/cli/terragraph_apply.md
+++ b/docs/cli/terragraph_apply.md
@@ -9,15 +9,16 @@ terragraph apply [flags]
 ### Options
 
 ```
-      --approve string     what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
-      --auto-approve       skip the interactive approval prompt
-      --downstream         include all successors of --node across data and ordering edges
-  -h, --help               help for apply
-      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
-      --output string      output format: text or json (default "text")
-      --parallelism int    max nodes to run concurrently within one execution level (default 1)
-      --plan string        apply the stored frontier of a saved execution without replanning
-      --retain-plan        retain optional plan artifacts while ordinary apply continues
+      --approve string       what a node may do without saying so per run: none, safe (create/update), or all (adds replace/delete); a node's own approve wins over this (default "safe")
+      --auto-approve         skip the interactive approval prompt
+      --downstream           include all successors of --node across data and ordering edges
+  -h, --help                 help for apply
+      --node stringArray     select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string        output format: text or json (default "text")
+      --output-retries int   additional attempts for failed output reads only (0-10; mutations are never retried)
+      --parallelism int      max nodes to run concurrently within one execution level (default 1)
+      --plan string          apply the stored frontier of a saved execution without replanning
+      --retain-plan          retain optional plan artifacts while ordinary apply continues
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/terragraph_destroy.md
+++ b/docs/cli/terragraph_destroy.md
@@ -9,12 +9,13 @@ terragraph destroy [flags]
 ### Options
 
 ```
-      --auto-approve       skip interactive approval
-      --downstream         include all successors of --node across data and ordering edges
-  -h, --help               help for destroy
-      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
-      --output string      output format: text or json (default "text")
-      --parallelism int    max nodes to run concurrently within one execution level (default 1)
+      --auto-approve         skip interactive approval
+      --downstream           include all successors of --node across data and ordering edges
+  -h, --help                 help for destroy
+      --node stringArray     select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string        output format: text or json (default "text")
+      --output-retries int   additional attempts for failed output reads only (0-10; mutations are never retried)
+      --parallelism int      max nodes to run concurrently within one execution level (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/terragraph_plan.md
+++ b/docs/cli/terragraph_plan.md
@@ -9,14 +9,15 @@ terragraph plan [flags]
 ### Options
 
 ```
-      --approve string     default policy to assess: none, safe, or all (does not authorize apply) (default "safe")
-      --continue string    create the next frontier after applying this saved execution
-      --downstream         include all successors of --node across data and ordering edges
-  -h, --help               help for plan
-      --node stringArray   select an exact leaf name (repeat for multiple nodes; commas are literal)
-      --output string      output format: text or json (default "text")
-      --parallelism int    max nodes to run concurrently within one execution level (default 1)
-      --save               save only the ready graph frontier for a later apply --plan
+      --approve string       default policy to assess: none, safe, or all (does not authorize apply) (default "safe")
+      --continue string      create the next frontier after applying this saved execution
+      --downstream           include all successors of --node across data and ordering edges
+  -h, --help                 help for plan
+      --node stringArray     select an exact leaf name (repeat for multiple nodes; commas are literal)
+      --output string        output format: text or json (default "text")
+      --output-retries int   additional attempts for failed output reads only (0-10; mutations are never retried)
+      --parallelism int      max nodes to run concurrently within one execution level (default 1)
+      --save                 save only the ready graph frontier for a later apply --plan
 ```
 
 ### Options inherited from parent commands

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -422,3 +422,7 @@ never automatic replay. Contract meaning and mode participate in retained-plan
 bindings. Review JSON exposes independent conditions through `review.contracts`.
 Known null is reconstructed only from the same successful plan, never from a
 missing live output. See the contracts reference for restart and recovery limits.
+
+### Output read retries
+
+`plan`, `apply`, and `destroy` accept `--output-retries N` (0–10, default 0). Only failed `terraform/tofu output -json` subprocess exits are retried, at most N additional attempts per read, with cancellation-aware delays of 100 ms, 200 ms, and so on. Invalid JSON, startup/configuration errors, and cancellation are not retried. Init, plan, apply, destroy, and saved-plan application are never repeated automatically. Successful output metadata and exact numbers remain unchanged; opted-in snapshot fallback occurs only after live attempts are exhausted. Saved executions use the same read behavior when this invocation supplies the flag; retries never authorize recovery or mutation replay.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -284,6 +284,7 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 	var save bool
 	var continueID string
 	var parallelism int
+	var outputRetries int
 	cmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Review node plans, actions, approval policy, and evidence limitations",
@@ -316,11 +317,15 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 				return policyErr
 			}
 			phase = "load"
+			if outputRetries < 0 || outputRetries > 10 {
+				return fmt.Errorf("--output-retries must be between 0 and 10; use 0 to disable retries")
+			}
 			e, unlock, err := loadLockedEngine(cmd, blueprintPath, binaryOf, loggerOf)
 			if err != nil {
 				return err
 			}
 			defer unlock()
+			e.OutputRetries = outputRetries
 			phase = "validation"
 			if err := checkValidate(cmd, e); err != nil {
 				return err
@@ -338,6 +343,7 @@ func newPlanCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fun
 		},
 	}
 	selection.add(cmd)
+	cmd.Flags().IntVar(&outputRetries, "output-retries", 0, "additional attempts for failed output reads only (0-10; mutations are never retried)")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
 	cmd.Flags().StringVar(&output, "output", "text", "output format: text or json")
 	cmd.Flags().BoolVar(&save, "save", false, "save only the ready graph frontier for a later apply --plan")
@@ -353,6 +359,7 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 	var retainPlan bool
 	var autoApprove bool
 	var parallelism int
+	var outputRetries int
 	var force bool
 	var approve string
 	var output string
@@ -371,11 +378,15 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 			if output == "json" && !autoApprove {
 				return fmt.Errorf("--output json needs --auto-approve: the approval prompt would have nowhere to appear without corrupting the JSON payload; approve in text mode or pass --auto-approve")
 			}
+			if outputRetries < 0 || outputRetries > 10 {
+				return fmt.Errorf("--output-retries must be between 0 and 10; use 0 to disable retries")
+			}
 			e, unlock, err := loadLockedEngine(cmd, blueprintPath, binaryOf, loggerOf)
 			if err != nil {
 				return err
 			}
 			defer unlock()
+			e.OutputRetries = outputRetries
 			if err := checkValidate(cmd, e); err != nil {
 				return err
 			}
@@ -403,6 +414,7 @@ func newApplyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf fu
 		},
 	}
 	selection.add(cmd)
+	cmd.Flags().IntVar(&outputRetries, "output-retries", 0, "additional attempts for failed output reads only (0-10; mutations are never retried)")
 	cmd.Flags().StringVar(&planID, "plan", "", "apply the stored frontier of a saved execution without replanning")
 	cmd.Flags().BoolVar(&retainPlan, "retain-plan", false, "retain optional plan artifacts while ordinary apply continues")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip the interactive approval prompt")
@@ -419,6 +431,7 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 	var selection selectionFlags
 	var autoApprove bool
 	var parallelism int
+	var outputRetries int
 	var output string
 	cmd := &cobra.Command{
 		Use:   "destroy",
@@ -432,11 +445,15 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 			if output == "json" && !autoApprove {
 				return fmt.Errorf("--output json needs --auto-approve: the destroy confirmation would have nowhere to appear without corrupting the JSON payload; confirm in text mode or pass --auto-approve")
 			}
+			if outputRetries < 0 || outputRetries > 10 {
+				return fmt.Errorf("--output-retries must be between 0 and 10; use 0 to disable retries")
+			}
 			e, unlock, err := loadLockedEngine(cmd, blueprintPath, binaryOf, loggerOf)
 			if err != nil {
 				return err
 			}
 			defer unlock()
+			e.OutputRetries = outputRetries
 			if err := checkValidate(cmd, e); err != nil {
 				return err
 			}
@@ -452,6 +469,7 @@ func newDestroyCmd(blueprintPath *string, binaryOf func() exec.Binary, loggerOf 
 		},
 	}
 	selection.add(cmd)
+	cmd.Flags().IntVar(&outputRetries, "output-retries", 0, "additional attempts for failed output reads only (0-10; mutations are never retried)")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip interactive approval")
 	cmd.Flags().IntVar(&parallelism, "parallelism", 1, "max nodes to run concurrently within one execution level")
 	cmd.Flags().StringVar(&output, "output", "text", "output format: text or json")

--- a/internal/engine/apply.go
+++ b/internal/engine/apply.go
@@ -70,7 +70,7 @@ func (e *Engine) Apply(opts Options) (result RunResult, resultErr error) {
 		defer func() { _ = os.Remove(varsPath) }()
 		varFileArgs := exec.VarFileArgs(varsPath, vars)
 
-		r := &exec.Runner{Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
+		r := &exec.Runner{OutputRetries: e.OutputRetries, Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		if err := session.transition(name, "initializing", "", ""); err != nil {
 			return nil, "", err
 		}

--- a/internal/engine/destroy.go
+++ b/internal/engine/destroy.go
@@ -81,7 +81,7 @@ func (e *Engine) Destroy(opts Options) (result RunResult, resultErr error) {
 		// Removed however this node exits: the file holds resolved input values in cleartext, and the next run rewrites it from scratch anyway.
 		defer func() { _ = os.Remove(varsPath) }()
 
-		r := &exec.Runner{Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
+		r := &exec.Runner{OutputRetries: e.OutputRetries, Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		// Unlike apply, there is no saved plan here for terragraph to ask about itself, so terraform's own confirmation is the approval — and it needs somewhere to read the answer from. Left nil when auto-approving, so an unattended run can never block on a question.
 		var answered *countingReader
 		if !opts.AutoApprove && e.Stdin != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -23,6 +23,8 @@ import (
 
 // Engine holds a loaded blueprint's graph and the I/O streams terraform/tofu subprocess output is forwarded to.
 type Engine struct {
+	// OutputRetries applies only to read-only output subprocesses, including fresh upstream reads.
+	OutputRetries int
 	// Context lets CLI cancellation reach every runtime and prevents later nodes from starting after interruption.
 	Context   context.Context
 	Binary    exec.Binary
@@ -95,6 +97,9 @@ func (e *Engine) logger() *slog.Logger {
 // one lock. See internal/runlock. The returned func releases a lock this call acquired;
 // it is a no-op when LoadLocked already holds one.
 func (e *Engine) lockRun() (func(), error) {
+	if e.OutputRetries < 0 || e.OutputRetries > 10 {
+		return nil, WithDiagnostic(fmt.Errorf("--output-retries must be between 0 and 10; use 0 to disable retries"), Diagnostic{Code: "invalid_arguments", Category: "arguments", Phase: "arguments"})
+	}
 	// Programmatic graphs can bypass parsing; check every node before acquiring locks or letting upstream output errors fall back to snapshots.
 	if e.Graph != nil {
 		names := make([]string, 0, len(e.Graph.Nodes))
@@ -262,7 +267,7 @@ func (e *Engine) dataDir(name string) string {
 
 // runner builds a Runner for internal, non-buffered use (reading an upstream node's already-applied outputs). The per-node runners used for the actual plan/apply/destroy commands (see plan.go/apply.go/destroy.go) are built separately, against that node's own buffered output writer.
 func (e *Engine) runner(name string) *exec.Runner {
-	return &exec.Runner{Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: e.Stdout, Stderr: e.Stderr}
+	return &exec.Runner{OutputRetries: e.OutputRetries, Context: e.context(), Binary: e.runtimeFor(name), Dir: e.nodeDir(name), DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: e.Stdout, Stderr: e.Stderr}
 }
 
 // envFor returns name's fully resolved extra environment variables (see graph.Node.Env): whatever an enclosing Use.Env cascade contributed, already merged with the node's own Env. Unlike runtimeFor, there is no further CLI-level fallback layer to apply on top: env has no CLI equivalent, so whatever the graph already resolved is final.

--- a/internal/engine/output_retry_unix_test.go
+++ b/internal/engine/output_retry_unix_test.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApply_OutputRetryDoesNotRepeatMutation(t *testing.T) {
+	e, _, log := loadApplyTestEngine(t)
+	e.OutputRetries = 1
+	t.Setenv("TG_RETRY_MARKER", filepath.Join(e.BaseDir, "output-attempted"))
+	path := string(e.Binary)
+	script, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script = bytes.Replace(script, []byte("  output)"), []byte("  output)\n if [ ! -f \"$TG_RETRY_MARKER\" ]; then touch \"$TG_RETRY_MARKER\"; exit 7; fi\n"), 1)
+	if err := os.WriteFile(path, script, 0700); err != nil {
+		t.Fatal(err)
+	}
+	runs, err := e.Apply(Options{AutoApprove: true})
+	if err != nil || runs.Nodes[0].Status != StatusApplied {
+		t.Fatalf("got = %+v, %v", runs, err)
+	}
+	calls, err := os.ReadFile(log)
+	if err != nil || strings.Count(string(calls), "apply\n") != 1 {
+		t.Fatalf("calls = %s, error = %v, want one mutation", calls, err)
+	}
+	if _, err := os.Stat(filepath.Join(e.BaseDir, "output-attempted")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -95,7 +95,7 @@ func (e *Engine) plan(opts Options, inspect, allowTextFallback bool) (result Run
 		// Removed however this node exits: the file holds resolved input values in cleartext, and the next run rewrites it from scratch anyway.
 		defer func() { _ = os.Remove(varsPath) }()
 
-		r := &exec.Runner{Context: e.context(), Binary: e.runtimeFor(name), Dir: nodeDir, DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
+		r := &exec.Runner{OutputRetries: e.OutputRetries, Context: e.context(), Binary: e.runtimeFor(name), Dir: nodeDir, DataDir: e.dataDir(name), Env: e.envFor(name), Stdout: out, Stderr: out}
 		if err := session.transition(name, "initializing", "", ""); err != nil {
 			return fail("journal_failed", "init", err)
 		}

--- a/internal/exec/output_retry_unix_test.go
+++ b/internal/exec/output_retry_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package exec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func retryRunner(t *testing.T, behavior string) (*Runner, string) {
+	t.Helper()
+	dir := t.TempDir()
+	calls := filepath.Join(dir, "calls")
+	t.Setenv("TG_RETRY_CALLS", calls)
+	path := filepath.Join(dir, "runtime")
+	script := `#!/bin/sh
+n=0
+if [ -f "$TG_RETRY_CALLS" ]; then n=$(cat "$TG_RETRY_CALLS"); fi
+n=$((n+1))
+printf '%s' "$n" > "$TG_RETRY_CALLS"
+` + behavior
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return &Runner{Binary: Binary(path), Dir: dir, OutputRetries: 2}, calls
+}
+
+func TestOutputs_RetriesFailedReadAndRetainsMetadata(t *testing.T) {
+	r, calls := retryRunner(t, `if [ "$n" -eq 1 ]; then exit 7; fi
+printf '%s' '{"value":{"value":1234567890123456789,"sensitive":true}}'
+`)
+	outputs, err := r.Outputs()
+	if err != nil || outputs["value"].Sensitive == nil || !*outputs["value"].Sensitive {
+		t.Fatalf("outputs = %+v, error = %v", outputs, err)
+	}
+	count, err := os.ReadFile(calls)
+	if err != nil || string(count) != "2" {
+		t.Fatalf("attempts = %s, error = %v, want 2", count, err)
+	}
+}
+
+func TestOutputs_DoesNotRetryInvalidJSON(t *testing.T) {
+	r, calls := retryRunner(t, `printf 'invalid-json'`)
+	if _, err := r.Outputs(); err == nil {
+		t.Fatal("invalid JSON accepted")
+	}
+	count, err := os.ReadFile(calls)
+	if err != nil || string(count) != "1" {
+		t.Fatalf("attempts = %s, error = %v, want 1", count, err)
+	}
+}
+
+func TestOutputs_RetryBudgetIsBounded(t *testing.T) {
+	r, calls := retryRunner(t, `exit 7`)
+	if _, err := r.Outputs(); err == nil {
+		t.Fatal("failed output accepted")
+	}
+	count, err := os.ReadFile(calls)
+	if err != nil || string(count) != "3" {
+		t.Fatalf("attempts = %s, error = %v, want 3", count, err)
+	}
+}
+
+func TestApplyPlan_NeverUsesOutputRetryBudget(t *testing.T) {
+	r, calls := retryRunner(t, `exit 7`)
+	if err := r.ApplyPlan("saved.tfplan"); err == nil {
+		t.Fatal("failed apply accepted")
+	}
+	count, err := os.ReadFile(calls)
+	if err != nil || string(count) != "1" {
+		t.Fatalf("attempts = %s, error = %v, want 1", count, err)
+	}
+}
+
+func TestOutputs_CancelsRetryDelay(t *testing.T) {
+	r, calls := retryRunner(t, `exit 7`)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.Context = ctx
+	done := make(chan error, 1)
+	go func() { _, err := r.Outputs(); done <- err }()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if data, err := os.ReadFile(calls); err == nil && strings.TrimSpace(string(data)) == "1" {
+			cancel()
+			break
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("output did not start")
+		}
+	}
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want cancellation", err)
+	}
+	count, err := os.ReadFile(calls)
+	if err != nil || string(count) != "1" {
+		t.Fatalf("attempts = %s, error = %v, want 1", count, err)
+	}
+}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Binary selects which CLI terragraph shells out to.
@@ -27,8 +28,10 @@ const (
 type Runner struct {
 	// Context bounds subprocess lifetime so cancellation finishes before the engine releases its run lock.
 	Context context.Context
-	Binary  Binary
-	Dir     string
+	// OutputRetries repeats failed output subprocesses without replaying mutations or invalid JSON.
+	OutputRetries int
+	Binary        Binary
+	Dir           string
 	// DataDir, if set, becomes TF_DATA_DIR: it isolates where Terraform keeps .terraform/ (downloaded providers and, critically, its cached backend configuration) away from Dir. Without this, two nodes that reuse the same module Source but configure different backend_config would collide: Terraform stores which backend it was last configured with inside .terraform/, keyed by working directory, so the second node's init would fail with "Backend configuration changed" even though -backend-config correctly gave it its own state. DataDir sidesteps that by giving every node its own .terraform/ regardless of whether Dir is shared.
 	DataDir string
 	// Env overrides inherited variables, but an explicit TF_DATA_DIR (case-insensitive) conflicts with DataDir and fails before execution to prevent nodes sharing a backend cache.
@@ -299,6 +302,33 @@ func (outputs Outputs) Values() map[string]any {
 
 // Outputs runs `terraform output -json` and preserves sensitivity and exact numbers; an empty collection does not establish deployment history.
 func (r *Runner) Outputs() (Outputs, error) {
+	if r.OutputRetries < 0 || r.OutputRetries > 10 {
+		return nil, fmt.Errorf("output retries must be between 0 and 10")
+	}
+	ctx := r.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for attempt := 0; ; attempt++ {
+		outputs, err := r.outputsOnce()
+		var exitErr *osexec.ExitError
+		if cancelled := ctx.Err(); err != nil && cancelled != nil {
+			return nil, cancelled
+		}
+		if err == nil || attempt >= r.OutputRetries || !errors.As(err, &exitErr) {
+			return outputs, err
+		}
+		timer := time.NewTimer(time.Duration(attempt+1) * 100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *Runner) outputsOnce() (Outputs, error) {
 	env, err := r.env()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add `--output-retries N` (0–10, default 0) for failed output subprocess reads in plan/apply/destroy, including the saved execution paths. Failed output exits get bounded, cancellation-aware delays; malformed JSON, startup/configuration errors, and cancellation are not retried. Init, plan, apply, and destroy are never replayed automatically.

Independent follow-up to #95, based on main. The existing execution journal and recovery rules remain authoritative. Sensitivity metadata and exact number decoding remain intact, and opt-in snapshot fallback happens only after live read attempts are exhausted.

Regression fixtures prove bounded attempts, cancellation during retry delay, no retries for invalid JSON, no retry budget for saved-plan apply, and an engine apply that survives a transient output failure with exactly one mutation.

Validation: `make check` passed on macOS with the pinned Go 1.27.1, including the race-enabled Go suite, generated documentation check, and all VS Code checks and Extension Host scenarios. No real infrastructure was changed.

```text
$ make check
0 issues.
ok  	github.com/cloudfluent/terragraph/internal/engine	79.064s
ok  	github.com/cloudfluent/terragraph/internal/exec	(cached)
PASS native contracts: type completion, inherited type hover, unsaved type diagnostics
Exit code:   0
```
